### PR TITLE
[codex] Handle class-level constructor signatures

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Respect class-level runtime constructor signatures for some metaclass-driven and extension-backed classes, so keyword-only constructors like `repoguess.Params(...)` no longer fall back to a bogus `object.__init__` call shape.
 - Make the command-line runner inject `typing.reveal_type` into `builtins` before importing user modules, with a compatible fallback on older Python versions, so top-level runtime use of `reveal_type()` no longer fails during CLI analysis.
 - Weaken inferred constructor-return generics, so fresh values like `Box(1)` and nested `defaultdict(...)` calls can satisfy broader annotated generic targets without forcing explicit specialization.
 - Avoid internal errors for some constructor-style generic patterns like `type[T] | T`, and stop showing a misleading `None.` module prefix in messages for generated callables.

--- a/pycroscope/arg_spec.py
+++ b/pycroscope/arg_spec.py
@@ -1090,6 +1090,7 @@ class ArgSpecCache:
                     )
                     constructor = obj
                 else:
+                    class_signature = self._safe_get_signature(obj)
                     if override is not None:
                         constructor = override
                         inspect_sig = self._safe_get_signature(constructor)
@@ -1105,6 +1106,18 @@ class ArgSpecCache:
                         is_dunder_new = True
                         constructor = obj.__new__
                         inspect_sig = self._safe_get_signature(constructor)
+                    elif (
+                        safe_getattr(obj, "__init__", None) is object.__init__
+                        and class_signature is not None
+                        and class_signature.parameters
+                    ):
+                        constructor = obj
+                        inspect_sig = class_signature.replace(
+                            parameters=[
+                                _SELF_PARAM,
+                                *class_signature.parameters.values(),
+                            ]
+                        )
                     elif _is_plain_object_constructor(obj):
                         constructor = obj.__init__
                         inspect_sig = inspect.Signature(parameters=[_SELF_PARAM])

--- a/pycroscope/test_arg_spec.py
+++ b/pycroscope/test_arg_spec.py
@@ -37,6 +37,15 @@ T = TypeVar("T")
 NT = NewType("NT", int)
 
 
+class _SignatureMeta(type):
+    def __call__(cls, *, x: int, y: str = "") -> object:
+        return super().__call__()
+
+
+class _SignatureParams(metaclass=_SignatureMeta):
+    pass
+
+
 def test_type_param_str_is_concise() -> None:
     bounded = TypeVar("S", bound=int)
     constrained = TypeVar("T", str, bytes)
@@ -207,6 +216,26 @@ def test_get_argspec_self() -> None:
     assert isinstance(sig.return_value, TypeVarValue)
     my_self = sig.return_value.typevar_param
     assert my_self.owner == ClassOwner(__name__, "ClassWithCall", ClassWithCall)
+
+
+def test_get_argspec_uses_class_level_signature_for_extension_like_class() -> None:
+    asc = Checker().arg_spec_cache
+    sig = asc.get_argspec(_SignatureParams)
+
+    assert isinstance(sig, Signature)
+    assert list(sig.parameters) == ["x", "y"]
+    assert sig.parameters["x"] == SigParameter(
+        "x", kind=ParameterKind.KEYWORD_ONLY, annotation=TypedValue(int)
+    )
+    assert sig.parameters["y"] == SigParameter(
+        "y",
+        kind=ParameterKind.KEYWORD_ONLY,
+        annotation=TypedValue(str),
+        default=KnownValue(""),
+    )
+    assert sig.callable is _SignatureMeta.__call__
+    assert sig.bound_receiver_param_name == "cls"
+    assert sig.return_value == TypedValue(object)
 
 
 def test_get_argspec():


### PR DESCRIPTION
## Summary
- use a class object's own runtime call signature when `inspect.signature(cls)` works but `__init__`/`__new__` do not expose the real constructor shape
- add a regression test for metaclass-driven class-call signatures, which matches the `repoguess.Params(...)` failure mode
- document the user-visible fix in the changelog

## Root cause
`repoguess` exposes constructor parameters at the class-call level rather than through a normal Python-defined `__init__`, `__new__`, or `__signature__`. Pycroscope fell through to an `object.__init__`-shaped fallback, so valid keyword arguments were reported as unexpected.

## Testing
- `pytest pycroscope/test_arg_spec.py`
- targeted checker snippet covering `repoguess.Params(...)` and `Params(**kwargs)`
