### PR TITLE
Fix typed property lookup on instances

### DIFF
--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -1132,7 +1132,7 @@ def _maybe_use_resolved_typed_instance_attribute(
     symbol = attribute.symbol
     raw_runtime_value = replace_fallback(attribute.raw_value)
     if attribute.is_property:
-        if plain_typed_receiver:
+        if symbol.property_info is None and plain_typed_receiver:
             runtime_property = (
                 raw_runtime_value.val
                 if isinstance(raw_runtime_value, KnownValue)

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -1132,6 +1132,15 @@ def _maybe_use_resolved_typed_instance_attribute(
     symbol = attribute.symbol
     raw_runtime_value = replace_fallback(attribute.raw_value)
     if attribute.is_property:
+        if isinstance(replace_fallback(resolved_value), AnyValue):
+            return None
+        fget = symbol.property_info.fget if symbol.property_info is not None else None
+        if fget is not None and isinstance(
+            fget.initializer, (KnownValue, KnownValueWithTypeVars)
+        ):
+            return _rebind_resolved_lookup_value(
+                resolved_value, lookup_receiver=receiver_value, self_value=self_value
+            )
         if symbol.property_info is None and plain_typed_receiver:
             runtime_property = (
                 raw_runtime_value.val
@@ -1141,9 +1150,14 @@ def _maybe_use_resolved_typed_instance_attribute(
             )
             if runtime_property is None:
                 return None
-        return _rebind_resolved_lookup_value(
-            resolved_value, lookup_receiver=receiver_value, self_value=self_value
-        )
+            return _rebind_resolved_lookup_value(
+                resolved_value, lookup_receiver=receiver_value, self_value=self_value
+            )
+        if symbol.property_info is None:
+            return _rebind_resolved_lookup_value(
+                resolved_value, lookup_receiver=receiver_value, self_value=self_value
+            )
+        return None
     if symbol.is_classmethod:
         return resolved_value
     if (

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -2248,6 +2248,27 @@ class TestClassAttributeChecker(TestNameCheckVisitorBase):
             assert_type(x.value, int)
 
     @assert_passes(run_in_both_module_modes=True)
+    def test_property_result_supports_method_calls_on_typed_instance(self):
+        from typing_extensions import assert_type
+
+        class Cache:
+            def get(self, obj: object) -> int:
+                return 1
+
+        class Box:
+            _cache: Cache | None = None
+
+            @property
+            def cache(self) -> Cache:
+                cache = self._cache
+                assert cache is not None
+                return cache
+
+            def use(self, obj: object) -> int:
+                assert_type(self.cache, Cache)
+                return self.cache.get(obj)
+
+    @assert_passes(run_in_both_module_modes=True)
     def test_classvar_container_methods_keep_receiver_parameter(self):
         from typing import ClassVar
 


### PR DESCRIPTION
## Summary
- make typed instance property lookup trust resolved property metadata instead of requiring a raw runtime property object
- preserve the older fallback behavior for non-property descriptor cases
- add a regression test for calling a method through a property-returned helper object

## Testing
- uv run --python 3.12 --extra tests pytest pycroscope/test_name_check_visitor.py -q -k "property_result_supports_method_calls_on_typed_instance or property_lookup_uses_specialized_self_type or self_annotated_property_uses_runtime_attribute_resolution"
- uv run --python 3.12 --extra tests pytest pycroscope/test_attributes.py -q -k "property_on_class_object or property_on_unhashable_object"
- uv run --python 3.12 --extra tests pytest pycroscope/test_find_unused.py -q -k "unused_call_pattern"
- uv run --python 3.12 --extra tests pytest pycroscope/test_self.py -q -k "reports_unused_call_patterns"