### PR TITLE
[codex] Simplify type alias representation

### DIFF
--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1641,7 +1641,11 @@ def _pack_typevartuple_runtime_args(
 
 
 def _validate_type_alias_arg_values(
-    type_params: Sequence[TypeParam], args_vals: Sequence[Value], ctx: Context
+    type_params: Sequence[TypeParam],
+    args_vals: Sequence[Value],
+    ctx: Context,
+    *,
+    node: ast.AST | None = None,
 ) -> list[Value]:
     normalized_args = list(args_vals)
     matched = match_typevar_arguments(type_params, args_vals)
@@ -1651,10 +1655,12 @@ def _validate_type_alias_arg_values(
         else list(zip(type_params, [value for _, value in matched]))
     )
     if matched_args is None:
-        ctx.show_error(
+        _show_error_from_context(
+            ctx,
             f"Expected {len(type_params)} type arguments for type alias,"
             f" got {len(args_vals)}",
             error_code=ErrorCode.invalid_specialization,
+            node=node,
         )
         return normalized_args
     for i, (type_param, arg) in enumerate(matched_args):
@@ -1670,9 +1676,11 @@ def _validate_type_alias_arg_values(
         if type_param.bound is not None and not _is_alias_arg_compatible_with_bound(
             type_param.bound, arg, ctx
         ):
-            ctx.show_error(
+            _show_error_from_context(
+                ctx,
                 f"Type argument {arg} is not compatible with {type_param}",
                 error_code=ErrorCode.invalid_specialization,
+                node=node,
             )
         elif type_param.constraints and not _is_alias_arg_compatible_with_constraints(
             type_param.constraints, arg, ctx
@@ -1680,11 +1688,28 @@ def _validate_type_alias_arg_values(
             constraint_list = ", ".join(
                 str(constraint) for constraint in type_param.constraints
             )
-            ctx.show_error(
+            _show_error_from_context(
+                ctx,
                 f"Type argument {arg} is not compatible with constraints ({constraint_list})",
                 error_code=ErrorCode.invalid_specialization,
+                node=node,
             )
     return normalized_args
+
+
+def _show_error_from_context(
+    ctx: Context,
+    message: str,
+    *,
+    error_code: Error = ErrorCode.invalid_annotation,
+    node: ast.AST | None = None,
+) -> None:
+    try:
+        ctx.show_error(message, error_code=error_code, node=node)
+    except TypeError:
+        if node is None:
+            raise
+        ctx.show_error(node, message, error_code)
 
 
 def _validate_generic_type_argument_count(
@@ -2554,12 +2579,16 @@ def _type_from_subscripted_value(
 
 
 def _specialize_type_alias_partial(
-    root: PartialValue, members: Sequence[Value], ctx: Context
+    root: PartialValue,
+    members: Sequence[Value],
+    ctx: Context,
+    *,
+    node: ast.AST | None = None,
 ) -> PartialValue:
     assert is_type_alias_partial_operation(root.operation)
     alias_root = get_type_alias_root(root)
     assert alias_root is not None
-    specialized_root = _specialize_type_alias_value(alias_root, members, ctx)
+    specialized_root = _specialize_type_alias_value(alias_root, members, ctx, node=node)
     runtime_value = (
         specialized_root.get_value()
         if root.operation is PartialValueOperation.PEP_613_ALIAS
@@ -2569,7 +2598,11 @@ def _specialize_type_alias_partial(
 
 
 def _specialize_type_alias_value(
-    root: TypeAliasValue, members: Sequence[Value], ctx: Context
+    root: TypeAliasValue,
+    members: Sequence[Value],
+    ctx: Context,
+    *,
+    node: ast.AST | None = None,
 ) -> TypeAliasValue:
     type_params = tuple(root.alias.get_type_params())
     type_arguments_are_packed = False
@@ -2620,8 +2653,10 @@ def _specialize_type_alias_value(
     else:
         args_vals = [_type_from_alias_argument_value(member, ctx) for member in members]
     if has_unbounded_unpack and packed_variadic_members is None:
-        ctx.show_error("Unpacked TypeVarTuple cannot specialize this type alias")
-    args_vals = _validate_type_alias_arg_values(type_params, args_vals, ctx)
+        _show_error_from_context(
+            ctx, "Unpacked TypeVarTuple cannot specialize this type alias", node=node
+        )
+    args_vals = _validate_type_alias_arg_values(type_params, args_vals, ctx, node=node)
     return TypeAliasValue(
         root.name,
         root.module,

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1655,8 +1655,7 @@ def _validate_type_alias_arg_values(
         else list(zip(type_params, [value for _, value in matched]))
     )
     if matched_args is None:
-        _show_error_from_context(
-            ctx,
+        ctx.show_error(
             f"Expected {len(type_params)} type arguments for type alias,"
             f" got {len(args_vals)}",
             error_code=ErrorCode.invalid_specialization,
@@ -1676,8 +1675,7 @@ def _validate_type_alias_arg_values(
         if type_param.bound is not None and not _is_alias_arg_compatible_with_bound(
             type_param.bound, arg, ctx
         ):
-            _show_error_from_context(
-                ctx,
+            ctx.show_error(
                 f"Type argument {arg} is not compatible with {type_param}",
                 error_code=ErrorCode.invalid_specialization,
                 node=node,
@@ -1688,28 +1686,12 @@ def _validate_type_alias_arg_values(
             constraint_list = ", ".join(
                 str(constraint) for constraint in type_param.constraints
             )
-            _show_error_from_context(
-                ctx,
+            ctx.show_error(
                 f"Type argument {arg} is not compatible with constraints ({constraint_list})",
                 error_code=ErrorCode.invalid_specialization,
                 node=node,
             )
     return normalized_args
-
-
-def _show_error_from_context(
-    ctx: Context,
-    message: str,
-    *,
-    error_code: Error = ErrorCode.invalid_annotation,
-    node: ast.AST | None = None,
-) -> None:
-    try:
-        ctx.show_error(message, error_code=error_code, node=node)
-    except TypeError:
-        if node is None:
-            raise
-        ctx.show_error(node, message, error_code)
 
 
 def _validate_generic_type_argument_count(
@@ -2653,8 +2635,8 @@ def _specialize_type_alias_value(
     else:
         args_vals = [_type_from_alias_argument_value(member, ctx) for member in members]
     if has_unbounded_unpack and packed_variadic_members is None:
-        _show_error_from_context(
-            ctx, "Unpacked TypeVarTuple cannot specialize this type alias", node=node
+        ctx.show_error(
+            "Unpacked TypeVarTuple cannot specialize this type alias", node=node
         )
     args_vals = _validate_type_alias_arg_values(type_params, args_vals, ctx, node=node)
     return TypeAliasValue(

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -2329,6 +2329,13 @@ def _type_from_subscripted_value(
             args_vals = packed_variadic_members
             type_arguments_are_packed = True
         elif (
+            not members
+            and len(type_params) == 1
+            and isinstance(type_params[0], TypeVarTupleParam)
+        ):
+            args_vals = [TypeVarTupleBindingValue(())]
+            type_arguments_are_packed = True
+        elif (
             saw_unpack
             and normalized_unpack_members is not None
             and not has_unbounded_unpack
@@ -2363,7 +2370,6 @@ def _type_from_subscripted_value(
             tuple(args_vals),
             runtime_allows_value_call=root.runtime_allows_value_call,
             uses_type_alias_object_semantics=root.uses_type_alias_object_semantics,
-            is_specialized=True,
             type_arguments_are_packed=type_arguments_are_packed,
         )
         if root.runtime_allows_value_call:
@@ -2386,7 +2392,15 @@ def _type_from_subscripted_value(
         alias_object = root
         runtime_type_params = tuple(alias_object.__type_params__)
         type_params = tuple(make_type_param(tp, ctx=ctx) for tp in runtime_type_params)
-        if len(members) == len(type_params):
+        type_arguments_are_packed = False
+        if (
+            not members
+            and len(type_params) == 1
+            and isinstance(type_params[0], TypeVarTupleParam)
+        ):
+            args_vals = [TypeVarTupleBindingValue(())]
+            type_arguments_are_packed = True
+        elif len(members) == len(type_params):
             args_vals = [
                 _type_from_value_type_alias_arg(member, type_param, ctx)
                 for member, type_param in zip(members, type_params)
@@ -2406,7 +2420,7 @@ def _type_from_subscripted_value(
             alias_object.__module__,
             alias,
             tuple(args_vals),
-            is_specialized=True,
+            type_arguments_are_packed=type_arguments_are_packed,
         )
     if root is typing.Union:
         return unite_values(*[_type_from_value(elt, ctx) for elt in members])

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -154,7 +154,9 @@ from .value import (
     bound_self_type_from_class_key,
     class_owner_from_key,
     get_single_typevartuple_param,
+    get_type_alias_root,
     get_typevar_variance,
+    is_type_alias_partial_operation,
     iter_type_params_in_value,
     match_typevar_arguments,
     replace_fallback,
@@ -1137,9 +1139,7 @@ def _make_runtime_type_alias_value(
             normalized_type_params
         ),
     )
-    return TypeAliasValue(
-        "<runtime_generic_alias>", module, alias, runtime_allows_value_call=True
-    )
+    return TypeAliasValue("<runtime_generic_alias>", module, alias)
 
 
 def _infer_alias_type_params_from_value(alias_value: Value) -> tuple[TypeParam, ...]:
@@ -1973,6 +1973,12 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
             return _type_from_subscripted_value(value.root, value.members, ctx)
         if value.operation is PartialValueOperation.BITOR:
             return _type_from_bitor_value(value.root, value.members, ctx)
+        if value.operation is PartialValueOperation.PEP_613_ALIAS:
+            assert isinstance(value.root, TypeAliasValue)
+            return value.root.get_value()
+        if value.operation is PartialValueOperation.PEP_695_ALIAS:
+            assert isinstance(value.root, TypeAliasValue)
+            return value.root
         return value.get_fallback_value()
     elif isinstance(value, PartialCallValue):
         type_param = make_type_param_from_value(value, ctx=ctx)
@@ -2095,6 +2101,14 @@ def _annotation_expr_from_subscripted_value(
 def _type_from_subscripted_value(
     root: Value, members: Sequence[Value], ctx: Context
 ) -> Value:
+    if isinstance(root, PartialValue) and is_type_alias_partial_operation(
+        root.operation
+    ):
+        specialized = _specialize_type_alias_partial(root, members, ctx)
+        if root.operation is PartialValueOperation.PEP_613_ALIAS:
+            return specialized.runtime_value
+        return specialized.root
+
     if isinstance(root, AnnotatedValue):
         self_owner = next(root.get_metadata_of_type(SelfOwnerExtension), None)
         if self_owner is not None:
@@ -2310,74 +2324,7 @@ def _type_from_subscripted_value(
             synthetic_typ, _canonicalize_generic_args_for_value(typed_members)
         )
     if isinstance(root, TypeAliasValue):
-        type_params = tuple(root.alias.get_type_params())
-        type_arguments_are_packed = False
-        if any(_is_unpack_annotation_member(member) for member in members):
-            normalized_unpack_members = _normalize_generic_unpack_members(members, ctx)
-        else:
-            normalized_unpack_members = None
-        saw_unpack = normalized_unpack_members is not None
-        has_unbounded_unpack = (
-            saw_unpack
-            and normalized_unpack_members is not None
-            and any(is_many for is_many, _ in normalized_unpack_members)
-        )
-        packed_variadic_members = _pack_typevartuple_args_from_unpack_members(
-            type_params, members, ctx
-        )
-        if packed_variadic_members is not None:
-            args_vals = packed_variadic_members
-            type_arguments_are_packed = True
-        elif (
-            not members
-            and len(type_params) == 1
-            and isinstance(type_params[0], TypeVarTupleParam)
-        ):
-            args_vals = [TypeVarTupleBindingValue(())]
-            type_arguments_are_packed = True
-        elif (
-            saw_unpack
-            and normalized_unpack_members is not None
-            and not has_unbounded_unpack
-        ):
-            unpacked_members = [member for _, member in normalized_unpack_members]
-            if len(unpacked_members) == len(type_params):
-                args_vals = [
-                    _type_from_value_type_alias_arg(member, type_param, ctx)
-                    for member, type_param in zip(unpacked_members, type_params)
-                ]
-            else:
-                args_vals = [
-                    _type_from_alias_argument_value(member, ctx)
-                    for member in unpacked_members
-                ]
-        elif len(members) == len(type_params):
-            args_vals = [
-                _type_from_value_type_alias_arg(member, type_param, ctx)
-                for member, type_param in zip(members, type_params)
-            ]
-        else:
-            args_vals = [
-                _type_from_alias_argument_value(member, ctx) for member in members
-            ]
-        if has_unbounded_unpack and packed_variadic_members is None:
-            ctx.show_error("Unpacked TypeVarTuple cannot specialize this type alias")
-        args_vals = _validate_type_alias_arg_values(type_params, args_vals, ctx)
-        alias_value = TypeAliasValue(
-            root.name,
-            root.module,
-            root.alias,
-            tuple(args_vals),
-            runtime_allows_value_call=root.runtime_allows_value_call,
-            uses_type_alias_object_semantics=root.uses_type_alias_object_semantics,
-            type_arguments_are_packed=type_arguments_are_packed,
-        )
-        if root.runtime_allows_value_call:
-            # Explicit `TypeAlias` declarations should behave like expanded types in
-            # annotation contexts so generic solving can bind function/class type
-            # variables precisely even when runtime module loading fails.
-            return alias_value.get_value()
-        return alias_value
+        return _specialize_type_alias_value(root, members, ctx)
 
     assert isinstance(root, Value)
     if not isinstance(root, KnownValue):
@@ -2604,6 +2551,84 @@ def _type_from_subscripted_value(
             return GenericValue(origin, typed_members)
         ctx.show_error(f"Unrecognized subscripted annotation: {root}")
         return AnyValue(AnySource.error)
+
+
+def _specialize_type_alias_partial(
+    root: PartialValue, members: Sequence[Value], ctx: Context
+) -> PartialValue:
+    assert is_type_alias_partial_operation(root.operation)
+    alias_root = get_type_alias_root(root)
+    assert alias_root is not None
+    specialized_root = _specialize_type_alias_value(alias_root, members, ctx)
+    runtime_value = (
+        specialized_root.get_value()
+        if root.operation is PartialValueOperation.PEP_613_ALIAS
+        else root.runtime_value
+    )
+    return PartialValue(root.operation, specialized_root, root.node, (), runtime_value)
+
+
+def _specialize_type_alias_value(
+    root: TypeAliasValue, members: Sequence[Value], ctx: Context
+) -> TypeAliasValue:
+    type_params = tuple(root.alias.get_type_params())
+    type_arguments_are_packed = False
+    if any(_is_unpack_annotation_member(member) for member in members):
+        normalized_unpack_members = _normalize_generic_unpack_members(members, ctx)
+    else:
+        normalized_unpack_members = None
+    saw_unpack = normalized_unpack_members is not None
+    has_unbounded_unpack = (
+        saw_unpack
+        and normalized_unpack_members is not None
+        and any(is_many for is_many, _ in normalized_unpack_members)
+    )
+    packed_variadic_members = _pack_typevartuple_args_from_unpack_members(
+        type_params, members, ctx
+    )
+    if packed_variadic_members is not None:
+        args_vals = packed_variadic_members
+        type_arguments_are_packed = True
+    elif (
+        not members
+        and len(type_params) == 1
+        and isinstance(type_params[0], TypeVarTupleParam)
+    ):
+        args_vals = [TypeVarTupleBindingValue(())]
+        type_arguments_are_packed = True
+    elif (
+        saw_unpack
+        and normalized_unpack_members is not None
+        and not has_unbounded_unpack
+    ):
+        unpacked_members = [member for _, member in normalized_unpack_members]
+        if len(unpacked_members) == len(type_params):
+            args_vals = [
+                _type_from_value_type_alias_arg(member, type_param, ctx)
+                for member, type_param in zip(unpacked_members, type_params)
+            ]
+        else:
+            args_vals = [
+                _type_from_alias_argument_value(member, ctx)
+                for member in unpacked_members
+            ]
+    elif len(members) == len(type_params):
+        args_vals = [
+            _type_from_value_type_alias_arg(member, type_param, ctx)
+            for member, type_param in zip(members, type_params)
+        ]
+    else:
+        args_vals = [_type_from_alias_argument_value(member, ctx) for member in members]
+    if has_unbounded_unpack and packed_variadic_members is None:
+        ctx.show_error("Unpacked TypeVarTuple cannot specialize this type alias")
+    args_vals = _validate_type_alias_arg_values(type_params, args_vals, ctx)
+    return TypeAliasValue(
+        root.name,
+        root.module,
+        root.alias,
+        tuple(args_vals),
+        type_arguments_are_packed=type_arguments_are_packed,
+    )
 
 
 def _maybe_get_extra(origin: type) -> ClassKey:

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -85,7 +85,6 @@ from .value import (
     _iter_typevar_map_items,
     _typevar_map_from_varlike_pairs,
     annotate_value,
-    get_type_alias_root,
     replace_fallback,
     set_self,
     unite_values,
@@ -193,16 +192,19 @@ def _get_type_object_attribute(
 
 
 def get_attribute(ctx: AttrContext) -> Value:
-    alias_root = get_type_alias_root(ctx.root_value)
-    if (
-        alias_root is not None
-        and isinstance(ctx.root_value, PartialValue)
-        and ctx.root_value.operation is PartialValueOperation.PEP_695_ALIAS
-    ):
-        return _get_attribute_from_type_alias(alias_root, ctx)
     lookup_root_value = (
         ctx.root_value if ctx.lookup_root_value is None else ctx.lookup_root_value
     )
+    if (
+        isinstance(ctx.root_value, PartialValue)
+        and ctx.root_value.operation is PartialValueOperation.PEP_695_ALIAS
+    ):
+        assert isinstance(ctx.root_value.root, TypeAliasValue)
+        attribute_value = _get_attribute_from_type_alias(ctx.root_value.root, ctx)
+        if attribute_value is not UNINITIALIZED_VALUE:
+            return attribute_value
+        if ctx.lookup_root_value is None:
+            lookup_root_value = ctx.root_value.runtime_value
     if (
         isinstance(lookup_root_value, TypeVarValue)
         and lookup_root_value.typevar_param.bound is not None
@@ -259,12 +261,14 @@ def get_attribute(ctx: AttrContext) -> Value:
             return ctx.root_value.predicate.value
         return attribute_value
     root_value = replace_fallback(lookup_root_value)
-    if isinstance(root_value, KnownValue) and is_typing_name(
-        type(root_value.val), "TypeAliasType"
-    ):
-        return _get_attribute_from_runtime_type_alias(root_value.val, ctx)
     attribute_value: Value = UNINITIALIZED_VALUE
     if isinstance(root_value, KnownValue):
+        if is_typing_name(type(root_value.val), "TypeAliasType"):
+            attribute_value = _get_attribute_from_runtime_type_alias(
+                root_value.val, ctx
+            )
+            if attribute_value is not UNINITIALIZED_VALUE:
+                return attribute_value
         attribute_value = _get_attribute_from_known(root_value.val, ctx)
     elif isinstance(root_value, TypedValue):
         if (

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -85,6 +85,7 @@ from .value import (
     _iter_typevar_map_items,
     _typevar_map_from_varlike_pairs,
     annotate_value,
+    get_type_alias_root,
     replace_fallback,
     set_self,
     unite_values,
@@ -192,11 +193,13 @@ def _get_type_object_attribute(
 
 
 def get_attribute(ctx: AttrContext) -> Value:
+    alias_root = get_type_alias_root(ctx.root_value)
     if (
-        isinstance(ctx.root_value, TypeAliasValue)
-        and ctx.root_value.uses_type_alias_object_semantics
+        alias_root is not None
+        and isinstance(ctx.root_value, PartialValue)
+        and ctx.root_value.operation is PartialValueOperation.PEP_695_ALIAS
     ):
-        return _get_attribute_from_type_alias(ctx.root_value, ctx)
+        return _get_attribute_from_type_alias(alias_root, ctx)
     lookup_root_value = (
         ctx.root_value if ctx.lookup_root_value is None else ctx.lookup_root_value
     )

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -34,6 +34,7 @@ from .safe import (
     safe_isinstance,
     safe_issubclass,
 )
+from .safe import is_union as is_runtime_union
 from .shared_options import EnforceNoUnusedCallPatterns, VariableNameValues
 from .signature import (
     ANY_SIGNATURE,
@@ -113,6 +114,18 @@ from .value import (
 )
 
 _SyntheticGenericBases = dict[ClassKey, TypeVarMap]
+
+
+def _runtime_value_is_union(value: Value) -> bool:
+    value = replace_fallback(value)
+    if isinstance(value, AnnotatedValue):
+        return _runtime_value_is_union(value.value)
+    if is_union(value):
+        return True
+    if not isinstance(value, KnownValue):
+        return False
+    origin = safe_getattr(value.val, "__origin__", None)
+    return is_runtime_union(value.val) or is_runtime_union(origin)
 
 
 @dataclass(frozen=True)
@@ -2063,8 +2076,9 @@ class Checker:
                 PartialValueOperation.PEP_613_ALIAS,
                 PartialValueOperation.PEP_695_ALIAS,
             ):
-                if value.operation is PartialValueOperation.PEP_613_ALIAS and is_union(
-                    replace_fallback(value.runtime_value)
+                if (
+                    value.operation is PartialValueOperation.PEP_613_ALIAS
+                    and _runtime_value_is_union(value.runtime_value)
                 ):
                     return None
                 return self.signature_from_value(

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -2059,28 +2059,16 @@ class Checker:
             )
             if sig is not None:
                 return sig
-        if (
-            isinstance(value, TypeAliasValue)
-            and value.runtime_allows_value_call
-            and not value.type_arguments
-            and not value.alias.get_type_params()
-        ):
-            alias_value = value.get_value()
-            # Explicit TypeAlias declarations can denote class objects (e.g.
-            # `Alias: TypeAlias = list`) that should remain callable.
-            if isinstance(alias_value, KnownValue) and isinstance(
-                alias_value.val, type
+            if value.operation in (
+                PartialValueOperation.PEP_613_ALIAS,
+                PartialValueOperation.PEP_695_ALIAS,
             ):
+                if value.operation is PartialValueOperation.PEP_613_ALIAS and is_union(
+                    replace_fallback(value.runtime_value)
+                ):
+                    return None
                 return self.signature_from_value(
-                    alias_value,
-                    get_return_override=get_return_override,
-                    get_call_attribute=get_call_attribute,
-                )
-            if isinstance(alias_value, TypedValue) and isinstance(
-                alias_value.typ, type
-            ):
-                return self.signature_from_value(
-                    KnownValue(alias_value.typ),
+                    value.runtime_value,
                     get_return_override=get_return_override,
                     get_call_attribute=get_call_attribute,
                 )

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -338,6 +338,11 @@ def _invalid_classinfo_kind(
         return _invalid_classinfo_kind(
             value.value, ctx, is_subclass_check=is_subclass_check
         )
+    if (
+        isinstance(value, PartialValue)
+        and value.operation is PartialValueOperation.PEP_695_ALIAS
+    ):
+        return "a type alias"
     if isinstance(value, TypeAliasValue):
         return "a type alias"
     if isinstance(value, SyntheticClassObjectValue):

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -73,6 +73,7 @@ from .annotations import (
     Context,
     Qualifier,
     SyntheticEvaluator,
+    _DefaultContext,
     _normalize_paramspec_generic_args,
     _specialize_type_alias_partial,
     _specialize_type_alias_value,
@@ -13275,14 +13276,15 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     # Value-position specialization of a declared type alias should
                     # use the recorded alias metadata rather than the raw runtime
                     # GenericAlias object, which may not support further specialization.
+                    annotation_ctx = _DefaultContext(visitor=self, node=node)
                     members = self._maybe_unpack_tuple(index, node)
                     if isinstance(runtime_type_alias, PartialValue):
                         return _specialize_type_alias_partial(
-                            runtime_type_alias, members, self, node=node
+                            runtime_type_alias, members, annotation_ctx, node=node
                         )
                     assert isinstance(runtime_type_alias, TypeAliasValue)
                     return _specialize_type_alias_value(
-                        runtime_type_alias, members, self, node=node
+                        runtime_type_alias, members, annotation_ctx, node=node
                     )
                 should_use_static_annotation_subscript = self.in_annotation and (
                     get_type_alias_root(stripped_root.value) is not None
@@ -17164,9 +17166,7 @@ def _runtime_value_for_pep695_alias(
 ) -> Value:
     if alias_obj is not None:
         return KnownValue(alias_obj)
-    if hasattr(typing, "TypeAliasType"):
-        return TypedValue(typing.TypeAliasType)
-    return TypedValue(typing_extensions.TypeAliasType)
+    return TypedValue(getattr(typing, "TypeAliasType", typing_extensions.TypeAliasType))
 
 
 def _get_runtime_type_alias_value_node(node: ast.Call) -> ast.AST | None:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -75,6 +75,7 @@ from .annotations import (
     SyntheticEvaluator,
     _normalize_paramspec_generic_args,
     _specialize_type_alias_partial,
+    _specialize_type_alias_value,
     annotation_expr_from_annotations,
     annotation_expr_from_ast,
     annotation_expr_from_runtime,
@@ -13265,7 +13266,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         stripped_value, root_composite.varname, root_composite.node
                     )
                 )
-                runtime_type_alias: PartialValue | None = None
+                runtime_type_alias: Value | None = None
                 if not self.in_annotation:
                     runtime_type_alias = self._get_value_position_type_alias_symbol(
                         stripped_root, node.value
@@ -13274,8 +13275,14 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     # Value-position specialization of a declared type alias should
                     # use the recorded alias metadata rather than the raw runtime
                     # GenericAlias object, which may not support further specialization.
-                    return _specialize_type_alias_partial(
-                        runtime_type_alias, self._maybe_unpack_tuple(index, node), self
+                    members = self._maybe_unpack_tuple(index, node)
+                    if isinstance(runtime_type_alias, PartialValue):
+                        return _specialize_type_alias_partial(
+                            runtime_type_alias, members, self, node=node
+                        )
+                    assert isinstance(runtime_type_alias, TypeAliasValue)
+                    return _specialize_type_alias_value(
+                        runtime_type_alias, members, self, node=node
                     )
                 should_use_static_annotation_subscript = self.in_annotation and (
                     get_type_alias_root(stripped_root.value) is not None
@@ -13646,12 +13653,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
     def _get_value_position_type_alias_symbol(
         self, root_composite: Composite, node: ast.expr
-    ) -> PartialValue | None:
+    ) -> Value | None:
         # Only the alias symbol itself should preserve type-alias specialization
         # behavior in value position. Ordinary values annotated with an alias type
         # should behave like their underlying runtime values.
         if _is_type_alias_specialization_symbol_composite(root_composite):
-            assert isinstance(root_composite.value, PartialValue)
+            assert isinstance(root_composite.value, (PartialValue, TypeAliasValue))
             return root_composite.value
         return None
 
@@ -17136,14 +17143,11 @@ def _is_type_alias_symbol_composite(root_composite: Composite) -> bool:
 
 
 def _is_type_alias_specialization_symbol_composite(root_composite: Composite) -> bool:
-    if not (
-        isinstance(root_composite.value, PartialValue)
-        and is_type_alias_partial_operation(root_composite.value.operation)
-        and isinstance(root_composite.value.root, TypeAliasValue)
-    ):
+    alias_root = get_type_alias_root(root_composite.value)
+    if alias_root is None:
         return False
     varname = root_composite.varname
-    return varname is not None and varname.varname == root_composite.value.root.name
+    return varname is not None and varname.varname == alias_root.name
 
 
 def _runtime_value_for_pep613_alias(alias_value: TypeAliasValue) -> Value:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -14700,12 +14700,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     self_value=resolved_self_value,
                 )
                 result = attributes.get_attribute(mangled_ctx)
-        if (
-            result is UNINITIALIZED_VALUE
-            and node is not None
-            and isinstance(root_composite.value, TypeAliasValue)
-            and is_type_alias_symbol
-        ):
+        if result is UNINITIALIZED_VALUE and node is not None and is_type_alias_symbol:
             self._show_error_if_checking(
                 node,
                 f"{root_composite.value} has no attribute {attr!r}",
@@ -17141,11 +17136,14 @@ def _is_type_alias_symbol_composite(root_composite: Composite) -> bool:
 
 
 def _is_type_alias_specialization_symbol_composite(root_composite: Composite) -> bool:
-    alias_root = get_type_alias_root(root_composite.value)
-    if alias_root is None:
+    if not (
+        isinstance(root_composite.value, PartialValue)
+        and is_type_alias_partial_operation(root_composite.value.operation)
+        and isinstance(root_composite.value.root, TypeAliasValue)
+    ):
         return False
     varname = root_composite.varname
-    return varname is not None and varname.varname == alias_root.name
+    return varname is not None and varname.varname == root_composite.value.root.name
 
 
 def _runtime_value_for_pep613_alias(alias_value: TypeAliasValue) -> Value:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -53,6 +53,7 @@ from typing import (
 from unittest.mock import ANY
 
 import typeshed_client
+import typing_extensions
 from typing_extensions import Protocol, assert_never, is_typeddict
 
 from . import attributes, format_strings, importer, node_visitor, type_evaluation
@@ -73,6 +74,7 @@ from .annotations import (
     Qualifier,
     SyntheticEvaluator,
     _normalize_paramspec_generic_args,
+    _specialize_type_alias_partial,
     annotation_expr_from_annotations,
     annotation_expr_from_ast,
     annotation_expr_from_runtime,
@@ -321,10 +323,12 @@ from .value import (
     concrete_values_from_iterable,
     flatten_values,
     get_self_param,
+    get_type_alias_root,
     get_typevar_variance,
     is_async_iterable,
     is_iterable,
     is_self_typevar_value,
+    is_type_alias_partial_operation,
     is_union,
     iter_type_params_in_value,
     kv_pairs_from_mapping,
@@ -2744,8 +2748,16 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         # declared types for annotated names.
                         declared_type = current_scope.get_declared_type(varname)
                         if declared_type is not None:
-                            current_scope.variables[varname] = declared_type
-                            return declared_type, EMPTY_ORIGIN
+                            stored_value = (
+                                value
+                                if (
+                                    isinstance(value, PartialValue)
+                                    and is_type_alias_partial_operation(value.operation)
+                                )
+                                else declared_type
+                            )
+                            current_scope.variables[varname] = stored_value
+                            return stored_value, EMPTY_ORIGIN
                         current_scope.variables[varname] = value
                         return value, EMPTY_ORIGIN
                     if isinstance(value, AnnotatedValue) and value.has_metadata_of_type(
@@ -3799,7 +3811,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
             if self.in_annotation:
                 declared_type = defining_scope.get_declared_type(node.id)
-                if isinstance(declared_type, TypeAliasValue):
+                if isinstance(declared_type, TypeAliasValue) and not (
+                    isinstance(value, PartialValue)
+                    and is_type_alias_partial_operation(value.operation)
+                ):
                     value = declared_type
         if value is UNINITIALIZED_VALUE:
             if suppress_errors or node.id in self.options.get_value_for(ExtraBuiltins):
@@ -11754,7 +11769,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         )
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
-        explicit_type_alias_assignment_value: TypeAliasValue | None = None
+        explicit_type_alias_assignment_value: PartialValue | None = None
         local_type_param_polarities: dict[object, set[int]] | None = None
         class_type_param_polarities = (
             self.active_type_params.current_class_type_param_polarities()
@@ -11905,16 +11920,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     disallowed_type_param_identities=disallowed_type_params,
                 )
 
-                explicit_type_alias_assignment_value = TypeAliasValue(
+                alias_root = TypeAliasValue(
                     node.target.id,
                     self.module.__name__ if self.module is not None else "",
                     TypeAlias(
                         alias_evaluator, lambda type_params=type_params: type_params
                     ),
-                    runtime_allows_value_call=True,
-                    uses_type_alias_object_semantics=_uses_type_alias_object_semantics(
-                        alias_type
-                    ),
+                )
+                explicit_type_alias_assignment_value = PartialValue(
+                    PartialValueOperation.PEP_613_ALIAS,
+                    alias_root,
+                    node.value,
+                    (),
+                    _runtime_value_for_pep613_alias(alias_root),
                 )
             # `TypeAlias` marks this assignment as an alias declaration, not a
             # variable declaration of the marker type itself.
@@ -12052,20 +12070,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         )
         if node.value is not None:
             if explicit_type_alias_assignment_value is not None:
-                if self.annotate:
-                    with (
-                        self.catch_errors(),
-                        override(self, "in_type_alias_definition", True),
-                    ):
-                        self.visit(node.value)
-                is_yield = False
-                alias_runtime_value = explicit_type_alias_assignment_value.get_value()
-                if isinstance(alias_runtime_value, TypedValue) and isinstance(
-                    alias_runtime_value.typ, type
+                runtime_value = explicit_type_alias_assignment_value.runtime_value
+                with (
+                    self.catch_errors(),
+                    override(self, "in_type_alias_definition", True),
                 ):
-                    value = KnownValue(alias_runtime_value.typ)
-                else:
-                    value = explicit_type_alias_assignment_value
+                    evaluated_runtime_value = self.visit(node.value)
+                if evaluated_runtime_value != AnyValue(AnySource.error):
+                    runtime_value = evaluated_runtime_value
+                explicit_type_alias_assignment_value = dataclass_replace(
+                    explicit_type_alias_assignment_value, runtime_value=runtime_value
+                )
+                is_yield = False
+                value = explicit_type_alias_assignment_value
                 initializer_value = value
             else:
                 is_yield = isinstance(node.value, ast.Yield)
@@ -12202,7 +12219,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
         ann_assign_declared_type = expected_type
         if explicit_type_alias_assignment_value is not None:
-            ann_assign_declared_type = explicit_type_alias_assignment_value
+            ann_assign_declared_type = explicit_type_alias_assignment_value.root
         if self.scopes.scope_type() == ScopeType.class_scope and isinstance(
             node.target, ast.Name
         ):
@@ -12624,6 +12641,21 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if value_node is None:
             return None
         name = node.targets[0].id
+        existing_value = self._get_local_object(name, node)
+        runtime_existing = (
+            existing_value.runtime_value
+            if (
+                isinstance(existing_value, PartialValue)
+                and existing_value.operation is PartialValueOperation.PEP_695_ALIAS
+            )
+            else existing_value
+        )
+        if isinstance(runtime_existing, KnownValue) and is_instance_of_typing_name(
+            type(runtime_existing.val), "TypeAliasType"
+        ):
+            alias_obj = runtime_existing.val
+        else:
+            alias_obj = None
         if self._is_collecting():
             self._record_type_alias_structure(name, node, value_node)
         type_params = self._extract_runtime_type_alias_type_params(node.value)
@@ -12691,11 +12723,18 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 value_node, suppress_errors=True
             )
 
-        return TypeAliasValue(
+        alias_root = TypeAliasValue(
             name,
             self.module.__name__ if self.module is not None else "",
             TypeAlias(evaluator, lambda: tuple(type_params)),
-            uses_type_alias_object_semantics=True,
+        )
+        runtime_value = _runtime_value_for_pep695_alias(alias_root, alias_obj)
+        return PartialValue(
+            PartialValueOperation.PEP_695_ALIAS,
+            alias_root,
+            node.value,
+            (),
+            runtime_value,
         )
 
     if sys.version_info >= (3, 12):
@@ -12739,10 +12778,18 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             if self._is_collecting():
                 self._record_type_alias_structure(name, node, node.value)
             alias_val = self._get_local_object(name, node)
-            if isinstance(alias_val, KnownValue) and isinstance(
-                alias_val.val, typing.TypeAliasType
+            alias_runtime = (
+                alias_val.runtime_value
+                if (
+                    isinstance(alias_val, PartialValue)
+                    and alias_val.operation is PartialValueOperation.PEP_695_ALIAS
+                )
+                else alias_val
+            )
+            if isinstance(alias_runtime, KnownValue) and isinstance(
+                alias_runtime.val, typing.TypeAliasType
             ):
-                alias_obj = alias_val.val
+                alias_obj = alias_runtime.val
             else:
                 alias_obj = None
             type_param_values = []
@@ -12817,14 +12864,20 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 if value is None or disallow_in_function:
                     alias_val = AnyValue(AnySource.inference)
                 else:
-                    alias_val = TypeAliasValue(
+                    alias_root = TypeAliasValue(
                         name,
                         self.module.__name__ if self.module is not None else "",
                         TypeAlias(
                             lambda: type_from_value(value, self, node),
                             lambda: tuple(type_param_values),
                         ),
-                        uses_type_alias_object_semantics=True,
+                    )
+                    alias_val = PartialValue(
+                        PartialValueOperation.PEP_695_ALIAS,
+                        alias_root,
+                        node.value,
+                        (),
+                        _runtime_value_for_pep695_alias(alias_root, alias_obj),
                     )
             set_value, _ = self._set_name_in_scope(name, node, alias_val)
             return set_value
@@ -13212,7 +13265,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         stripped_value, root_composite.varname, root_composite.node
                     )
                 )
-                runtime_type_alias: TypeAliasValue | None = None
+                runtime_type_alias: PartialValue | None = None
                 if not self.in_annotation:
                     runtime_type_alias = self._get_value_position_type_alias_symbol(
                         stripped_root, node.value
@@ -13221,20 +13274,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     # Value-position specialization of a declared type alias should
                     # use the recorded alias metadata rather than the raw runtime
                     # GenericAlias object, which may not support further specialization.
-                    return type_from_value(
-                        PartialValue(
-                            PartialValueOperation.SUBSCRIPT,
-                            runtime_type_alias,
-                            node,
-                            self._maybe_unpack_tuple(index, node),
-                            TypedValue(types.GenericAlias),
-                        ),
-                        self,
-                        node,
-                        suppress_errors=False,
+                    return _specialize_type_alias_partial(
+                        runtime_type_alias, self._maybe_unpack_tuple(index, node), self
                     )
                 should_use_static_annotation_subscript = self.in_annotation and (
-                    isinstance(stripped_root.value, TypeAliasValue)
+                    get_type_alias_root(stripped_root.value) is not None
                     or (
                         self.module is None
                         and _should_use_static_annotation_subscript_on_import_failure(
@@ -13602,12 +13646,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
     def _get_value_position_type_alias_symbol(
         self, root_composite: Composite, node: ast.expr
-    ) -> TypeAliasValue | None:
+    ) -> PartialValue | None:
         # Only the alias symbol itself should preserve type-alias specialization
         # behavior in value position. Ordinary values annotated with an alias type
         # should behave like their underlying runtime values.
         if _is_type_alias_specialization_symbol_composite(root_composite):
-            assert isinstance(root_composite.value, TypeAliasValue)
+            assert isinstance(root_composite.value, PartialValue)
             return root_composite.value
         return None
 
@@ -15264,6 +15308,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         return None
 
     def _is_non_instantiable_union_runtime_value(self, value: Value) -> bool:
+        if (
+            isinstance(value, PartialValue)
+            and value.operation is PartialValueOperation.PEP_613_ALIAS
+        ):
+            return False
         value = replace_fallback(value)
         if not isinstance(value, KnownValue):
             return False
@@ -17070,7 +17119,8 @@ def _is_typealiastype_value(value: Value) -> bool:
 
 def _is_type_alias_object_value(value: Value) -> bool:
     return (
-        isinstance(value, TypeAliasValue) and value.uses_type_alias_object_semantics
+        isinstance(value, PartialValue)
+        and value.operation is PartialValueOperation.PEP_695_ALIAS
     ) or _is_typealiastype_known_value(value)
 
 
@@ -17082,35 +17132,39 @@ def _is_typealiastype_known_value(value: Value) -> bool:
 
 
 def _is_type_alias_symbol_composite(root_composite: Composite) -> bool:
-    if not isinstance(root_composite.value, TypeAliasValue):
-        return False
-    if not root_composite.value.uses_type_alias_object_semantics:
+    if not (
+        isinstance(root_composite.value, PartialValue)
+        and root_composite.value.operation is PartialValueOperation.PEP_695_ALIAS
+    ):
         return False
     return _is_type_alias_specialization_symbol_composite(root_composite)
 
 
 def _is_type_alias_specialization_symbol_composite(root_composite: Composite) -> bool:
-    if not isinstance(root_composite.value, TypeAliasValue):
+    alias_root = get_type_alias_root(root_composite.value)
+    if alias_root is None:
         return False
     varname = root_composite.varname
-    return varname is not None and varname.varname == root_composite.value.name
+    return varname is not None and varname.varname == alias_root.name
 
 
-def _uses_type_alias_object_semantics(alias_value: Value) -> bool:
-    for subval in flatten_values(alias_value, unwrap_annotated=True):
-        if isinstance(subval, (SubclassValue, TypeAliasValue)):
-            return True
-        if isinstance(subval, TypedValue) and subval.typ is type:
-            return True
-        if isinstance(subval, GenericValue) and subval.typ is type:
-            return True
-        if isinstance(subval, KnownValue):
-            if subval.val is type or is_typing_name(subval.val, "Type"):
-                return True
-            origin = safe_getattr(subval.val, "__origin__", None)
-            if origin is type:
-                return True
-    return False
+def _runtime_value_for_pep613_alias(alias_value: TypeAliasValue) -> Value:
+    runtime_value = alias_value.get_value()
+    if isinstance(runtime_value, TypeAliasValue):
+        return _runtime_value_for_pep613_alias(runtime_value)
+    if isinstance(runtime_value, TypedValue) and isinstance(runtime_value.typ, type):
+        return KnownValue(runtime_value.typ)
+    return runtime_value
+
+
+def _runtime_value_for_pep695_alias(
+    alias_value: TypeAliasValue, alias_obj: object | None
+) -> Value:
+    if alias_obj is not None:
+        return KnownValue(alias_obj)
+    if hasattr(typing, "TypeAliasType"):
+        return TypedValue(typing.TypeAliasType)
+    return TypedValue(typing_extensions.TypeAliasType)
 
 
 def _get_runtime_type_alias_value_node(node: ast.Call) -> ast.AST | None:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -45,6 +45,7 @@ from typing import (
     ClassVar,
     Literal,
     Optional,
+    TypeGuard,
     TypeVar,
     Union,
     get_args,
@@ -698,6 +699,10 @@ def _count_typevartuple_type_param_arg(value: Value) -> tuple[int, int]:
     if _is_typevartuple_annotation_value(value):
         return (1, 0)
     return (0, 0)
+
+
+def _is_runtime_class_for_attribute_tracking(obj: object) -> TypeGuard[type]:
+    return safe_isinstance(obj, type) and not isinstance(obj, GenericAlias)
 
 
 @dataclass(init=False)
@@ -15945,8 +15950,13 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             node.attr, ClassSymbol(initializer=self.being_assigned)
         )
 
-    def _record_type_attr_read(self, typ: type, attr_name: str, node: ast.AST) -> None:
-        if self.attribute_checker is not None:
+    def _record_type_attr_read(
+        self, typ: object, attr_name: str, node: ast.AST
+    ) -> None:
+        if (
+            self.attribute_checker is not None
+            and _is_runtime_class_for_attribute_tracking(typ)
+        ):
             self.attribute_checker.record_attribute_read(typ, attr_name, node, self)
 
     def _record_attr_read_for_value(

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -499,6 +499,17 @@ class TestImportFailureHandling(TestNameCheckVisitorBase):
         _x2: ListAlias[int]  # E: invalid_specialization
         _x3 = ListOrSetAlias()  # E: not_callable
 
+    @assert_passes(allow_import_failures=True)
+    def test_implicit_tuple_alias_specialization_after_runtime_load_failure(self):
+        from typing import TypeVar
+
+        _bad_type1: type[int, str]  # E: invalid_annotation
+
+        T = TypeVar("T")
+        IntTupleGeneric = tuple[int, T]
+
+        IntTupleGeneric[str]
+
     @assert_passes(run_in_both_module_modes=True)
     def test_explicit_type_alias_uses_runtime_attribute_semantics(self):
         from typing import TypeAlias

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -12,7 +12,12 @@ from .analysis_lib import make_module
 from .attributes import ClassAttributeTransformer
 from .checker import Checker
 from .error_code import DISABLED_IN_TESTS, ErrorCode
-from .name_check_visitor import ClassAttributeChecker, NameCheckVisitor, _static_hasattr
+from .name_check_visitor import (
+    ClassAttributeChecker,
+    NameCheckVisitor,
+    _is_runtime_class_for_attribute_tracking,
+    _static_hasattr,
+)
 from .test_config import CONFIG_PATH
 from .test_node_visitor import (
     assert_fails,
@@ -2218,6 +2223,11 @@ class TestYieldFrom(TestNameCheckVisitorBase):
 
 
 class TestClassAttributeChecker(TestNameCheckVisitorBase):
+    def test_type_generic_alias_is_not_runtime_class_for_attribute_tracking(self):
+        from typing import Any
+
+        assert not _is_runtime_class_for_attribute_tracking(type[Any])
+
     @assert_passes(check_attributes=False)
     def test_attribute_checker_can_be_disabled(self):
         class Capybara(object):
@@ -2255,6 +2265,34 @@ class TestClassAttributeChecker(TestNameCheckVisitorBase):
             @classmethod
             def do_stuff(cls):
                 return cls.stuff  # E: attribute_is_never_set
+
+    def test_unused_attributes_ignores_type_generic_alias_reads(self):
+        code = textwrap.dedent("""
+            from typing import Any
+
+            type[Any].__name__
+            """)
+        tree = ast.parse(code, "<test input>")
+        module = _make_module(code)
+        settings = {code: code not in DISABLED_IN_TESTS for code in ErrorCode}
+        kwargs = self.visitor_cls.prepare_constructor_kwargs({"settings": settings})
+        with ClassAttributeChecker(
+            enabled=True,
+            should_check_unused_attributes=True,
+            options=kwargs["checker"].options,
+        ) as attribute_checker:
+            visitor = self.visitor_cls(
+                module.__name__,
+                code,
+                tree,
+                module=module,
+                attribute_checker=attribute_checker,
+                verbosity=0,
+                **kwargs,
+            )
+            result = visitor.check_for_test()
+            result += visitor.perform_final_checks(kwargs)
+        assert not result
 
     @assert_passes()
     def test_getattribute_overridden(self):

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -1539,13 +1539,12 @@ class TypeAliasValue(Value):
     runtime_allows_value_call: bool = False
     uses_type_alias_object_semantics: bool = False
     """Whether symbol access should behave like a runtime TypeAliasType object."""
-    is_specialized: bool = False
     type_arguments_are_packed: bool = False
 
     def get_value(self) -> Value:
         val = self.alias.get_value()
         type_params = self.alias.get_type_params()
-        if self.type_arguments or self.is_specialized:
+        if self.type_arguments:
             matched_type_arguments = _match_type_alias_type_arguments(
                 type_params,
                 self.type_arguments,
@@ -1595,7 +1594,6 @@ class TypeAliasValue(Value):
             substituted_type_arguments,
             runtime_allows_value_call=self.runtime_allows_value_call,
             uses_type_alias_object_semantics=self.uses_type_alias_object_semantics,
-            is_specialized=self.is_specialized,
             type_arguments_are_packed=self.type_arguments_are_packed,
         )
 

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -940,6 +940,8 @@ class PartialValueOperation(enum.Enum):
     SUBSCRIPT = 1
     UNPACK = 2
     BITOR = 3
+    PEP_613_ALIAS = 4
+    PEP_695_ALIAS = 5
 
 
 @dataclass(frozen=True)
@@ -962,6 +964,10 @@ class PartialValue(Value):
             case PartialValueOperation.BITOR:
                 members = " | ".join(str(member) for member in self.members)
                 return f"{self.runtime_value} (partial from {self.root} | {members})"
+            case PartialValueOperation.PEP_613_ALIAS:
+                return f"{self.runtime_value} (PEP 613 alias for {self.root})"
+            case PartialValueOperation.PEP_695_ALIAS:
+                return f"{self.runtime_value} (PEP 695 alias for {self.root})"
             case _:
                 assert_never(self.operation)
 
@@ -993,6 +999,25 @@ class PartialValue(Value):
         for member in self.members:
             yield from member.walk_values()
         yield from self.runtime_value.walk_values()
+
+
+def is_type_alias_partial_operation(operation: PartialValueOperation) -> bool:
+    return operation in (
+        PartialValueOperation.PEP_613_ALIAS,
+        PartialValueOperation.PEP_695_ALIAS,
+    )
+
+
+def get_type_alias_root(value: Value) -> "TypeAliasValue | None":
+    if (
+        isinstance(value, PartialValue)
+        and is_type_alias_partial_operation(value.operation)
+        and isinstance(value.root, TypeAliasValue)
+    ):
+        return value.root
+    if isinstance(value, TypeAliasValue):
+        return value
+    return None
 
 
 @dataclass(frozen=True)
@@ -1536,9 +1561,6 @@ class TypeAliasValue(Value):
     """Module where the type alias is defined."""
     alias: TypeAlias = field(compare=False, hash=False)
     type_arguments: Sequence[Value] = ()
-    runtime_allows_value_call: bool = False
-    uses_type_alias_object_semantics: bool = False
-    """Whether symbol access should behave like a runtime TypeAliasType object."""
     type_arguments_are_packed: bool = False
 
     def get_value(self) -> Value:
@@ -1592,8 +1614,6 @@ class TypeAliasValue(Value):
             self.module,
             self.alias,
             substituted_type_arguments,
-            runtime_allows_value_call=self.runtime_allows_value_call,
-            uses_type_alias_object_semantics=self.uses_type_alias_object_semantics,
             type_arguments_are_packed=self.type_arguments_are_packed,
         )
 

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -43,3 +43,6 @@ namedtuples_define_class
 
 # https://github.com/python/typing/issues/2259
 dataclasses_descriptors
+
+# Newly added on typing; pycroscope doesn't fully implement disjoint_base yet
+directives_disjoint_base


### PR DESCRIPTION
## Summary
- represent explicit TypeAlias declarations and PEP 695 aliases as dedicated PartialValue operations instead of overloading TypeAliasValue with runtime/object-semantics flags
- remove the redundant is_specialized state and rely on stored type arguments, including packed empty TypeVarTuple arguments
- simplify alias attribute lookup so PEP 695 alias partials only synthesize alias-defined attributes and otherwise defer to their runtime value

## Why
TypeAliasValue had drifted into representing two different things at once: the typing-level alias metadata and the runtime alias object/value behavior. That forced several boolean flags and special cases to keep the two roles in sync.

This change separates those roles. TypeAliasValue now stays focused on the typing alias, while PartialValue PEP_613_ALIAS and PartialValue PEP_695_ALIAS carry the runtime-facing behavior.

## Impact
- the internal representation of type aliases is simpler and more consistent
- PEP 613 aliases keep runtime callability without pretending to be runtime alias objects
- PEP 695 alias symbols preserve runtime alias attributes like __value__ and __type_params__ while ordinary attributes follow normal runtime lookup

## Root Cause
The old model mixed alias types and alias values in one object, so downstream code had to inspect flags like runtime_allows_value_call and uses_type_alias_object_semantics to guess which behavior it should use.

## Validation
- uv run --python 3.12 --extra tests pytest pycroscope/test_type_aliases.py pycroscope/test_name_check_visitor.py pycroscope/test_annotations.py pycroscope/test_attributes.py -q
