### PR TITLE
Weaken inferred constructor generics

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Make the command-line runner inject `typing.reveal_type` into `builtins` before importing user modules, with a compatible fallback on older Python versions, so top-level runtime use of `reveal_type()` no longer fails during CLI analysis.
+- Weaken inferred constructor-return generics, so fresh values like `Box(1)` and nested `defaultdict(...)` calls can satisfy broader annotated generic targets without forcing explicit specialization.
 - Avoid internal errors for some constructor-style generic patterns like `type[T] | T`, and stop showing a misleading `None.` module prefix in messages for generated callables.
 - Make `type()` results more consistent for imprecise values like `str`, `type[T]`, and `super()`, so pycroscope preserves subclass-aware class objects where appropriate and stops relying on implicit fallback behavior for internal type values.
 - Simplify `type()` lookups through narrowed intersections, so `hasattr()`-guarded class-object calls preserve the real constructor signature instead of picking up confusing fallback overloads like `object.__init__`.

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -981,7 +981,7 @@ def _sequence_common_getitem_impl(ctx: CallContext, typ: type) -> ImplReturn:
                     else:
                         # If the value contains unpacked values, we don't attempt
                         # to resolve the slice.
-                        return GenericValue(typ, self_value.args)
+                        return GenericValue(typ, self_value.args, weak=self_value.weak)
                 elif self_value.typ in (list, tuple, collections.abc.Sequence):
                     # For generics of exactly list/tuple, return the self type.
                     if from_tuple_subtype:
@@ -1006,7 +1006,9 @@ def _sequence_common_getitem_impl(ctx: CallContext, typ: type) -> ImplReturn:
                 if generated_tuple_sequence and isinstance(
                     original_self_value, GenericValue
                 ):
-                    return GenericValue(typ, original_self_value.args)
+                    return GenericValue(
+                        typ, original_self_value.args, weak=original_self_value.weak
+                    )
                 return self_value
             else:
                 ctx.show_error(f"Invalid {typ.__name__} key {key}")

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -1038,9 +1038,7 @@ def _has_relation(
                     variances = _get_generic_variances(
                         comparison_left.typ, len(comparison_left.args), ctx
                     )
-                    strict_invariant = not isinstance(
-                        right, (SequenceValue, DictIncompleteValue)
-                    )
+                    strict_invariant = not _allows_forward_only_invariant_rhs(right)
                     bounds_maps = []
                     for i, (my_arg, their_arg, variance) in enumerate(
                         zip(comparison_left.args, generic_args, variances)
@@ -1280,12 +1278,20 @@ def _has_relation_for_generic_arg(
     forward = _has_relation_for_generic_arg_pair(left, right, relation, ctx)
     if isinstance(forward, CanAssignError):
         return forward
-    if relation is Relation.ASSIGNABLE and not strict_invariant:
+    if relation is Relation.ASSIGNABLE and (
+        not strict_invariant or _allows_forward_only_invariant_rhs(right)
+    ):
         return forward
     backward = _has_relation_for_generic_arg_pair(right, left, relation, ctx)
     if isinstance(backward, CanAssignError):
         return backward
     return unify_bounds_maps([forward, backward])
+
+
+def _allows_forward_only_invariant_rhs(value: Value) -> bool:
+    if isinstance(value, AnnotatedValue):
+        return _allows_forward_only_invariant_rhs(value.value)
+    return isinstance(value, GenericValue) and value.weak
 
 
 def _get_generic_variances(

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -15,7 +15,7 @@ import warnings
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field, replace
 from types import FunctionType, MethodType
-from typing import Any, ClassVar, Literal, NamedTuple, TypeVar
+from typing import Any, ClassVar, Literal, NamedTuple, TypeVar, get_args, get_origin
 
 from typing_extensions import Self, assert_never
 
@@ -110,6 +110,7 @@ from .value import (
     UnboundMethodValue,
     UpperBound,
     Value,
+    Variance,
     _iter_typevar_map_items,
     _typevar_map_from_varlike_pairs,
     annotate_value,
@@ -192,6 +193,111 @@ def _should_widen_constructor_typevar_solutions(
         and isinstance(callable_obj, FunctionType)
         and callable_obj.__name__ in {"__init__", "__new__"}
     )
+
+
+def _constructor_origin_from_callee(callee: Value | None) -> type | str | None:
+    if callee is None:
+        return None
+    callee = replace_fallback(callee)
+    if (
+        isinstance(callee, PartialValue)
+        and callee.operation is PartialValueOperation.SUBSCRIPT
+    ):
+        return _constructor_origin_from_callee(callee.root)
+    if isinstance(callee, KnownValue):
+        origin = get_origin(callee.val)
+        if isinstance(origin, type):
+            return origin
+        if isinstance(callee.val, type):
+            return callee.val
+        return None
+    if isinstance(callee, SyntheticClassObjectValue):
+        return callee.class_type.typ
+    if isinstance(callee, SubclassValue):
+        typ = callee.typ
+        if isinstance(typ, GenericValue):
+            return typ.typ
+        if isinstance(typ, TypedValue):
+            return typ.typ
+        return None
+    return None
+
+
+def _constructor_should_preserve_strong_return(callee: Value | None) -> bool:
+    if callee is None:
+        return False
+    callee = replace_fallback(callee)
+    if (
+        isinstance(callee, PartialValue)
+        and callee.operation is PartialValueOperation.SUBSCRIPT
+    ):
+        return _constructor_should_preserve_strong_return(callee.root)
+    if isinstance(callee, SubclassValue):
+        return not isinstance(callee.typ, (TypedValue, GenericValue))
+    return False
+
+
+def _is_explicitly_specialized_constructor_callee(callee: Value | None) -> bool:
+    if callee is None:
+        return False
+    callee = replace_fallback(callee)
+    if (
+        isinstance(callee, PartialValue)
+        and callee.operation is PartialValueOperation.SUBSCRIPT
+    ):
+        return _constructor_origin_from_callee(callee.root) is not None
+    if isinstance(callee, KnownValue):
+        origin = get_origin(callee.val)
+        return isinstance(origin, type) and bool(get_args(callee.val))
+    return False
+
+
+def _should_weaken_call_return(
+    callable_obj: object | None,
+    callee: Value | None,
+    return_value: Value,
+    ctx: CanAssignContext,
+    *,
+    has_inferable_typevars: bool,
+) -> bool:
+    if not has_inferable_typevars:
+        return False
+    origin = _constructor_origin_from_callee(callee)
+    if origin is None or not isinstance(return_value, GenericValue):
+        return False
+    if return_value.typ != origin:
+        return False
+    if _constructor_should_preserve_strong_return(callee):
+        return False
+    if not _generic_has_invariant_type_parameters(return_value, ctx):
+        return False
+    if _is_explicitly_specialized_constructor_callee(callee):
+        return False
+    if isinstance(callable_obj, MethodType):
+        callable_obj = callable_obj.__func__
+    if isinstance(callable_obj, FunctionType):
+        return callable_obj.__name__ in {"__init__", "__new__"}
+    return True
+
+
+def _generic_has_invariant_type_parameters(
+    value: GenericValue, ctx: CanAssignContext
+) -> bool:
+    return any(
+        type_param.variance is Variance.INVARIANT
+        for type_param in ctx.get_type_parameters(value.typ)
+    )
+
+
+def _weaken_call_return(return_value: "Value | ImplReturn") -> "Value | ImplReturn":
+    if isinstance(return_value, ImplReturn):
+        inner = return_value.return_value
+        if isinstance(inner, GenericValue) and not inner.weak:
+            inner = GenericValue(inner.typ, inner.args, weak=True)
+        return ImplReturn(inner, return_value.constraint, return_value.no_return_unless)
+    if isinstance(return_value, GenericValue) and not return_value.weak:
+        return GenericValue(return_value.typ, return_value.args, weak=True)
+    return return_value
 
 
 def _get_constructor_literal_runtime_type(bounds: Sequence[Bound]) -> type | None:
@@ -1687,6 +1793,19 @@ class Signature:
                 )
             else:
                 return_value = partial_return
+        final_return_value = (
+            return_value.return_value
+            if isinstance(return_value, ImplReturn)
+            else return_value
+        )
+        if _should_weaken_call_return(
+            self.callable,
+            ctx.callee,
+            final_return_value,
+            ctx.can_assign_ctx,
+            has_inferable_typevars=bool(self.inferable_typevars),
+        ):
+            return_value = _weaken_call_return(return_value)
         ret = self._apply_annotated_constraints(return_value, composites, ctx)
         return CallReturn(
             ret,

--- a/pycroscope/suggested_type.py
+++ b/pycroscope/suggested_type.py
@@ -451,12 +451,16 @@ def _prepare_simple_type(value: SimpleType, ctx: CanAssignContext | None) -> Val
                 return SequenceValue(
                     tuple, [(False, prepare_type(elt, ctx)) for elt in members]
                 )
-        return GenericValue(value.typ, [prepare_type(arg, ctx) for arg in value.args])
+        return GenericValue(
+            value.typ, [prepare_type(arg, ctx) for arg in value.args], weak=value.weak
+        )
     elif isinstance(value, (TypedDictValue, CallableValue)):
         return value
     elif isinstance(value, GenericValue):
         # TODO maybe turn DictIncompleteValue into TypedDictValue?
-        return GenericValue(value.typ, [prepare_type(arg, ctx) for arg in value.args])
+        return GenericValue(
+            value.typ, [prepare_type(arg, ctx) for arg in value.args], weak=value.weak
+        )
     elif isinstance(value, VariableNameValue):
         return AnyValue(AnySource.unannotated)
     elif isinstance(value, KnownValue):

--- a/pycroscope/test_dataclass.py
+++ b/pycroscope/test_dataclass.py
@@ -695,8 +695,7 @@ class TestDataclass(TestNameCheckVisitorBase):
         import does_not_exist  # noqa: F401
         from typing_extensions import assert_type
 
-        from pycroscope.test_name_check_visitor import BOX_FLOAT_OR_INT_IN_TEST_INPUT
-        from pycroscope.value import assert_is_value
+        from pycroscope.value import GenericValue, TypedValue, assert_is_value
 
         T = TypeVar("T")
 
@@ -705,7 +704,12 @@ class TestDataclass(TestNameCheckVisitorBase):
                 self.value = value
 
         assert_type(Box(1), Box[int])
-        assert_is_value(Box(1.0), BOX_FLOAT_OR_INT_IN_TEST_INPUT)
+        assert_is_value(
+            Box(1.0),
+            GenericValue(
+                "<test input>.Box", [TypedValue(float) | TypedValue(int)], weak=True
+            ),
+        )
         assert_type(Box(1j), Box[complex | float | int])
         assert_type(Box(""), Box[str])
         assert_type(Box[float](1), Box[float | int])

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -556,6 +556,27 @@ class TestImportFailureHandlingCodeSamples(TestNameCheckVisitorBase):
             force_runtime_module_load_failure=True,
         )
 
+    @assert_passes(run_in_both_module_modes=True)
+    def test_code_only_constructor_returns_are_weakened(self):
+        from collections import defaultdict
+        from typing import Generic, TypeVar
+
+        from typing_extensions import assert_type
+
+        T = TypeVar("T")
+
+        class Box(Generic[T]):
+            value: T
+
+            def __init__(self, value: T) -> None:
+                self.value = value
+
+        def capybara() -> None:
+            box: Box[int | str] = Box(1)
+            nested: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+            assert_type(box.value, int | str)
+            assert_type(nested, dict[str, dict[str, int]])
+
     def test_code_only_import_failure_reports_failing_line(self):
         self.assert_passes(
             """

--- a/pycroscope/test_typeshed.py
+++ b/pycroscope/test_typeshed.py
@@ -555,13 +555,17 @@ class TestConstructors(TestNameCheckVisitorBase):
             my_enumerate([1], start="x")  # E: incompatible_argument
             assert_is_value(
                 my_enumerate([1]),
-                GenericValue("_pycroscope_tests.initnew.my_enumerate", [KnownValue(1)]),
+                GenericValue(
+                    "_pycroscope_tests.initnew.my_enumerate", [KnownValue(1)], weak=True
+                ),
             )
 
             overloadinit()  # E: incompatible_call
             assert_is_value(
                 overloadinit(1, "x", 2),
-                GenericValue("_pycroscope_tests.initnew.overloadinit", [KnownValue(2)]),
+                GenericValue(
+                    "_pycroscope_tests.initnew.overloadinit", [KnownValue(2)], weak=True
+                ),
             )
 
             simplenew()  # E: incompatible_call
@@ -572,7 +576,9 @@ class TestConstructors(TestNameCheckVisitorBase):
             overloadnew()  # E: incompatible_call
             assert_is_value(
                 overloadnew(1, "x", 2),
-                GenericValue("_pycroscope_tests.initnew.overloadnew", [KnownValue(2)]),
+                GenericValue(
+                    "_pycroscope_tests.initnew.overloadnew", [KnownValue(2)], weak=True
+                ),
             )
 
     @assert_passes()
@@ -1074,7 +1080,8 @@ class TestIntegration(TestNameCheckVisitorBase):
 
         def capybara():
             assert_is_value(
-                itertools.count(1), GenericValue(itertools.count, [TypedValue(int)])
+                itertools.count(1),
+                GenericValue(itertools.count, [TypedValue(int)], weak=True),
             )
 
     @assert_passes()

--- a/pycroscope/test_value.py
+++ b/pycroscope/test_value.py
@@ -459,6 +459,21 @@ def test_nested_weak_tuple_value_arg_allows_empty_lists_in_defaultdict() -> None
     assert_can_assign(left, right)
 
 
+def test_weak_generic_allows_forward_only_invariant_assignability() -> None:
+    left = GenericValue(
+        dict, [TypedValue(str), GenericValue(dict, [TypedValue(str), TypedValue(int)])]
+    )
+    right = GenericValue(
+        dict,
+        [
+            TypedValue(str),
+            GenericValue(defaultdict, [TypedValue(str), TypedValue(int)], weak=True),
+        ],
+    )
+
+    assert_can_assign(left, right)
+
+
 def test_strong_list_is_assignable_to_empty_weak_list() -> None:
     assert_can_assign(SequenceValue(list, []), GenericValue(list, [TypedValue(int)]))
 
@@ -1200,7 +1215,7 @@ def test_unite_and_simplify() -> None:
     vals = [GenericValue(list, [TypedValue(int)]), KnownValue([])]
     assert unite_and_simplify(*vals, limit=2) == GenericValue(
         list, [TypedValue(int)]
-    ) | GenericValue(list, [AnyValue(AnySource.unreachable)])
+    ) | GenericValue(list, [AnyValue(AnySource.unreachable)], weak=True)
 
 
 def test_unpack_values() -> None:

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -2168,12 +2168,17 @@ class GenericValue(TypedValue):
 
     args: tuple[Value, ...]
     """The generic arguments to the type."""
+    weak: bool
+    """Whether assignability should relax invariant generic arguments on the RHS."""
 
-    def __init__(self, typ: type | str, args: Iterable[Value]) -> None:
+    def __init__(
+        self, typ: type | str, args: Iterable[Value], *, weak: bool = False
+    ) -> None:
         super().__init__(typ)
         args = tuple(args)
         assert all(isinstance(arg, Value) for arg in args), args
         self.args = args
+        self.weak = weak
 
     def __str__(self) -> str:
         if self.typ is tuple:
@@ -2181,7 +2186,8 @@ class GenericValue(TypedValue):
         else:
             args = self.args
         args_str = ", ".join(str(arg) for arg in args)
-        return f"{stringify_object(self.typ)}[{args_str}]"
+        weak_marker = "~" if self.weak else ""
+        return f"{stringify_object(self.typ)}{weak_marker}[{args_str}]"
 
     def can_overlap(
         self, other: Value, ctx: CanAssignContext, mode: OverlapMode
@@ -2226,10 +2232,12 @@ class GenericValue(TypedValue):
                     )
                     continue
             new_args.append(substituted)
-        return GenericValue(self.typ, new_args)
+        return GenericValue(self.typ, new_args, weak=self.weak)
 
     def simplify(self) -> Value:
-        return GenericValue(self.typ, [arg.simplify() for arg in self.args])
+        return GenericValue(
+            self.typ, [arg.simplify() for arg in self.args], weak=self.weak
+        )
 
     def decompose(self) -> Iterable[Value] | None:
         if self.typ is tuple and len(self.args) == 1:
@@ -2266,7 +2274,7 @@ class SequenceValue(GenericValue):
         else:
             # Using Never for mutable types leads to issues
             args = (AnyValue(AnySource.unreachable),)
-        super().__init__(typ, args)
+        super().__init__(typ, args, weak=True)
         self.members = tuple(members)
 
     def get_member_sequence(self) -> Sequence[Value] | None:
@@ -2348,7 +2356,7 @@ class SequenceValue(GenericValue):
         arg = unite_values(*members)
         if arg is NO_RETURN_VALUE:
             arg = AnyValue(AnySource.unreachable)
-        return GenericValue(self.typ, [arg])
+        return GenericValue(self.typ, [arg], weak=True)
 
     def decompose(self) -> Iterable[Value] | None:
         if not self.members:
@@ -2430,7 +2438,7 @@ class DictIncompleteValue(GenericValue):
             value_type = unite_values(*[pair.value for pair in kv_pairs])
         else:
             key_type = value_type = AnyValue(AnySource.unreachable)
-        super().__init__(typ, (key_type, value_type))
+        super().__init__(typ, (key_type, value_type), weak=True)
         self.kv_pairs = tuple(kv_pairs)
 
     def __str__(self) -> str:
@@ -2457,7 +2465,7 @@ class DictIncompleteValue(GenericValue):
             key = AnyValue(AnySource.unreachable)
         if value is NO_RETURN_VALUE:
             value = AnyValue(AnySource.unreachable)
-        return GenericValue(self.typ, [key, value])
+        return GenericValue(self.typ, [key, value], weak=True)
 
     @property
     def items(self) -> Sequence[tuple[Value, Value]]:


### PR DESCRIPTION
## Summary
- add a `weak` marker to `GenericValue` and make incomplete literal/container values produce weak generics
- weaken inferred constructor returns only for unspecialized constructors with invariant type parameters
- allow weak generics to match stronger generic supertypes during assignability and update regression coverage

## Testing
- `uv run --python 3.14 --extra tests python -m pytest`

Result: `2055 passed, 33 skipped, 1 warning`
