### PR TITLE
Capture main in branch patterns

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   release:
     types: [published]
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: main
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
     paths-ignore:


### PR DESCRIPTION
Since the rename of branch from master to main, the workflows intended to run on push for the default branch (including test workflow) had never really been invoked (notice `2 / 2` everywhere):

<img src="https://github.com/user-attachments/assets/72ecaa94-ceed-4863-944a-f68df8905f27" alt="workflow status" width="400" />

<img src="https://github.com/user-attachments/assets/3e4c1af8-f70f-4a72-a6fb-31345e0bcfce" width="400" />

