### PR TITLE
[codex] Track type parameter owners through scopes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ pycroscope: A semi-static typechecker
    configuration
    typesystem
    design
+   type_params
    type_evaluation
    annotated_types
    glossary

--- a/docs/type_params.md
+++ b/docs/type_params.md
@@ -1,0 +1,168 @@
+# Type Parameter Scope Design
+
+This note sketches the intended shape of `pycroscope/type_params.py`. The goal is
+to make ownership of type parameters explicit without scattering owner-binding,
+aliasing, and annotation-validity rules through `name_check_visitor.py`.
+
+## Terms
+
+A **type parameter** is one of pycroscope's canonical `TypeParam` values:
+`TypeVarParam`, `ParamSpecParam`, or `TypeVarTupleParam`.
+
+A **type parameter owner** is the class, function, or type alias definition that
+binds a type parameter. Owners are represented by `TypeParamOwner`.
+
+A **type parameter identity** is the thing used to recognize a type parameter in
+source or runtime annotations. It should be restricted to:
+
+```python
+TypeParamIdentity = TypeVarLike | ast.AST
+```
+
+Use a `TypeVarLike` identity when there is a runtime `TypeVar`, `ParamSpec`, or
+`TypeVarTuple` object. Use an AST identity when pycroscope synthesized the type
+parameter while analyzing unimportable code and no runtime object exists. Avoid
+using arbitrary `object` identities; every identity should be explainable as
+either the runtime object or the syntax node that declares the parameter.
+Avoid manually creating `TypeVarLike` objects at type checking time.
+
+## Proposed Model
+
+`ActiveTypeParams` should be an explicit stack of nested type-parameter scopes.
+Each scope owns the type parameters declared by one definition, plus the small
+amount of state needed to validate references to those parameters while visiting
+annotations.
+
+```python
+@dataclass
+class TypeParamScope:
+    owner: TypeParamOwner | None
+    bindings: dict[TypeParamIdentity, TypeParam]
+    disallowed: set[TypeParamIdentity]
+```
+
+### `owner`
+
+The owner for type parameters declared directly in this scope. It is `None` only
+for helper scopes that do not declare parameters, such as a temporary annotation
+validation scope.
+
+This replaces caller-side owner reconstruction. Code that visits a PEP 695
+`TypeVar` node should ask `ActiveTypeParams` for the current declaration owner
+instead of duplicating class/function/alias owner logic in `NameCheckVisitor`.
+
+### `bindings`
+
+Maps every known identity for a type parameter to its canonical `TypeParam`.
+Usually this contains one identity: `type_param.typevar`. During import-failure
+or synthetic-class handling, the same canonical parameter may also need an AST
+identity or a pre-rebinding runtime identity. Those aliases should be recorded in
+this mapping instead of passed around as parallel `additional_identities` lists.
+
+The important invariant is that lookup returns the already owner-bound canonical
+parameter. Callers should not need to call `with_type_param_owner()` after a
+parameter has entered a scope.
+
+### `disallowed`
+
+A set of identities that are lexically visible but invalid in the current
+annotation context. This is for rules such as "an outer class type parameter is
+not valid in this nested alias annotation" or other contexts where normal name
+resolution can find a type parameter but the typing spec does not permit using
+it there.
+
+This should stay as scope state because it is about validity of a reference at a
+particular point in the syntax, not about the parameter's owner or canonical
+identity.
+
+## Why There Is No `kind` Field
+
+The scope does not need a `kind` field if callers provide the owner explicitly
+when entering the definition. A field such as `"class"`, `"function"`, or
+`"alias"` would duplicate information that is already represented by the owner
+type (`ClassOwner` or runtime class, `FunctionOwner`, `AliasOwner`).
+
+If a future rule truly depends on the syntactic kind of a scope instead of the
+owner, that should be modeled as a narrow field for that rule. It should not be
+part of the core owner-binding abstraction.
+
+## Binding API
+
+The main operations should be:
+
+```python
+def push_scope(owner: TypeParamOwner | None = None) -> AbstractContextManager[None]:
+    ...
+
+def declare(type_param: TypeParam, aliases: Iterable[TypeParamIdentity] = ()) -> TypeParam:
+    ...
+
+def lookup(identity: TypeParamIdentity) -> TypeParam | None:
+    ...
+
+def bind_all(type_params: Sequence[TypeParam], owner: TypeParamOwner) -> TypeParamBindingResult:
+    ...
+```
+
+`declare()` should owner-bind the parameter using the current scope owner, record
+all aliases in `bindings`, and return the canonical parameter.
+
+`bind_all()` should replace `NameCheckVisitor._bind_type_param_owners()`. It
+should return:
+
+```python
+@dataclass(frozen=True)
+class TypeParamBindingResult:
+    type_params: tuple[TypeParam, ...]
+    substitutions: TypeVarMap
+    aliases: tuple[frozenset[TypeParamIdentity], ...]
+```
+
+### `type_params`
+
+The canonical, owner-bound parameters.
+
+### `substitutions`
+
+A map from the incoming unbound parameters to the canonical parameters. This is
+needed to rewrite bounds, constraints, defaults, function annotations, alias
+values, and class bases that mention the old parameter objects.
+
+### `aliases`
+
+For each canonical parameter, the identities that should also resolve to it.
+This replaces ad hoc dictionaries and parallel alias lists in class registration.
+
+## Responsibilities
+
+`type_params.py` should own:
+
+- Owner binding for classes, functions, aliases, and runtime generic objects.
+- Lookup from `TypeParamIdentity` to canonical `TypeParam`.
+- Alias identities created while rebinding synthetic or runtime parameters.
+- Validity checks for direct type-parameter use in annotation contexts.
+- Legacy TypeVar rejection state.
+
+`name_check_visitor.py` should still own:
+
+- Building the correct `TypeParamOwner` for a class, function, or alias node.
+- Deciding when to enter and exit scopes while visiting the AST.
+- Reporting errors through the existing visitor methods.
+
+Variance collection can remain in `type_params.py`, but it should be separated
+from owner-binding state. It is usage-analysis state, not identity or ownership
+state.
+
+## Migration Plan
+
+1. Add the typed identity alias and make all type-parameter lookup APIs accept
+   `TypeParamIdentity` instead of `object`.
+2. Make `TypeParamScope.bindings` the source of truth and remove the parallel
+   `_active_pep695_identities` and `_active_pep695_type_params` stacks.
+3. Move owner binding and type-parameter component rewriting from
+   `NameCheckVisitor` into a `bind_all()` helper in `type_params.py`.
+4. Replace `additional_identities` with explicit aliases passed to `declare()`
+   or returned by `bind_all()`.
+5. Once every construction path has an owner, make `owner` required on
+   `TypeVarParam`, `ParamSpecParam`, and `TypeVarTupleParam`, then include it in
+   equality and hashing.

--- a/docs/type_params.md
+++ b/docs/type_params.md
@@ -163,6 +163,5 @@ state.
    `NameCheckVisitor` into a `bind_all()` helper in `type_params.py`.
 4. Replace `additional_identities` with explicit aliases passed to `declare()`
    or returned by `bind_all()`.
-5. Once every construction path has an owner, make `owner` required on
-   `TypeVarParam`, `ParamSpecParam`, and `TypeVarTupleParam`, then include it in
-   equality and hashing.
+5. Once every construction path has an owner, include owners in equality and
+   hashing.

--- a/pycroscope/__init__.py
+++ b/pycroscope/__init__.py
@@ -38,6 +38,7 @@ from . import (
     tests,
     type_object,
     type_object_builder,
+    type_params,
     typeshed,
     typevar,
     value,
@@ -82,3 +83,4 @@ used(annotated_types)
 used(runtime)
 used(input_sig)
 used(relations)
+used(type_params)

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1191,9 +1191,20 @@ def _make_typevar_param_from_partial_call(
         )
     else:
         constraints = ()
+    if len(constraints) == 1:
+        _show_type_param_call_error(
+            ctx, "TypeVar must have at least two constraints", value=value
+        )
     if bound is not None and constraints:
         _show_type_param_call_error(
             ctx, "TypeVar cannot have both bound and constraints", value=value
+        )
+    if infer_variance and (covariant or contravariant):
+        _show_type_param_call_error(
+            ctx,
+            "TypeVar cannot combine infer_variance with explicit variance",
+            value=value,
+            node=ctx.get_error_node(),
         )
     if covariant and contravariant:
         _show_type_param_call_error(

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -100,9 +100,11 @@ from .signature import (
     Signature,
     SigParameter,
 )
+from .type_params import ActiveTypeParams
 from .value import (
     NO_RETURN_VALUE,
     UNINITIALIZED_VALUE,
+    AliasOwner,
     AnnotatedValue,
     AnnotationExpr,
     AnySource,
@@ -145,6 +147,7 @@ from .value import (
     TypeGuardExtension,
     TypeIsExtension,
     TypeParam,
+    TypeParamOwner,
     TypeVarLike,
     TypeVarMap,
     TypeVarParam,
@@ -200,6 +203,23 @@ def _is_valid_pep586_literal_value(value: object) -> bool:
     return isinstance(type(value), _ENUM_TYPE)
 
 
+def _alias_owner_from_runtime_alias(alias_object: object) -> AliasOwner:
+    module = safe_getattr(alias_object, "__module__", "typing") or "typing"
+    qualname = safe_getattr(
+        alias_object,
+        "__qualname__",
+        safe_getattr(alias_object, "__name__", "<type alias>"),
+    )
+    return AliasOwner(module, qualname, alias_object)
+
+
+def _evaluate_with_active_type_params(
+    evaluator: Callable[[], Value], type_params: Sequence[TypeParam], ctx: "Context"
+) -> Value:
+    with ctx.active_type_params.push_pep695_scope(type_params):
+        return evaluator()
+
+
 @runtime_checkable
 class AnnotationVisitor(ErrorContext, CanAssignContext, Protocol):
     def resolve_name(
@@ -237,6 +257,11 @@ class Context:
     _invalid_self_nodes: set[int] = field(default_factory=set, init=False)
     visitor: AnnotationVisitor | None = field(default=None, kw_only=True)
     can_assign_ctx: CanAssignContext | None = field(default=None, kw_only=True)
+    active_type_params: ActiveTypeParams = field(
+        default_factory=ActiveTypeParams, kw_only=True
+    )
+    new_type_param_owner: TypeParamOwner | None = field(default=None, kw_only=True)
+    """Fallback owner for freshly synthesized type parameters."""
 
     def suppress_errors(self) -> AbstractContextManager[None]:
         """Temporarily suppress all annotation-evaluation errors."""
@@ -804,7 +829,9 @@ def _type_from_runtime(val: Any, ctx: Context) -> Value:
         supertype = _type_from_runtime(val.__supertype__, ctx)
         return NewTypeValue(val.__name__, supertype, val)
     elif is_instance_of_typing_name(val, "ParamSpec"):
-        return InputSigValue(ParamSpecParam(val))
+        type_param = make_type_param(val, ctx=ctx)
+        assert isinstance(type_param, ParamSpecParam)
+        return InputSigValue(type_param)
     elif is_typevarlike(val):
         type_param = make_type_param(val, ctx=ctx)
         if isinstance(type_param, TypeVarParam):
@@ -826,10 +853,16 @@ def _type_from_runtime(val: Any, ctx: Context) -> Value:
                 final_value = _eval_forward_ref(val.__forward_arg__, ctx).to_value()
         return final_value
     elif is_instance_of_typing_name(val, "TypeAliasType"):
+        alias_owner = _alias_owner_from_runtime_alias(val)
+        type_params = tuple(
+            make_type_param(tv, ctx, owner=alias_owner) for tv in val.__type_params__
+        )
         alias = ctx.get_type_alias(
             val,
-            lambda: type_from_runtime(val.__value__, ctx=ctx),
-            lambda: tuple(make_type_param(tv, ctx) for tv in val.__type_params__),
+            lambda: _evaluate_with_active_type_params(
+                lambda: type_from_runtime(val.__value__, ctx=ctx), type_params, ctx
+            ),
+            lambda: type_params,
         )
         return TypeAliasValue(val.__name__, val.__module__, alias)
     elif val is Ellipsis:
@@ -887,54 +920,9 @@ def make_type_param_from_value(
         runtime_val = replace_fallback(value.runtime_value)
         if isinstance(runtime_val, TypedValue):
             if is_typing_name(runtime_val.typ, "TypeVar"):
-                name, default = _extract_common_type_param_args(value, ctx)
-                if name is None:
-                    return None
-                tv = typing.cast(
-                    TypeVarType,
-                    _synthetic_type_param_for_partial_call(
-                        value, name, lambda name: TypeVar(name)
-                    ),
-                )
-                if value.arguments["bound"] is NO_ARG_SENTINEL:
-                    bound = None
-                else:
-                    bound = type_from_value(value.arguments["bound"], ctx=ctx)
-                if (
-                    isinstance(value.arguments["constraints"], SequenceValue)
-                    and value.arguments["constraints"].members
-                ):
-                    constraints = [
-                        type_from_value(constraint, ctx=ctx)
-                        for constraint in (
-                            value.arguments["constraints"].get_member_sequence() or ()
-                        )
-                    ]
-                else:
-                    constraints = None
-                infer_variance = _extract_boolean_arg(value, "infer_variance")
-                covariant = _extract_boolean_arg(value, "covariant")
-                contravariant = _extract_boolean_arg(value, "contravariant")
-                if covariant is None or contravariant is None:
-                    return None
-                match (infer_variance, covariant, contravariant):
-                    case (True, _, _):
-                        variance = Variance.INFERRED
-                    case (_, True, _):
-                        variance = Variance.COVARIANT
-                    case (_, _, True):
-                        variance = Variance.CONTRAVARIANT
-                    case _:
-                        variance = Variance.INVARIANT
-                return TypeVarParam(
-                    tv,
-                    bound=bound,
-                    constraints=tuple(constraints) if constraints is not None else (),
-                    variance=variance,
-                    default=default,
-                )
+                return _make_typevar_param_from_partial_call(value, ctx)
             elif is_typing_name(runtime_val.typ, "ParamSpec"):
-                name, default = _extract_common_type_param_args(value, ctx)
+                name = _extract_type_param_name_arg(value)
                 if name is None:
                     return None
                 ps = typing.cast(
@@ -943,7 +931,17 @@ def make_type_param_from_value(
                         value, name, lambda name: ParamSpec(name)
                     ),
                 )
-                return ParamSpecParam(ps, default=default)
+                active_type_param = ctx.active_type_params.get_type_param(ps)
+                if active_type_param is not None:
+                    return active_type_param
+                default_val = value.arguments.get("default", NO_ARG_SENTINEL)
+                if default_val is NO_ARG_SENTINEL:
+                    default = None
+                else:
+                    default = _paramspec_default_from_value(default_val, ctx)
+                return ParamSpecParam(
+                    ps, owner=ctx.new_type_param_owner, default=default
+                )
             elif is_typing_name(runtime_val.typ, "TypeVarTuple"):
                 name, default = _extract_common_type_param_args(value, ctx)
                 if name is None:
@@ -954,7 +952,12 @@ def make_type_param_from_value(
                         value, name, lambda name: typing_extensions.TypeVarTuple(name)
                     ),
                 )
-                return TypeVarTupleParam(tvt, default=default)
+                active_type_param = ctx.active_type_params.get_type_param(tvt)
+                if active_type_param is not None:
+                    return active_type_param
+                return TypeVarTupleParam(
+                    tvt, owner=ctx.new_type_param_owner, default=default
+                )
     typevartuple_param = get_single_typevartuple_param(value)
     if typevartuple_param is not None:
         return typevartuple_param
@@ -990,17 +993,263 @@ def _synthetic_type_param_for_partial_call(
 def _extract_common_type_param_args(
     pcv: PartialCallValue, ctx: Context
 ) -> tuple[str | None, Value | None]:
-    name_val = pcv.arguments["name"]
-    if isinstance(name_val, KnownValue) and isinstance(name_val.val, str):
-        name = name_val.val
-    else:
-        name = None
+    name = _extract_type_param_name_arg(pcv)
     default_val = pcv.arguments.get("default", NO_ARG_SENTINEL)
     if default_val is NO_ARG_SENTINEL:
         default = None
     else:
-        default = type_from_value(default_val, ctx=ctx)
+        default = _type_param_default_from_value(default_val, pcv, ctx)
     return name, default
+
+
+def _extract_type_param_name_arg(pcv: PartialCallValue) -> str | None:
+    name_val = pcv.arguments["name"]
+    if isinstance(name_val, KnownValue) and isinstance(name_val.val, str):
+        return name_val.val
+    return None
+
+
+def _typevar_component_from_value(value: Value, ctx: Context) -> Value:
+    allow_undefined_names = isinstance(value, KnownValue) and isinstance(value.val, str)
+    typed = type_from_value(
+        value,
+        ctx=ctx,
+        allow_undefined_names=allow_undefined_names,
+        suppress_errors=True,
+    )
+    if isinstance(typed, AnyValue) and typed.source is AnySource.error:
+        ctx.show_error(
+            f"Invalid type annotation {value}",
+            error_code=ErrorCode.invalid_annotation,
+            node=ctx.get_error_node(),
+        )
+        return typed
+    if _value_contains_type_params(value, ctx) or any(iter_type_params_in_value(typed)):
+        ctx.show_error(
+            "TypeVar bounds and constraints cannot contain type parameters",
+            error_code=ErrorCode.invalid_annotation,
+            node=getattr(value, "node", ctx.get_error_node()),
+        )
+        return AnyValue(AnySource.error)
+    return typed
+
+
+def _type_param_default_from_value(
+    value: Value, partial: PartialCallValue, ctx: Context
+) -> Value:
+    allow_undefined_names = isinstance(value, KnownValue) and isinstance(value.val, str)
+    typed = type_from_value(
+        value,
+        ctx=ctx,
+        allow_undefined_names=allow_undefined_names,
+        suppress_errors=True,
+    )
+    if isinstance(typed, AnyValue) and typed.source is AnySource.error:
+        ctx.show_error(
+            f"Invalid type parameter default {value}",
+            error_code=ErrorCode.incompatible_argument,
+            node=partial.node,
+        )
+    return typed
+
+
+def _value_contains_type_params(value: Value, ctx: Context) -> bool:
+    for subval in value.walk_values():
+        if make_type_param_from_value(subval, ctx=ctx) is not None:
+            return True
+    return False
+
+
+def _paramspec_default_from_value(value: Value, ctx: Context) -> Value:
+    value = replace_known_sequence_value(value)
+    if value == KnownValue(Ellipsis):
+        return value
+    if isinstance(value, SequenceValue) and value.typ in (list, tuple):
+        members = value.get_member_sequence()
+        if members is None:
+            return value
+        return SequenceValue(
+            value.typ, [(False, type_from_value(member, ctx=ctx)) for member in members]
+        )
+    return type_from_value(value, ctx=ctx)
+
+
+def _show_type_param_call_error(
+    ctx: Context, message: str, *, value: PartialCallValue, node: ast.AST | None = None
+) -> None:
+    ctx.show_error(
+        message,
+        error_code=ErrorCode.incompatible_call,
+        node=node if node is not None else value.node,
+    )
+
+
+def _is_assignable_type_param_component(
+    expected: Value, actual: Value, ctx: Context
+) -> bool:
+    can_assign_ctx = _get_can_assign_context(ctx)
+    if can_assign_ctx is None:
+        return True
+    return not isinstance(
+        has_relation(expected, actual, Relation.ASSIGNABLE, can_assign_ctx),
+        CanAssignError,
+    )
+
+
+def _default_matches_typevar_constraint(
+    constraint: Value, default: Value, ctx: Context
+) -> bool:
+    if constraint == default:
+        return True
+    if isinstance(constraint, TypedValue) and isinstance(default, TypedValue):
+        return constraint.typ == default.typ
+    if isinstance(constraint, KnownValue) and isinstance(default, KnownValue):
+        return constraint.val == default.val
+    return False
+
+
+def _validate_partial_typevar_defaults(
+    type_param: TypeVarParam, value: PartialCallValue, ctx: Context
+) -> None:
+    default = type_param.default
+    if default is None:
+        return
+    if type_param.bound is not None and not _is_assignable_type_param_component(
+        type_param.bound, default, ctx
+    ):
+        _show_type_param_call_error(
+            ctx,
+            "TypeVar default must be assignable to its bound",
+            value=value,
+            node=ctx.get_error_node(),
+        )
+        return
+    if not type_param.constraints:
+        return
+    if isinstance(default, TypeVarValue) and default.typevar_param.constraints:
+        default_constraints = default.typevar_param.constraints
+        if all(
+            any(
+                _default_matches_typevar_constraint(constraint, default_constraint, ctx)
+                for constraint in type_param.constraints
+            )
+            for default_constraint in default_constraints
+        ):
+            return
+    elif any(
+        _default_matches_typevar_constraint(constraint, default, ctx)
+        for constraint in type_param.constraints
+    ):
+        return
+    _show_type_param_call_error(
+        ctx,
+        "TypeVar default must be one of its constraints",
+        value=value,
+        node=ctx.get_error_node(),
+    )
+
+
+def _make_typevar_param_from_partial_call(
+    value: PartialCallValue, ctx: Context
+) -> TypeVarParam | None:
+    name, default = _extract_common_type_param_args(value, ctx)
+    if name is None:
+        return None
+    infer_variance = _extract_boolean_arg(value, "infer_variance")
+    covariant = _extract_boolean_arg(value, "covariant")
+    contravariant = _extract_boolean_arg(value, "contravariant")
+    if covariant is None or contravariant is None:
+        return None
+    tv = typing.cast(
+        TypeVarType,
+        _synthetic_type_param_for_partial_call(
+            value,
+            name,
+            lambda name: _make_synthetic_partial_typevar(
+                name,
+                covariant=covariant,
+                contravariant=contravariant,
+                infer_variance=bool(infer_variance),
+            ),
+        ),
+    )
+    active_type_param = ctx.active_type_params.get_type_param(tv)
+    if active_type_param is not None:
+        assert isinstance(active_type_param, TypeVarParam)
+        return active_type_param
+    if value.arguments["bound"] is NO_ARG_SENTINEL:
+        bound = None
+    else:
+        bound = _typevar_component_from_value(value.arguments["bound"], ctx)
+    if (
+        isinstance(value.arguments["constraints"], SequenceValue)
+        and value.arguments["constraints"].members
+    ):
+        constraints = tuple(
+            _typevar_component_from_value(constraint, ctx)
+            for constraint in value.arguments["constraints"].get_member_sequence() or ()
+        )
+    else:
+        constraints = ()
+    if bound is not None and constraints:
+        _show_type_param_call_error(
+            ctx, "TypeVar cannot have both bound and constraints", value=value
+        )
+    if covariant and contravariant:
+        _show_type_param_call_error(
+            ctx,
+            "Bivariant types are not supported",
+            value=value,
+            node=ctx.get_error_node(),
+        )
+    match (infer_variance, covariant, contravariant):
+        case (True, _, _):
+            variance = Variance.INFERRED
+        case (_, True, _):
+            variance = Variance.COVARIANT
+        case (_, _, True):
+            variance = Variance.CONTRAVARIANT
+        case _:
+            variance = Variance.INVARIANT
+    type_param = TypeVarParam(
+        tv,
+        owner=ctx.new_type_param_owner,
+        bound=bound,
+        constraints=constraints,
+        variance=variance,
+        default=default,
+    )
+    _validate_partial_typevar_defaults(type_param, value, ctx)
+    return type_param
+
+
+def _make_partial_type_param_call(
+    *, callee: Value, runtime_value: Value, arguments: dict[str, Value], node: ast.AST
+) -> PartialCallValue:
+    return PartialCallValue(
+        callee=callee, arguments=arguments, runtime_value=runtime_value, node=node
+    )
+
+
+def _make_synthetic_partial_typevar(
+    name: str, *, covariant: bool, contravariant: bool, infer_variance: bool
+) -> TypeVarType:
+    try:
+        if infer_variance:
+            return typing.cast(
+                TypeVarType,
+                typing_extensions.TypeVar(
+                    name,
+                    covariant=covariant,
+                    contravariant=contravariant,
+                    infer_variance=True,
+                ),
+            )
+        return typing.cast(
+            TypeVarType, TypeVar(name, covariant=covariant, contravariant=contravariant)
+        )
+    except Exception:
+        return typing.cast(TypeVarType, TypeVar(name))
 
 
 def _type_param_component_from_runtime(val: object, ctx: Context) -> Value:
@@ -1041,10 +1290,16 @@ def make_type_param(
     *,
     visitor: "pycroscope.name_check_visitor.NameCheckVisitor | None" = None,
     node: ast.AST | None = None,
+    owner: TypeParamOwner | None = None,
 ) -> TypeParam:
     if ctx is None:
         assert visitor is not None, "visitor must be provided if ctx is not"
         ctx = _DefaultContext(visitor=visitor, node=node)
+    if owner is None:
+        active_type_param = ctx.active_type_params.get_type_param(tv)
+        if active_type_param is not None:
+            return active_type_param
+        owner = ctx.new_type_param_owner
     runtime_default = getattr(tv, "__default__", NoDefault)
     if runtime_default is not NoDefault:
         default = _type_param_component_from_runtime(runtime_default, ctx)
@@ -1063,16 +1318,38 @@ def make_type_param(
             constraints = ()
         return TypeVarParam(
             tv,
+            owner=owner,
             bound=bound,
             constraints=constraints,
             default=default,
             variance=get_typevar_variance(tv),
         )
     if is_instance_of_typing_name(tv, "ParamSpec"):
-        return ParamSpecParam(tv, default=default)
+        return ParamSpecParam(tv, owner=owner, default=default)
     if is_instance_of_typing_name(tv, "TypeVarTuple"):
-        return TypeVarTupleParam(tv, default=default)
+        return TypeVarTupleParam(tv, owner=owner, default=default)
     raise TypeError(f"Unsupported type parameter: {tv!r}")
+
+
+def add_runtime_type_param_scope(
+    ctx: Context, scope_object: object, owner: TypeParamOwner
+) -> tuple[TypeParam, ...]:
+    runtime_type_params = safe_getattr(scope_object, "__type_params__", ())
+    if not runtime_type_params:
+        runtime_type_params = safe_getattr(scope_object, "__parameters__", ())
+    try:
+        runtime_type_params_iter = iter(runtime_type_params)
+    except TypeError:
+        return ()
+    type_params: list[TypeParam] = []
+    for type_param in runtime_type_params_iter:
+        try:
+            type_params.append(make_type_param(type_param, ctx=ctx, owner=owner))
+        except TypeError:
+            continue
+    result = tuple(type_params)
+    ctx.active_type_params.add_pep695_scope(result)
+    return result
 
 
 def _get_can_assign_context(ctx: Context) -> CanAssignContext | None:
@@ -1122,7 +1399,9 @@ def _get_generic_type_parameters_for_annotation(
 ) -> Sequence[TypeParam]:
     runtime_type_params = getattr(typ, "__parameters__", ())
     if isinstance(runtime_type_params, tuple) and runtime_type_params:
-        return tuple(make_type_param(tp, ctx=ctx) for tp in runtime_type_params)
+        return tuple(
+            make_type_param(tp, ctx=ctx, owner=typ) for tp in runtime_type_params
+        )
     can_assign_ctx = _get_can_assign_context(ctx)
     if can_assign_ctx is None:
         return ()
@@ -1187,7 +1466,10 @@ def _runtime_type_alias_from_runtime_value(
         type_params = inferred_type_params
     else:
         type_params = tuple(
-            make_type_param(param, ctx=ctx) for param in runtime_type_params
+            make_type_param(
+                param, ctx=ctx, owner=origin if isinstance(origin, type) else None
+            )
+            for param in runtime_type_params
         )
     return _make_runtime_type_alias_value(
         alias_value,
@@ -1216,18 +1498,34 @@ def _is_paramspec_annotation(value: Value) -> bool:
     )
 
 
+def _is_paramspec_component_annotation(value: Value) -> bool:
+    return (
+        isinstance(value, (ParamSpecArgsValue, ParamSpecKwargsValue))
+        or isinstance(value, TypedValue)
+        and (
+            is_typing_name(value.typ, "ParamSpecArgs")
+            or is_typing_name(value.typ, "ParamSpecKwargs")
+        )
+    )
+
+
 def has_invalid_paramspec_usage(
     value: Value, can_assign_ctx: CanAssignContext | None
 ) -> bool:
     if _is_paramspec_annotation(value):
         return True
-    if isinstance(value, (ParamSpecArgsValue, ParamSpecKwargsValue)):
+    if _is_paramspec_component_annotation(value):
         return True
     if isinstance(value, AnnotatedValue):
         return has_invalid_paramspec_usage(value.value, can_assign_ctx)
     if isinstance(value, MultiValuedValue):
         return any(
             has_invalid_paramspec_usage(subval, can_assign_ctx) for subval in value.vals
+        )
+    if isinstance(value, SequenceValue):
+        return any(
+            has_invalid_paramspec_usage(member, can_assign_ctx)
+            for _is_many, member in value.members
         )
     if isinstance(value, TypeAliasValue):
         alias_type_params = tuple(value.alias.get_type_params())
@@ -1300,6 +1598,14 @@ def _type_from_value_type_alias_arg(
         concatenate_value = _maybe_paramspec_concatenate_value(arg, ctx)
         if concatenate_value is not None:
             return concatenate_value
+        if isinstance(arg, KnownValue) and isinstance(arg.val, tuple):
+            return SequenceValue(
+                tuple, [(False, _type_from_runtime(member, ctx)) for member in arg.val]
+            )
+        if isinstance(arg, KnownValue) and isinstance(arg.val, list):
+            return SequenceValue(
+                list, [(False, _type_from_runtime(member, ctx)) for member in arg.val]
+            )
         if isinstance(arg, SequenceValue) and arg.typ in (list, tuple):
             members = arg.get_member_sequence()
             if members is not None:
@@ -1387,8 +1693,13 @@ def _normalize_paramspec_generic_arg_in_context(
         return AnyValue(AnySource.ellipsis_callable)
     if isinstance(arg, AnyValue):
         return arg
+    type_param = make_type_param_from_value(arg, ctx=ctx)
+    if isinstance(type_param, ParamSpecParam):
+        return InputSigValue(type_param)
     if isinstance(arg, KnownValue) and is_instance_of_typing_name(arg.val, "ParamSpec"):
-        return InputSigValue(ParamSpecParam(arg.val))
+        type_param = make_type_param(arg.val, ctx=ctx)
+        assert isinstance(type_param, ParamSpecParam)
+        return InputSigValue(type_param)
     if allow_flat_form:
         return SequenceValue(tuple, [(False, arg)])
     ctx.show_error(
@@ -1864,7 +2175,9 @@ def _callable_args_from_runtime(
             normalized_args.append((False, _type_from_runtime(arg, ctx)))
         return _callable_params_from_normalized_args(normalized_args)
     elif is_instance_of_typing_name(arg_types, "ParamSpec"):
-        param_spec = InputSigValue(ParamSpecParam(arg_types))
+        type_param = make_type_param(arg_types, ctx=ctx)
+        assert isinstance(type_param, ParamSpecParam)
+        param_spec = InputSigValue(type_param)
         param = SigParameter(
             "__P", kind=ParameterKind.PARAM_SPEC, annotation=param_spec
         )
@@ -1967,6 +2280,8 @@ def _is_self_annotation_value(value: Value) -> bool:
 def _type_from_value(value: Value, ctx: Context) -> Value:
     if isinstance(value, KnownValue):
         return _type_from_runtime(value.val, ctx)
+    elif _is_paramspec_component_annotation(value):
+        return value
     elif isinstance(value, TypedDictValue):
         return value
     elif isinstance(value, SyntheticClassObjectValue):
@@ -2007,7 +2322,7 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
         return AnyValue(AnySource.error)
     elif isinstance(value, AnyValue):
         return value
-    elif isinstance(value, InputSigValue):
+    elif isinstance(value, (InputSigValue, ParamSpecArgsValue, ParamSpecKwargsValue)):
         return value
     else:
         ctx.show_error(f"Unrecognized annotation {value}")
@@ -2207,7 +2522,10 @@ def _type_from_subscripted_value(
             and len(root_type_params) == 1
             and isinstance(root_type_params[0], ParamSpecParam)
         ):
-            typed_members = [_type_from_value(member, ctx) for member in members]
+            typed_members = [
+                _type_from_value_type_alias_arg(member, root_type_params[0], ctx)
+                for member in members
+            ]
             typed_members = _normalize_paramspec_generic_args(
                 root_type_params, typed_members, ctx
             )
@@ -2352,8 +2670,11 @@ def _type_from_subscripted_value(
     root = root.val
     if is_instance_of_typing_name(root, "TypeAliasType"):
         alias_object = root
-        runtime_type_params = tuple(alias_object.__type_params__)
-        type_params = tuple(make_type_param(tp, ctx=ctx) for tp in runtime_type_params)
+        alias_owner = _alias_owner_from_runtime_alias(alias_object)
+        type_params = tuple(
+            make_type_param(tp, ctx=ctx, owner=alias_owner)
+            for tp in alias_object.__type_params__
+        )
         type_arguments_are_packed = False
         if (
             not members
@@ -2372,10 +2693,12 @@ def _type_from_subscripted_value(
         args_vals = _validate_type_alias_arg_values(type_params, args_vals, ctx)
         alias = ctx.get_type_alias(
             root,
-            lambda: type_from_runtime(alias_object.__value__, ctx=ctx),
-            lambda: tuple(
-                make_type_param(tv, ctx) for tv in alias_object.__type_params__
+            lambda: _evaluate_with_active_type_params(
+                lambda: type_from_runtime(alias_object.__value__, ctx=ctx),
+                type_params,
+                ctx,
             ),
+            lambda: type_params,
         )
         return TypeAliasValue(
             alias_object.__name__,
@@ -2527,7 +2850,11 @@ def _type_from_subscripted_value(
                     is_typevarlike(type_param) for type_param in runtime_type_params
                 ):
                     typed_runtime_type_params = tuple(
-                        make_type_param(type_param, ctx)
+                        make_type_param(
+                            type_param,
+                            ctx,
+                            owner=origin if isinstance(origin, type) else None,
+                        )
                         for type_param in runtime_type_params
                     )
 
@@ -2705,7 +3032,14 @@ class _DefaultContext(Context):
         else:
             base_visitor = None
         super().__init__(
-            can_assign_ctx=visitor, visitor=base_visitor, self_key=self_key
+            can_assign_ctx=visitor,
+            visitor=base_visitor,
+            self_key=self_key,
+            active_type_params=(
+                base_visitor.active_type_params
+                if base_visitor is not None
+                else ActiveTypeParams()
+            ),
         )
         self.node = node
         self.globals = globals
@@ -2819,6 +3153,10 @@ class _DefaultContext(Context):
 class RuntimeAnnotationsContext(Context):
     owner: object
     node: ast.AST | None = None
+
+    def __post_init__(self) -> None:
+        if self.new_type_param_owner is not None:
+            add_runtime_type_param_scope(self, self.owner, self.new_type_param_owner)
 
     def show_error(
         self,
@@ -3003,21 +3341,8 @@ class _Visitor(ast.NodeVisitor):
             if not isinstance(name_val, KnownValue):
                 self.ctx.show_error("TypeVar name must be a literal", node=node.args[0])
                 return AnyValue(AnySource.error)
-
-            def _typevar_arg_to_type(arg_value: Value) -> Value:
-                # String bounds/constraints may contain forward refs to names that
-                # are defined later in the file.
-                allow_undefined_names = isinstance(
-                    arg_value, KnownValue
-                ) and isinstance(arg_value.val, str)
-                return type_from_value(
-                    arg_value, ctx=self.ctx, allow_undefined_names=allow_undefined_names
-                )
-
-            constraints = []
-            for arg_value in arg_values[1:]:
-                constraints.append(_typevar_arg_to_type(arg_value))
-            bound = default = None
+            constraints = list(arg_values[1:])
+            bound = default = NO_ARG_SENTINEL
             covariant = False
             contravariant = False
             infer_variance = False
@@ -3037,40 +3362,30 @@ class _Visitor(ast.NodeVisitor):
                     elif name == "infer_variance":
                         infer_variance = kwarg_value.val
                 elif name == "bound":
-                    bound = _typevar_arg_to_type(kwarg_value)
+                    bound = kwarg_value
                 elif name == "default":
-                    default = _typevar_arg_to_type(kwarg_value)
+                    default = kwarg_value
                 else:
                     self.ctx.show_error(f"Unrecognized TypeVar kwarg {name}", node=node)
                     return AnyValue(AnySource.error)
-            try:
-                kwargs = {"covariant": covariant, "contravariant": contravariant}
-                if infer_variance:
-                    kwargs_with_infer = {**kwargs, "infer_variance": True}
-                    tv = typing.cast(
-                        TypeVarType,
-                        typing_extensions.TypeVar(name_val.val, **kwargs_with_infer),
-                    )
-                else:
-                    tv = typing.cast(TypeVarType, TypeVar(name_val.val, **kwargs))
-            except Exception as e:
-                self.ctx.show_error(str(e), node=node)
-                return AnyValue(AnySource.error)
-            if covariant:
-                variance = Variance.COVARIANT
-            elif contravariant:
-                variance = Variance.CONTRAVARIANT
-            else:
-                variance = Variance.INVARIANT
-            return TypeVarValue(
-                TypeVarParam(
-                    tv,
-                    bound=bound,
-                    constraints=tuple(constraints),
-                    default=default,
-                    variance=variance,
-                )
+            partial = _make_partial_type_param_call(
+                callee=func,
+                runtime_value=TypedValue(func.val),
+                arguments={
+                    "name": name_val,
+                    "constraints": SequenceValue(
+                        tuple, [(False, constraint) for constraint in constraints]
+                    ),
+                    "bound": bound,
+                    "covariant": KnownValue(covariant),
+                    "contravariant": KnownValue(contravariant),
+                    "infer_variance": KnownValue(infer_variance),
+                    "default": default,
+                },
+                node=node,
             )
+            make_type_param_from_value(partial, ctx=self.ctx)
+            return partial
         elif is_typing_name(func.val, "ParamSpec"):
             arg_values = [self.visit(arg) for arg in node.args]
             kwarg_values = [(kw.arg, self.visit(kw.value)) for kw in node.keywords]
@@ -3085,12 +3400,52 @@ class _Visitor(ast.NodeVisitor):
                     "ParamSpec name must be a literal", node=node.args[0]
                 )
                 return AnyValue(AnySource.error)
-            for name, _ in kwarg_values:
-                # TODO support defaults
+            default = NO_ARG_SENTINEL
+            for name, kwarg_value in kwarg_values:
+                if name == "default":
+                    default = kwarg_value
+                    continue
                 self.ctx.show_error(f"Unrecognized ParamSpec kwarg {name}", node=node)
                 return AnyValue(AnySource.error)
-            tv = ParamSpec(name_val.val)
-            return InputSigValue(ParamSpecParam(tv))
+            partial = _make_partial_type_param_call(
+                callee=func,
+                runtime_value=TypedValue(func.val),
+                arguments={"name": name_val, "default": default},
+                node=node,
+            )
+            make_type_param_from_value(partial, ctx=self.ctx)
+            return partial
+        elif is_typing_name(func.val, "TypeVarTuple"):
+            arg_values = [self.visit(arg) for arg in node.args]
+            kwarg_values = [(kw.arg, self.visit(kw.value)) for kw in node.keywords]
+            if not arg_values:
+                self.ctx.show_error(
+                    "TypeVarTuple() requires at least one argument", node=node
+                )
+                return AnyValue(AnySource.error)
+            name_val = arg_values[0]
+            if not isinstance(name_val, KnownValue):
+                self.ctx.show_error(
+                    "TypeVarTuple name must be a literal", node=node.args[0]
+                )
+                return AnyValue(AnySource.error)
+            default = NO_ARG_SENTINEL
+            for name, kwarg_value in kwarg_values:
+                if name == "default":
+                    default = kwarg_value
+                    continue
+                self.ctx.show_error(
+                    f"Unrecognized TypeVarTuple kwarg {name}", node=node
+                )
+                return AnyValue(AnySource.error)
+            partial = _make_partial_type_param_call(
+                callee=func,
+                runtime_value=TypedValue(func.val),
+                arguments={"name": name_val, "default": default},
+                node=node,
+            )
+            make_type_param_from_value(partial, ctx=self.ctx)
+            return partial
         elif is_typing_name(func.val, "deprecated") or func.val is deprecated:
             if node.keywords:
                 self.ctx.show_error(
@@ -3278,8 +3633,9 @@ def _value_of_origin_args(
         return TypeFormValue(_type_from_runtime(args[0], ctx))
     elif is_instance_of_typing_name(origin, "TypeAliasType"):
         alias_object = origin
+        alias_owner = _alias_owner_from_runtime_alias(alias_object)
         type_params = tuple(
-            make_type_param(type_param, ctx)
+            make_type_param(type_param, ctx, owner=alias_owner)
             for type_param in alias_object.__type_params__
         )
         if len(args) == len(type_params):
@@ -3292,11 +3648,12 @@ def _value_of_origin_args(
         args_vals = _validate_type_alias_arg_values(type_params, args_vals, ctx)
         alias = ctx.get_type_alias(
             val,
-            lambda: type_from_runtime(alias_object.__value__, ctx=ctx),
-            lambda: tuple(
-                make_type_param(type_param, ctx)
-                for type_param in alias_object.__type_params__
+            lambda: _evaluate_with_active_type_params(
+                lambda: type_from_runtime(alias_object.__value__, ctx=ctx),
+                type_params,
+                ctx,
             ),
+            lambda: type_params,
         )
         return TypeAliasValue(
             alias_object.__name__, alias_object.__module__, alias, tuple(args_vals)
@@ -3364,6 +3721,8 @@ def _make_callable_from_value(
     return_annotation = _type_from_value(return_value, ctx)
     if isinstance(args, KnownValue):
         args = replace_known_sequence_value(args)
+    if isinstance(args, PartialCallValue):
+        args = _type_from_value(args, ctx)
     if args == KnownValue(Ellipsis):
         return CallableValue(
             Signature.make(
@@ -3423,7 +3782,9 @@ def _make_callable_from_value(
     elif isinstance(args, KnownValue) and is_instance_of_typing_name(
         args.val, "ParamSpec"
     ):
-        annotation = InputSigValue(ParamSpecParam(args.val))
+        type_param = make_type_param(args.val, ctx=ctx)
+        assert isinstance(type_param, ParamSpecParam)
+        annotation = InputSigValue(type_param)
         params = [
             SigParameter("__P", kind=ParameterKind.PARAM_SPEC, annotation=annotation)
         ]

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -2097,8 +2097,22 @@ def _paramspec_value_from_concatenate_members(
 def _callable_params_from_normalized_args(
     normalized_args: Sequence[tuple[bool, Value]],
 ) -> list[SigParameter]:
+    def normalize_many_annotation(annotation: Value) -> Value:
+        if (
+            isinstance(annotation, TypeVarTupleBindingValue)
+            and len(annotation.binding) == 1
+            and annotation.binding[0][0]
+            and isinstance(annotation.binding[0][1], TypeVarTupleValue)
+        ):
+            return annotation.binding[0][1]
+        return annotation
+
     if any(is_many for is_many, _ in normalized_args) and all(
-        isinstance(annotation, TypeVarTupleValue) if is_many else True
+        (
+            isinstance(normalize_many_annotation(annotation), TypeVarTupleValue)
+            if is_many
+            else True
+        )
         for is_many, annotation in normalized_args
     ):
         return [
@@ -2106,10 +2120,10 @@ def _callable_params_from_normalized_args(
                 f"@{i}",
                 kind=(
                     ParameterKind.PARAM_SPEC
-                    if isinstance(annotation, InputSigValue)
+                    if isinstance(normalize_many_annotation(annotation), InputSigValue)
                     else ParameterKind.POSITIONAL_ONLY
                 ),
-                annotation=annotation,
+                annotation=normalize_many_annotation(annotation),
             )
             for i, (_is_many, annotation) in enumerate(normalized_args)
         ]
@@ -2312,6 +2326,9 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
         return value.get_fallback_value()
     elif isinstance(value, PartialCallValue):
         type_param = make_type_param_from_value(value, ctx=ctx)
+        if type_param is None:
+            ctx.show_error(f"Unrecognized annotation {value}")
+            return AnyValue(AnySource.error)
         if isinstance(type_param, TypeVarParam):
             return TypeVarValue(type_param)
         if isinstance(type_param, TypeVarTupleParam):

--- a/pycroscope/arg_spec.py
+++ b/pycroscope/arg_spec.py
@@ -28,6 +28,7 @@ from .analysis_lib import is_positional_only_arg_name, override
 from .annotations import (
     Context,
     RuntimeEvaluator,
+    add_runtime_type_param_scope,
     annotation_expr_from_runtime,
     make_type_param,
     type_from_runtime,
@@ -67,6 +68,7 @@ from .signature import (
     make_bound_method,
 )
 from .stacked_scopes import Composite, uniq_chain
+from .type_params import ActiveTypeParams
 from .typeshed import TypeshedFinder
 from .value import (
     UNINITIALIZED_VALUE,
@@ -77,6 +79,7 @@ from .value import (
     ClassKey,
     ClassOwner,
     Extension,
+    FunctionOwner,
     GenericBases,
     GenericValue,
     KnownValue,
@@ -107,6 +110,7 @@ from .value import (
     iter_type_params_in_value,
     make_coro_type,
     type_param_to_value,
+    with_type_param_owner,
 )
 
 _GET_OVERLOADS = []
@@ -245,19 +249,28 @@ def _get_callable_owner(callable_obj: object | None) -> type | None:
     if not isinstance(callable_obj, FunctionType):
         return None
     module = inspect.getmodule(callable_obj)
-    if module is None:
-        return None
     qualname_parts = callable_obj.__qualname__.split(".")
     if len(qualname_parts) < 2:
         return None
-    owner: object = module
+    if module is None:
+        globals_dict = safe_getattr(callable_obj, "__globals__", None)
+        if not isinstance(globals_dict, Mapping):
+            return None
+        owner: object = globals_dict
+    else:
+        owner = module
     for part in qualname_parts[:-1]:
         if part == "<locals>":
             return None
-        try:
-            owner = getattr(owner, part)
-        except AttributeError:
-            return None
+        if isinstance(owner, Mapping):
+            owner = owner.get(part)
+            if owner is None:
+                return None
+        else:
+            try:
+                owner = getattr(owner, part)
+            except AttributeError:
+                return None
     try:
         member = inspect.getattr_static(owner, qualname_parts[-1])
     except AttributeError:
@@ -275,7 +288,33 @@ def _make_annotations_context(
 ) -> AnnotationsContext:
     if owner is None:
         owner = _get_callable_owner(callable_obj)
-    return AnnotationsContext(globals=globals, self_key=owner)
+    active_type_params = ActiveTypeParams()
+    ctx = AnnotationsContext(
+        globals=globals, self_key=owner, active_type_params=active_type_params
+    )
+    if owner is not None:
+        add_runtime_type_param_scope(ctx, owner, owner)
+    function_owner = _function_owner_from_callable(callable_obj)
+    if function_owner is not None:
+        add_runtime_type_param_scope(
+            ctx, safe_getattr(callable_obj, "__func__", callable_obj), function_owner
+        )
+    return ctx
+
+
+def _function_owner_from_callable(callable_obj: object | None) -> FunctionOwner | None:
+    if callable_obj is None:
+        return None
+    function_object = safe_getattr(callable_obj, "__func__", callable_obj)
+    if not isinstance(function_object, FunctionType):
+        return None
+    module = safe_getattr(function_object, "__module__", "<unknown>") or "<unknown>"
+    qualname = safe_getattr(
+        function_object,
+        "__qualname__",
+        safe_getattr(function_object, "__name__", "<function>"),
+    )
+    return FunctionOwner(module, qualname, function_object)
 
 
 class IgnoredCallees(PyObjectSequenceOption[object]):
@@ -687,7 +726,12 @@ class ArgSpecCache:
             and seen_paramspec_args.param_spec is typ.param_spec
         ):
             kind = ParameterKind.PARAM_SPEC
-            typ = InputSigValue(ParamSpecParam(typ.param_spec))
+            ctx = _make_annotations_context(
+                func_globals, function_object, owner=owner_for_self
+            )
+            type_param = make_type_param(typ.param_spec, ctx=ctx)
+            assert isinstance(type_param, ParamSpecParam)
+            typ = InputSigValue(type_param)
         return (
             SigParameter(parameter.name, kind, default=default, annotation=typ),
             make_everything_pos_only,
@@ -1228,7 +1272,7 @@ class ArgSpecCache:
         for field in fields:
             annotation = type_from_runtime(
                 get_namedtuple_field_annotation(obj, field),
-                ctx=AnnotationsContext(self_key=obj),
+                ctx=_make_annotations_context(owner=obj),
             )
             field_annotations[field] = annotation
             default: Value | None
@@ -1252,7 +1296,9 @@ class ArgSpecCache:
             return_type = GenericValue(
                 obj,
                 [
-                    type_from_runtime(type_param, ctx=AnnotationsContext(self_key=obj))
+                    type_from_runtime(
+                        type_param, ctx=_make_annotations_context(owner=obj)
+                    )
                     for type_param in class_type_params
                 ],
             )
@@ -1362,12 +1408,12 @@ class ArgSpecCache:
             runtime_type_params_iter = iter(runtime_type_params)
         except TypeError:
             return []
+        ctx = AnnotationsContext(self_key=typ)
+        add_runtime_type_param_scope(ctx, typ, typ)
         type_params: list[TypeParam] = []
         for type_param in runtime_type_params_iter:
             try:
-                type_params.append(
-                    make_type_param(type_param, ctx=AnnotationsContext(self_key=typ))
-                )
+                type_params.append(make_type_param(type_param, ctx=ctx))
             except TypeError:
                 continue
         self.type_params_cache[typ] = tuple(type_params)
@@ -1639,7 +1685,7 @@ class ArgSpecCache:
             return TypedValue(float)
         elif base is complex:
             return TypedValue(complex)
-        return type_from_runtime(base, ctx=AnnotationsContext(self_key=owner))
+        return type_from_runtime(base, ctx=_make_annotations_context(owner=owner))
 
     def _extract_bases(
         self, typ: ClassKey, bases: Sequence[Value] | None
@@ -1653,9 +1699,23 @@ class ArgSpecCache:
             key=lambda base: not isinstance(base, TypedValue)
             or base.typ is not Generic,
         )
-        my_typevars = tuple(
+        raw_typevars = tuple(
             uniq_chain(tuple(iter_type_params_in_value(base)) for base in bases)
         )
+        my_typevars = raw_typevars
+        if not isinstance(typ, ClassOwner):
+            my_typevars = tuple(
+                with_type_param_owner(type_param, typ) for type_param in raw_typevars
+            )
+            owner_rebinding = TypeVarMap()
+            for raw_type_param, owned_type_param in zip(raw_typevars, my_typevars):
+                if raw_type_param is owned_type_param:
+                    continue
+                owner_rebinding = owner_rebinding.with_value(
+                    raw_type_param, type_param_to_value(owned_type_param)
+                )
+            if owner_rebinding:
+                bases = [base.substitute_typevars(owner_rebinding) for base in bases]
         self.type_params_cache[typ] = my_typevars
         generic_bases = {}
         self_typevars = TypeVarMap()

--- a/pycroscope/arg_spec.py
+++ b/pycroscope/arg_spec.py
@@ -284,7 +284,7 @@ def _make_annotations_context(
     globals: Mapping[str, object] | None = None,
     callable_obj: object | None = None,
     *,
-    owner: type | None = None,
+    owner: ClassKey | None = None,
 ) -> AnnotationsContext:
     if owner is None:
         owner = _get_callable_owner(callable_obj)
@@ -1679,7 +1679,7 @@ class ArgSpecCache:
         self.generic_bases_cache[typ] = generic_bases
         return generic_bases
 
-    def _type_from_base(self, base: object, owner: type) -> Value:
+    def _type_from_base(self, base: object, owner: ClassKey) -> Value:
         # Avoid promoting float to float|int here.
         if base is float:
             return TypedValue(float)

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -610,11 +610,7 @@ def _get_attribute_from_known_inner(
         # Self for importable classes. TypeObject.get_attribute() handles many
         # Self-sensitive cases above, but not all runtime MRO fallbacks.
         if safe_isinstance(obj, type):
-            context_self_value = ctx.get_self_value()
-            if isinstance(context_self_value, KnownValueWithTypeVars):
-                self_value = context_self_value
-            else:
-                self_value = TypedValue(obj)
+            self_value = TypedValue(obj)
         else:
             self_value = ctx.get_self_value()
         runtime_value = set_self(runtime_value, self_value, type_object_attr.owner.typ)

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -17,7 +17,7 @@ from .annotations import RuntimeAnnotationsContext, type_from_runtime
 from .options import Options, PyObjectSequenceOption
 from .predicates import HasAttr
 from .relations import intersect_multi
-from .safe import safe_getattr, safe_isinstance
+from .safe import safe_getattr, safe_isinstance, safe_issubclass
 from .signature import MaybeSignature
 from .stacked_scopes import Composite
 from .type_object import AttributePolicy, TypeObject, TypeObjectAttribute
@@ -35,6 +35,7 @@ from .value import (
     GradualType,
     IntersectionValue,
     KnownValue,
+    KnownValueWithTypeVars,
     MultiValuedValue,
     NewTypeValue,
     OverlappingValue,
@@ -307,6 +308,10 @@ def _get_attribute_from_generic_alias(
         )
     if ctx.attr in _GENERIC_ALIAS_ATTR_EXCEPTIONS:
         return _get_attribute_from_value(TypedValue(types.GenericAlias), ctx)
+    lookup_root = ctx.get_self_value()
+    if lookup_root is not ctx.root_value:
+        lookup_ctx = ctx.clone_for_attribute_lookup(Composite(lookup_root), ctx.attr)
+        return _get_attribute_from_value(gradualize(lookup_root), lookup_ctx)
     return _get_attribute_from_value(gradualize(root), ctx)
 
 
@@ -386,6 +391,18 @@ def _get_attribute_from_subclass(
                 assert_never(metaclass)
     if ctx.attr == "__bases__":
         return GenericValue(tuple, [SubclassValue(TypedValue(object))]), None
+    if (
+        ctx.attr == "__getitem__"
+        and ctx.get_self_value() != ctx.root_value
+        and safe_isinstance(typ, type)
+        and safe_issubclass(typ, dict)
+    ):
+        default = object()
+        runtime_obj = safe_getattr(typ, ctx.attr, default)
+        if runtime_obj is not default:
+            result = set_self(KnownValue(runtime_obj), ctx.get_self_value(), typ)
+            ctx.record_usage(typ, result)
+            return result, None
     attribute = _get_type_object_attribute(
         tobj, ctx.attr, ctx, on_class=True, receiver_value=self_value
     )
@@ -484,8 +501,6 @@ def _get_attribute_from_known(
     obj = value.val
     if safe_isinstance(obj, type):
         ctx.record_attr_read(obj)
-        if ctx.attr in {"__name__", "__qualname__", "__module__", "__doc__"}:
-            return KnownValue(getattr(obj, ctx.attr))
     else:
         ctx.record_attr_read(type(obj))
 
@@ -558,6 +573,8 @@ def _get_attribute_from_known_inner(
         on_class = False
     policy = ctx.get_type_object_attribute_policy(on_class=on_class, receiver=value)
     type_object_attr = tobj.get_attribute(ctx.attr, policy)
+    if isinstance(value, KnownValueWithTypeVars) and type_object_attr is not None:
+        return type_object_attr.value, type_object_attr.error
 
     # Even if there's no runtime attribute, we believe the annotation if there is one.
     if runtime_value is None:
@@ -609,7 +626,11 @@ def _get_attribute_from_known_inner(
         # Self for importable classes. TypeObject.get_attribute() handles many
         # Self-sensitive cases above, but not all runtime MRO fallbacks.
         if safe_isinstance(obj, type):
-            self_value = TypedValue(obj)
+            context_self_value = ctx.get_self_value()
+            if isinstance(context_self_value, KnownValueWithTypeVars):
+                self_value = context_self_value
+            else:
+                self_value = TypedValue(obj)
         else:
             self_value = ctx.get_self_value()
         runtime_value = set_self(runtime_value, self_value, type_object_attr.owner.typ)

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -484,6 +484,8 @@ def _get_attribute_from_known(
     obj = value.val
     if safe_isinstance(obj, type):
         ctx.record_attr_read(obj)
+        if ctx.attr in {"__name__", "__qualname__", "__module__", "__doc__"}:
+            return KnownValue(getattr(obj, ctx.attr))
     else:
         ctx.record_attr_read(type(obj))
 

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -35,7 +35,6 @@ from .value import (
     GradualType,
     IntersectionValue,
     KnownValue,
-    KnownValueWithTypeVars,
     MultiValuedValue,
     NewTypeValue,
     OverlappingValue,
@@ -557,8 +556,6 @@ def _get_attribute_from_known_inner(
         on_class = False
     policy = ctx.get_type_object_attribute_policy(on_class=on_class, receiver=value)
     type_object_attr = tobj.get_attribute(ctx.attr, policy)
-    if isinstance(value, KnownValueWithTypeVars) and type_object_attr is not None:
-        return type_object_attr.value, type_object_attr.error
 
     # Even if there's no runtime attribute, we believe the annotation if there is one.
     if runtime_value is None:

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -308,10 +308,6 @@ def _get_attribute_from_generic_alias(
         )
     if ctx.attr in _GENERIC_ALIAS_ATTR_EXCEPTIONS:
         return _get_attribute_from_value(TypedValue(types.GenericAlias), ctx)
-    lookup_root = ctx.get_self_value()
-    if lookup_root is not ctx.root_value:
-        lookup_ctx = ctx.clone_for_attribute_lookup(Composite(lookup_root), ctx.attr)
-        return _get_attribute_from_value(gradualize(lookup_root), lookup_ctx)
     return _get_attribute_from_value(gradualize(root), ctx)
 
 

--- a/pycroscope/attributes.py
+++ b/pycroscope/attributes.py
@@ -17,7 +17,7 @@ from .annotations import RuntimeAnnotationsContext, type_from_runtime
 from .options import Options, PyObjectSequenceOption
 from .predicates import HasAttr
 from .relations import intersect_multi
-from .safe import safe_getattr, safe_isinstance, safe_issubclass
+from .safe import safe_getattr, safe_isinstance
 from .signature import MaybeSignature
 from .stacked_scopes import Composite
 from .type_object import AttributePolicy, TypeObject, TypeObjectAttribute
@@ -387,18 +387,6 @@ def _get_attribute_from_subclass(
                 assert_never(metaclass)
     if ctx.attr == "__bases__":
         return GenericValue(tuple, [SubclassValue(TypedValue(object))]), None
-    if (
-        ctx.attr == "__getitem__"
-        and ctx.get_self_value() != ctx.root_value
-        and safe_isinstance(typ, type)
-        and safe_issubclass(typ, dict)
-    ):
-        default = object()
-        runtime_obj = safe_getattr(typ, ctx.attr, default)
-        if runtime_obj is not default:
-            result = set_self(KnownValue(runtime_obj), ctx.get_self_value(), typ)
-            ctx.record_usage(typ, result)
-            return result, None
     attribute = _get_type_object_attribute(
         tobj, ctx.attr, ctx, on_class=True, receiver_value=self_value
     )

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -1154,7 +1154,7 @@ class Checker:
             )
         )
         typevar = cast(TypeVarType, TypeVar(f"_Ctor_{class_name}_T", *constraints))
-        tv_value = TypeVarValue(TypeVarParam(typevar))
+        tv_value = TypeVarValue(TypeVarParam(typevar, owner=None))
         generic_param = SigParameter(
             first_param.name,
             kind=first_param.kind,

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -734,7 +734,9 @@ class Checker:
     ) -> None:
         self.make_synthetic_class(typ)
         type_object = self.make_type_object(typ)
-        type_object.set_direct_bases(direct_bases_from_values(base_values, self))
+        type_object.set_direct_bases(
+            direct_bases_from_values(base_values, self, owner=typ)
+        )
         if declared_type_params:
             type_object.set_declared_type_params(declared_type_params)
         else:

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -263,6 +263,26 @@ def _strip_signature_deprecation(signature: MaybeSignature) -> MaybeSignature:
     )
 
 
+def _apply_return_override(
+    signature: MaybeSignature, return_override: Value | None
+) -> MaybeSignature:
+    if return_override is None:
+        return signature
+
+    def transform(sig: Signature) -> Signature:
+        if sig.has_return_value():
+            return sig
+        return dataclass_replace(sig, return_value=return_override)
+
+    updated = _map_maybe_signature(signature, transform)
+    if (
+        isinstance(updated, BoundMethodSignature)
+        and not updated.signature.has_return_value()
+    ):
+        return dataclass_replace(updated, return_override=return_override)
+    return updated
+
+
 # TODO: Ideally we should set self_param correctly from the beginning instead
 # of patching it in later
 def _set_missing_signature_self_param(
@@ -1236,6 +1256,35 @@ class Checker:
             return GenericValue(typ, _apply_type_parameter_defaults(type_params))
         return TypedValue(typ)
 
+    def _direct_python_constructor_method_lacks_receiver(
+        self, typ: type, method_name: str
+    ) -> bool:
+        method_object = typ.__dict__.get(method_name)
+        if isinstance(method_object, (staticmethod, classmethod)):
+            method_object = method_object.__func__
+        if not isinstance(method_object, types.FunctionType):
+            return False
+        method_sig = self.arg_spec_cache.get_argspec(method_object)
+        concrete = as_concrete_signature(method_sig, self)
+        if concrete is None:
+            return False
+        signatures = (
+            concrete.signatures
+            if isinstance(concrete, OverloadedSignature)
+            else [concrete]
+        )
+        return all(
+            not sig.parameters
+            or next(iter(sig.parameters.values())).kind
+            not in {
+                ParameterKind.ELLIPSIS,
+                ParameterKind.VAR_POSITIONAL,
+                ParameterKind.POSITIONAL_ONLY,
+                ParameterKind.POSITIONAL_OR_KEYWORD,
+            }
+            for sig in signatures
+        )
+
     def _get_runtime_constructor_method_signature(
         self,
         typ: type,
@@ -1370,6 +1419,11 @@ class Checker:
             bound_self_value=instance_type,
             self_annotation_value=instance_type,
         )
+
+        if self._direct_python_constructor_method_lacks_receiver(
+            typ, "__new__"
+        ) or self._direct_python_constructor_method_lacks_receiver(typ, "__init__"):
+            return _make_incompatible_constructor_signature(instance_type)
 
         if has_direct_new and not has_direct_init:
             init_sig = None
@@ -2364,74 +2418,75 @@ class Checker:
                     if value.typevars is not None:
                         primary_sig = primary_sig.substitute_typevars(value.typevars)
                     return primary_sig
-            receiver_for_symbolic: Value | None = None
-            composite_root = replace_fallback(value.composite.value)
-            if isinstance(composite_root, SubclassValue) and isinstance(
-                composite_root.typ, TypedValue
+            composite_root = value.composite.value
+            if (
+                isinstance(composite_root, TypeVarValue)
+                and composite_root.typevar_param.is_self
             ):
-                receiver_for_symbolic = composite_root.typ
-            elif isinstance(composite_root, TypedValue):
-                receiver_for_symbolic = composite_root
-            if receiver_for_symbolic is not None and value.secondary_attr_name is None:
-                static_attr = receiver_for_symbolic.get_type_object(self).get_attribute(
-                    value.attr_name,
-                    AttributePolicy(
-                        receiver=receiver_for_symbolic, prefer_symbolic=True
-                    ),
-                )
-                if static_attr is not None and not isinstance(
-                    static_attr.value, UnboundMethodValue
-                ):
-                    symbolic_sig = self.signature_from_value(static_attr.value)
-                    if symbolic_sig is not None:
-                        if value.typevars is not None:
-                            symbolic_sig = symbolic_sig.substitute_typevars(
-                                value.typevars
+                upper_bound = composite_root.get_upper_bound_value()
+                if isinstance(upper_bound, TypedValue):
+                    static_attr = upper_bound.get_type_object(self).get_attribute(
+                        value.attr_name,
+                        AttributePolicy(receiver=composite_root, prefer_symbolic=True),
+                    )
+                    if static_attr is not None and not isinstance(
+                        static_attr.value, UnboundMethodValue
+                    ):
+                        symbolic_sig = self.signature_from_value(static_attr.value)
+                        if symbolic_sig is not None:
+                            symbolic_sig = _apply_return_override(
+                                symbolic_sig, get_return_override(symbolic_sig)
                             )
-                        if isinstance(symbolic_sig, Signature):
-                            if symbolic_sig.bound_receiver_param_name is not None:
-                                if (
-                                    symbolic_sig.bound_receiver_composite is None
-                                    or symbolic_sig.bound_receiver_composite.varname
-                                    is None
-                                ):
-                                    return dataclass_replace(
-                                        symbolic_sig,
-                                        bound_receiver_composite=value.composite,
-                                    )
-                                return symbolic_sig
-                        elif isinstance(symbolic_sig, OverloadedSignature):
-                            if all(
-                                subsig.bound_receiver_param_name is not None
-                                for subsig in symbolic_sig.signatures
-                            ):
-                                if all(
-                                    subsig.bound_receiver_composite is not None
-                                    and subsig.bound_receiver_composite.varname
-                                    is not None
-                                    for subsig in symbolic_sig.signatures
-                                ):
-                                    return symbolic_sig
-                                return OverloadedSignature(
-                                    [
-                                        dataclass_replace(
-                                            subsig,
+                            if symbolic_sig is not None and value.typevars is not None:
+                                symbolic_sig = symbolic_sig.substitute_typevars(
+                                    value.typevars
+                                )
+                            if symbolic_sig is None:
+                                return None
+                            if isinstance(symbolic_sig, Signature):
+                                if symbolic_sig.bound_receiver_param_name is not None:
+                                    if (
+                                        symbolic_sig.bound_receiver_composite is None
+                                        or symbolic_sig.bound_receiver_composite.varname
+                                        is None
+                                    ):
+                                        return dataclass_replace(
+                                            symbolic_sig,
                                             bound_receiver_composite=value.composite,
                                         )
+                                    return symbolic_sig
+                            elif isinstance(symbolic_sig, OverloadedSignature):
+                                if all(
+                                    subsig.bound_receiver_param_name is not None
+                                    for subsig in symbolic_sig.signatures
+                                ):
+                                    if all(
+                                        subsig.bound_receiver_composite is not None
+                                        and subsig.bound_receiver_composite.varname
+                                        is not None
                                         for subsig in symbolic_sig.signatures
-                                    ]
+                                    ):
+                                        return symbolic_sig
+                                    return OverloadedSignature(
+                                        [
+                                            dataclass_replace(
+                                                subsig,
+                                                bound_receiver_composite=value.composite,
+                                            )
+                                            for subsig in symbolic_sig.signatures
+                                        ]
+                                    )
+                            if isinstance(symbolic_sig, BoundMethodSignature):
+                                return dataclass_replace(
+                                    symbolic_sig, self_composite=value.composite
                                 )
-                        if isinstance(symbolic_sig, BoundMethodSignature):
-                            return dataclass_replace(
-                                symbolic_sig, self_composite=value.composite
+                            return_override = get_return_override(symbolic_sig)
+                            bound_symbolic = make_bound_method(
+                                symbolic_sig, value.composite, return_override, ctx=self
                             )
-                        return_override = get_return_override(symbolic_sig)
-                        bound_symbolic = make_bound_method(
-                            symbolic_sig, value.composite, return_override, ctx=self
-                        )
-                        if bound_symbolic is not None:
-                            return bound_symbolic
-                        return symbolic_sig
+                            if bound_symbolic is not None:
+                                return bound_symbolic
+                            return symbolic_sig
             method = value.get_method()
             if method is not None:
                 sig: MaybeSignature = None

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -2364,6 +2364,74 @@ class Checker:
                     if value.typevars is not None:
                         primary_sig = primary_sig.substitute_typevars(value.typevars)
                     return primary_sig
+            receiver_for_symbolic: Value | None = None
+            composite_root = replace_fallback(value.composite.value)
+            if isinstance(composite_root, SubclassValue) and isinstance(
+                composite_root.typ, TypedValue
+            ):
+                receiver_for_symbolic = composite_root.typ
+            elif isinstance(composite_root, TypedValue):
+                receiver_for_symbolic = composite_root
+            if receiver_for_symbolic is not None and value.secondary_attr_name is None:
+                static_attr = receiver_for_symbolic.get_type_object(self).get_attribute(
+                    value.attr_name,
+                    AttributePolicy(
+                        receiver=receiver_for_symbolic, prefer_symbolic=True
+                    ),
+                )
+                if static_attr is not None and not isinstance(
+                    static_attr.value, UnboundMethodValue
+                ):
+                    symbolic_sig = self.signature_from_value(static_attr.value)
+                    if symbolic_sig is not None:
+                        if value.typevars is not None:
+                            symbolic_sig = symbolic_sig.substitute_typevars(
+                                value.typevars
+                            )
+                        if isinstance(symbolic_sig, Signature):
+                            if symbolic_sig.bound_receiver_param_name is not None:
+                                if (
+                                    symbolic_sig.bound_receiver_composite is None
+                                    or symbolic_sig.bound_receiver_composite.varname
+                                    is None
+                                ):
+                                    return dataclass_replace(
+                                        symbolic_sig,
+                                        bound_receiver_composite=value.composite,
+                                    )
+                                return symbolic_sig
+                        elif isinstance(symbolic_sig, OverloadedSignature):
+                            if all(
+                                subsig.bound_receiver_param_name is not None
+                                for subsig in symbolic_sig.signatures
+                            ):
+                                if all(
+                                    subsig.bound_receiver_composite is not None
+                                    and subsig.bound_receiver_composite.varname
+                                    is not None
+                                    for subsig in symbolic_sig.signatures
+                                ):
+                                    return symbolic_sig
+                                return OverloadedSignature(
+                                    [
+                                        dataclass_replace(
+                                            subsig,
+                                            bound_receiver_composite=value.composite,
+                                        )
+                                        for subsig in symbolic_sig.signatures
+                                    ]
+                                )
+                        if isinstance(symbolic_sig, BoundMethodSignature):
+                            return dataclass_replace(
+                                symbolic_sig, self_composite=value.composite
+                            )
+                        return_override = get_return_override(symbolic_sig)
+                        bound_symbolic = make_bound_method(
+                            symbolic_sig, value.composite, return_override, ctx=self
+                        )
+                        if bound_symbolic is not None:
+                            return bound_symbolic
+                        return symbolic_sig
             method = value.get_method()
             if method is not None:
                 sig: MaybeSignature = None

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -263,26 +263,6 @@ def _strip_signature_deprecation(signature: MaybeSignature) -> MaybeSignature:
     )
 
 
-def _apply_return_override(
-    signature: MaybeSignature, return_override: Value | None
-) -> MaybeSignature:
-    if return_override is None:
-        return signature
-
-    def transform(sig: Signature) -> Signature:
-        if sig.has_return_value():
-            return sig
-        return dataclass_replace(sig, return_value=return_override)
-
-    updated = _map_maybe_signature(signature, transform)
-    if (
-        isinstance(updated, BoundMethodSignature)
-        and not updated.signature.has_return_value()
-    ):
-        return dataclass_replace(updated, return_override=return_override)
-    return updated
-
-
 # TODO: Ideally we should set self_param correctly from the beginning instead
 # of patching it in later
 def _set_missing_signature_self_param(
@@ -1256,35 +1236,6 @@ class Checker:
             return GenericValue(typ, _apply_type_parameter_defaults(type_params))
         return TypedValue(typ)
 
-    def _direct_python_constructor_method_lacks_receiver(
-        self, typ: type, method_name: str
-    ) -> bool:
-        method_object = typ.__dict__.get(method_name)
-        if isinstance(method_object, (staticmethod, classmethod)):
-            method_object = method_object.__func__
-        if not isinstance(method_object, types.FunctionType):
-            return False
-        method_sig = self.arg_spec_cache.get_argspec(method_object)
-        concrete = as_concrete_signature(method_sig, self)
-        if concrete is None:
-            return False
-        signatures = (
-            concrete.signatures
-            if isinstance(concrete, OverloadedSignature)
-            else [concrete]
-        )
-        return all(
-            not sig.parameters
-            or next(iter(sig.parameters.values())).kind
-            not in {
-                ParameterKind.ELLIPSIS,
-                ParameterKind.VAR_POSITIONAL,
-                ParameterKind.POSITIONAL_ONLY,
-                ParameterKind.POSITIONAL_OR_KEYWORD,
-            }
-            for sig in signatures
-        )
-
     def _get_runtime_constructor_method_signature(
         self,
         typ: type,
@@ -1419,11 +1370,6 @@ class Checker:
             bound_self_value=instance_type,
             self_annotation_value=instance_type,
         )
-
-        if self._direct_python_constructor_method_lacks_receiver(
-            typ, "__new__"
-        ) or self._direct_python_constructor_method_lacks_receiver(typ, "__init__"):
-            return _make_incompatible_constructor_signature(instance_type)
 
         if has_direct_new and not has_direct_init:
             init_sig = None
@@ -2418,75 +2364,6 @@ class Checker:
                     if value.typevars is not None:
                         primary_sig = primary_sig.substitute_typevars(value.typevars)
                     return primary_sig
-            composite_root = value.composite.value
-            if (
-                isinstance(composite_root, TypeVarValue)
-                and composite_root.typevar_param.is_self
-            ):
-                upper_bound = composite_root.get_upper_bound_value()
-                if isinstance(upper_bound, TypedValue):
-                    static_attr = upper_bound.get_type_object(self).get_attribute(
-                        value.attr_name,
-                        AttributePolicy(receiver=composite_root, prefer_symbolic=True),
-                    )
-                    if static_attr is not None and not isinstance(
-                        static_attr.value, UnboundMethodValue
-                    ):
-                        symbolic_sig = self.signature_from_value(static_attr.value)
-                        if symbolic_sig is not None:
-                            symbolic_sig = _apply_return_override(
-                                symbolic_sig, get_return_override(symbolic_sig)
-                            )
-                            if symbolic_sig is not None and value.typevars is not None:
-                                symbolic_sig = symbolic_sig.substitute_typevars(
-                                    value.typevars
-                                )
-                            if symbolic_sig is None:
-                                return None
-                            if isinstance(symbolic_sig, Signature):
-                                if symbolic_sig.bound_receiver_param_name is not None:
-                                    if (
-                                        symbolic_sig.bound_receiver_composite is None
-                                        or symbolic_sig.bound_receiver_composite.varname
-                                        is None
-                                    ):
-                                        return dataclass_replace(
-                                            symbolic_sig,
-                                            bound_receiver_composite=value.composite,
-                                        )
-                                    return symbolic_sig
-                            elif isinstance(symbolic_sig, OverloadedSignature):
-                                if all(
-                                    subsig.bound_receiver_param_name is not None
-                                    for subsig in symbolic_sig.signatures
-                                ):
-                                    if all(
-                                        subsig.bound_receiver_composite is not None
-                                        and subsig.bound_receiver_composite.varname
-                                        is not None
-                                        for subsig in symbolic_sig.signatures
-                                    ):
-                                        return symbolic_sig
-                                    return OverloadedSignature(
-                                        [
-                                            dataclass_replace(
-                                                subsig,
-                                                bound_receiver_composite=value.composite,
-                                            )
-                                            for subsig in symbolic_sig.signatures
-                                        ]
-                                    )
-                            if isinstance(symbolic_sig, BoundMethodSignature):
-                                return dataclass_replace(
-                                    symbolic_sig, self_composite=value.composite
-                                )
-                            return_override = get_return_override(symbolic_sig)
-                            bound_symbolic = make_bound_method(
-                                symbolic_sig, value.composite, return_override, ctx=self
-                            )
-                            if bound_symbolic is not None:
-                                return bound_symbolic
-                            return symbolic_sig
             method = value.get_method()
             if method is not None:
                 sig: MaybeSignature = None

--- a/pycroscope/functions.py
+++ b/pycroscope/functions.py
@@ -789,7 +789,9 @@ def _signature_params_from_function_params(
                     SigParameter(
                         param.name,
                         ParameterKind.PARAM_SPEC,
-                        annotation=InputSigValue(ParamSpecParam(annotation.param_spec)),
+                        annotation=InputSigValue(
+                            ParamSpecParam(annotation.param_spec, owner=None)
+                        ),
                     )
                 )
                 pending_param = None

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -3544,11 +3544,6 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
         default=NO_ARG_SENTINEL,
         annotation=TypeFormValue(TypedValue(object)),
     )
-    constraints_param = SigParameter(
-        "constraints",
-        ParameterKind.VAR_POSITIONAL,
-        annotation=GenericValue(tuple, [TypeFormValue(TypedValue(object))]),
-    )
     covariant_param = SigParameter(
         "covariant",
         ParameterKind.KEYWORD_ONLY,

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -16,7 +16,12 @@ import typing_extensions
 import pycroscope
 
 from . import runtime
-from .annotations import annotation_expr_from_value, is_typevarlike, type_from_value
+from .annotations import (
+    annotation_expr_from_value,
+    is_typevarlike,
+    make_type_param_from_value,
+    type_from_value,
+)
 from .error_code import ErrorCode
 from .extensions import assert_type, reveal_locals, reveal_type
 from .format_strings import parse_format_string
@@ -31,7 +36,6 @@ from .relations import (
     intersect_values,
     is_assignable,
     is_assignable_with_reason,
-    is_equivalent,
     is_equivalent_with_reason,
 )
 from .safe import (
@@ -89,6 +93,7 @@ from .value import (
     MultiValuedValue,
     NewTypeValue,
     ParameterTypeGuardExtension,
+    PartialCallValue,
     PartialValue,
     PartialValueOperation,
     PredicateValue,
@@ -2246,9 +2251,50 @@ def _assert_type_impl(ctx: CallContext) -> Value:
 def _subclasses_impl(ctx: CallContext) -> Value:
     """Overridden because typeshed types make it (T) => List[T] instead."""
     self_obj = ctx.vars["self"]
+    self_composite = ctx.composite_for_arg("self")
+    if self_composite is not None:
+        self_obj = self_composite.value
     if isinstance(self_obj, KnownValue) and isinstance(self_obj.val, type):
         return KnownValue(self_obj.val.__subclasses__())
+    class_key = _exact_class_key_from_value(self_obj)
+    if class_key is not None:
+        subclasses = _synthetic_direct_subclasses(class_key, ctx)
+        if subclasses is not None:
+            return SequenceValue(list, [(False, subclass) for subclass in subclasses])
     return GenericValue(list, [TypedValue(type)])
+
+
+def _exact_class_key_from_value(value: Value) -> ClassKey | None:
+    value = replace_fallback(value)
+    if isinstance(value, KnownValue) and isinstance(value.val, type):
+        return value.val
+    if isinstance(value, SyntheticClassObjectValue):
+        if value.class_key is not None:
+            return value.class_key
+        if isinstance(value.class_type, TypedValue):
+            return value.class_type.typ
+    return None
+
+
+def _synthetic_direct_subclasses(
+    class_key: ClassKey, ctx: CallContext
+) -> tuple[Value, ...] | None:
+    synthetic_classes = ctx.visitor.checker.synthetic_classes
+    subclasses: list[Value] = []
+    for candidate_key, synthetic_class in synthetic_classes.items():
+        if candidate_key == class_key:
+            continue
+        direct_bases = ctx.visitor.checker.make_type_object(
+            candidate_key
+        ).get_direct_bases()
+        if any(
+            isinstance(base, TypedValue) and base.typ == class_key
+            for base in direct_bases
+        ):
+            subclasses.append(synthetic_class)
+    if not subclasses:
+        return None
+    return tuple(subclasses)
 
 
 def _type_impl(ctx: CallContext) -> Value:
@@ -2515,6 +2561,34 @@ def _newtype_contains_any(value: Value) -> bool:
 
 
 def _newtype_contains_typevar(value: Value) -> bool:
+    if isinstance(value, PartialCallValue):
+
+        def _is_type_param_constructor(obj: object) -> bool:
+            module = safe_getattr(obj, "__module__", None)
+            name = safe_getattr(obj, "__name__", None)
+            return module in {"typing", "typing_extensions"} and name in {
+                "TypeVar",
+                "ParamSpec",
+                "TypeVarTuple",
+            }
+
+        runtime_value = replace_fallback(value.runtime_value)
+        if isinstance(value.callee, KnownValue) and _is_type_param_constructor(
+            value.callee.val
+        ):
+            return True
+        if isinstance(runtime_value, TypedValue) and _is_type_param_constructor(
+            runtime_value.typ
+        ):
+            return True
+        return _newtype_contains_typevar(value.callee) or any(
+            _newtype_contains_typevar(argument) for argument in value.arguments.values()
+        )
+    if isinstance(value, PartialValue):
+        return _newtype_contains_typevar(value.root) or any(
+            _newtype_contains_typevar(member) for member in value.members
+        )
+
     value = replace_fallback(value)
     if isinstance(value, AnyValue):
         return value.source is AnySource.generic_argument
@@ -2665,6 +2739,7 @@ def _newtype_impl(ctx: CallContext) -> Value:
     if (
         _newtype_runtime_has_type_parameters(ctx.vars["tp"])
         or _newtype_runtime_is_union(ctx.vars["tp"])
+        or _newtype_contains_typevar(ctx.vars["tp"])
         or _newtype_contains_typevar(supertype)
     ):
         ctx.show_error(
@@ -2835,61 +2910,7 @@ def _check_assignment_name_match(ctx: CallContext, name_arg: str, callee: str) -
 
 def _typevar_impl(ctx: CallContext) -> Value:
     _check_assignment_name_match(ctx, "name", "TypeVar")
-    if ctx.vars["bound"] is NO_ARG_SENTINEL:
-        bound = None
-    else:
-        bound = _type_from_typeform_arg(ctx.vars["bound"], ctx, "bound")
-    if (
-        isinstance(ctx.vars["constraints"], SequenceValue)
-        and ctx.vars["constraints"].members
-    ):
-        constraints = [
-            _type_from_typeform_arg(constraint, ctx, "constraints")
-            for constraint in ctx.vars["constraints"].get_member_sequence() or ()
-        ]
-    else:
-        constraints = None
-    if bound is not None and constraints is not None:
-        ctx.show_error(
-            "TypeVar cannot have both bound and constraints",
-            ErrorCode.incompatible_call,
-            node=ctx.node,
-        )
-    default_arg = ctx.vars.get("default", NO_ARG_SENTINEL)
-    if default_arg is NO_ARG_SENTINEL:
-        default = None
-    else:
-        default = _type_from_typeform_arg(default_arg, ctx, "default")
-
-    if bound is not None and default is not None:
-        if not is_assignable(bound, default, ctx.visitor):
-            ctx.show_error(
-                "TypeVar default must be assignable to its bound",
-                ErrorCode.incompatible_call,
-                arg="default",
-            )
-    if constraints is not None and default is not None:
-        if isinstance(default, TypeVarValue) and default.typevar_param.constraints:
-            default_constraints = default.typevar_param.constraints
-            default_matches_constraints = all(
-                any(
-                    is_equivalent(constraint, default_constraint, ctx.visitor)
-                    for constraint in constraints
-                )
-                for default_constraint in default_constraints
-            )
-        else:
-            default_matches_constraints = any(
-                is_equivalent(constraint, default, ctx.visitor)
-                for constraint in constraints
-            )
-        if not default_matches_constraints:
-            ctx.show_error(
-                "TypeVar default must be one of its constraints",
-                ErrorCode.incompatible_call,
-                arg="default",
-            )
-
+    _validate_type_param_partial_call(ctx)
     return ctx.inferred_return_value
 
 
@@ -2901,7 +2922,7 @@ def _paramspec_impl(ctx: CallContext) -> Value:
             ErrorCode.incompatible_call,
             arg="bound",
         )
-    # TODO: check variance and default
+    _validate_type_param_partial_call(ctx)
     return ctx.inferred_return_value
 
 
@@ -2913,8 +2934,21 @@ def _typevartuple_impl(ctx: CallContext) -> Value:
             ErrorCode.incompatible_call,
             arg="bound",
         )
-    # TODO: check variance and default
+    _validate_type_param_partial_call(ctx)
     return ctx.inferred_return_value
+
+
+def _validate_type_param_partial_call(ctx: CallContext) -> None:
+    make_type_param_from_value(
+        PartialCallValue(
+            callee=KnownValue(ctx.sig.callable),
+            arguments=ctx.vars,
+            runtime_value=ctx.inferred_return_value,
+            node=ctx.node if ctx.node is not None else ctx.visitor.tree,
+        ),
+        visitor=ctx.visitor,
+        node=ctx.ast_for_arg("default") if "default" in ctx.vars else ctx.node,
+    )
 
 
 def _sentinel_impl(ctx: CallContext) -> Value:
@@ -3599,22 +3633,112 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
             pass
         else:
             typevar_params = [
-                name_param,
-                constraints_param,
-                bound_param,
-                covariant_param,
-                contravariant_param,
+                SigParameter(
+                    "name",
+                    ParameterKind.POSITIONAL_OR_KEYWORD,
+                    annotation=TypedValue(str),
+                ),
+                SigParameter(
+                    "constraints",
+                    ParameterKind.VAR_POSITIONAL,
+                    annotation=AnyValue(AnySource.explicit),
+                ),
+                SigParameter(
+                    "bound",
+                    ParameterKind.KEYWORD_ONLY,
+                    default=NO_ARG_SENTINEL,
+                    annotation=AnyValue(AnySource.explicit),
+                ),
+                SigParameter(
+                    "covariant",
+                    ParameterKind.KEYWORD_ONLY,
+                    default=KnownValue(False),
+                    annotation=TypedValue(bool),
+                ),
+                SigParameter(
+                    "contravariant",
+                    ParameterKind.KEYWORD_ONLY,
+                    default=KnownValue(False),
+                    annotation=TypedValue(bool),
+                ),
             ]
             if sys.version_info >= (3, 11) or mod is typing_extensions:
                 typevar_params.append(infer_variance_param)
             if sys.version_info >= (3, 12) or mod is typing_extensions:
-                typevar_params.append(default_param)
+                typevar_params.append(
+                    SigParameter(
+                        "default",
+                        ParameterKind.KEYWORD_ONLY,
+                        default=NO_ARG_SENTINEL,
+                        annotation=AnyValue(AnySource.explicit),
+                    )
+                )
             sig = Signature.make(
                 typevar_params,
                 return_annotation=TypedValue(typevar_class),
                 callable=typevar_class,
                 impl=_typevar_impl,
-                allow_call=True,
+                allow_call=False,
+                allow_partial_call=True,
+            )
+            signatures.append(sig)
+        try:
+            paramspec_class = getattr(mod, "ParamSpec")
+        except AttributeError:
+            pass
+        else:
+            paramspec_params = [
+                SigParameter(
+                    "name",
+                    ParameterKind.POSITIONAL_OR_KEYWORD,
+                    annotation=TypedValue(str),
+                )
+            ]
+            if sys.version_info >= (3, 13) or mod is typing_extensions:
+                paramspec_params.append(
+                    SigParameter(
+                        "default",
+                        ParameterKind.KEYWORD_ONLY,
+                        default=NO_ARG_SENTINEL,
+                        annotation=AnyValue(AnySource.explicit),
+                    )
+                )
+            sig = Signature.make(
+                paramspec_params,
+                return_annotation=TypedValue(paramspec_class),
+                callable=paramspec_class,
+                impl=_paramspec_impl,
+                allow_call=False,
+                allow_partial_call=True,
+            )
+            signatures.append(sig)
+        try:
+            typevartuple_class = getattr(mod, "TypeVarTuple")
+        except AttributeError:
+            pass
+        else:
+            typevartuple_params = [
+                SigParameter(
+                    "name",
+                    ParameterKind.POSITIONAL_OR_KEYWORD,
+                    annotation=TypedValue(str),
+                )
+            ]
+            if sys.version_info >= (3, 13) or mod is typing_extensions:
+                typevartuple_params.append(
+                    SigParameter(
+                        "default",
+                        ParameterKind.KEYWORD_ONLY,
+                        default=NO_ARG_SENTINEL,
+                        annotation=AnyValue(AnySource.explicit),
+                    )
+                )
+            sig = Signature.make(
+                typevartuple_params,
+                return_annotation=TypedValue(typevartuple_class),
+                callable=typevartuple_class,
+                impl=_typevartuple_impl,
+                allow_call=False,
                 allow_partial_call=True,
             )
             signatures.append(sig)

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -2987,10 +2987,12 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
         Signature.make(
             [
                 SigParameter(
-                    "value", _POS_ONLY, annotation=TypeVarValue(TypeVarParam(T))
+                    "value",
+                    _POS_ONLY,
+                    annotation=TypeVarValue(TypeVarParam(T, owner=None)),
                 )
             ],
-            return_annotation=TypeVarValue(TypeVarParam(T)),
+            return_annotation=TypeVarValue(TypeVarParam(T, owner=None)),
             impl=_reveal_type_impl,
             callable=reveal_type,
         ),
@@ -3003,10 +3005,12 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
         Signature.make(
             [
                 SigParameter(
-                    "value", _POS_ONLY, annotation=TypeVarValue(TypeVarParam(T))
+                    "value",
+                    _POS_ONLY,
+                    annotation=TypeVarValue(TypeVarParam(T, owner=None)),
                 )
             ],
-            return_annotation=TypeVarValue(TypeVarParam(T)),
+            return_annotation=TypeVarValue(TypeVarParam(T, owner=None)),
             impl=_dump_value_impl,
             callable=dump_value,
         ),
@@ -3282,14 +3286,17 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
                     _POS_ONLY,
                     annotation=GenericValue(
                         dict,
-                        [TypeVarValue(TypeVarParam(K)), TypeVarValue(TypeVarParam(V))],
+                        [
+                            TypeVarValue(TypeVarParam(K, owner=None)),
+                            TypeVarValue(TypeVarParam(V, owner=None)),
+                        ],
                     ),
                 ),
                 SigParameter("k", _POS_ONLY),
             ],
             callable=dict.__getitem__,
             impl=_dict_getitem_impl,
-            return_annotation=TypeVarValue(TypeVarParam(V)),
+            return_annotation=TypeVarValue(TypeVarParam(V, owner=None)),
         ),
         Signature.make(
             [
@@ -3359,7 +3366,10 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
                     _POS_ONLY,
                     annotation=GenericValue(
                         dict,
-                        [TypeVarValue(TypeVarParam(K)), TypeVarValue(TypeVarParam(V))],
+                        [
+                            TypeVarValue(TypeVarParam(K, owner=None)),
+                            TypeVarValue(TypeVarParam(V, owner=None)),
+                        ],
                     ),
                 )
             ],
@@ -3367,8 +3377,8 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
                 dict,
                 [
                     KVPair(
-                        TypeVarValue(TypeVarParam(K)),
-                        TypeVarValue(TypeVarParam(V)),
+                        TypeVarValue(TypeVarParam(K, owner=None)),
+                        TypeVarValue(TypeVarParam(V, owner=None)),
                         is_many=True,
                     )
                 ],
@@ -3450,11 +3460,13 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
         Signature.make(
             [
                 SigParameter(
-                    "val", _POS_ONLY, annotation=TypeVarValue(TypeVarParam(T))
+                    "val",
+                    _POS_ONLY,
+                    annotation=TypeVarValue(TypeVarParam(T, owner=None)),
                 ),
                 SigParameter("typ", _POS_ONLY),
             ],
-            return_annotation=TypeVarValue(TypeVarParam(T)),
+            return_annotation=TypeVarValue(TypeVarParam(T, owner=None)),
             callable=assert_type,
             impl=_assert_type_impl,
         ),
@@ -3769,10 +3781,12 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
             sig = Signature.make(
                 [
                     SigParameter(
-                        "value", _POS_ONLY, annotation=TypeVarValue(TypeVarParam(T))
+                        "value",
+                        _POS_ONLY,
+                        annotation=TypeVarValue(TypeVarParam(T, owner=None)),
                     )
                 ],
-                return_annotation=TypeVarValue(TypeVarParam(T)),
+                return_annotation=TypeVarValue(TypeVarParam(T, owner=None)),
                 impl=_reveal_type_impl,
                 callable=reveal_type_func,
             )
@@ -3785,11 +3799,13 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
             sig = Signature.make(
                 [
                     SigParameter(
-                        "val", _POS_ONLY, annotation=TypeVarValue(TypeVarParam(T))
+                        "val",
+                        _POS_ONLY,
+                        annotation=TypeVarValue(TypeVarParam(T, owner=None)),
                     ),
                     SigParameter("typ", _POS_ONLY),
                 ],
-                return_annotation=TypeVarValue(TypeVarParam(T)),
+                return_annotation=TypeVarValue(TypeVarParam(T, owner=None)),
                 callable=assert_type_func,
                 impl=_assert_type_impl,
             )

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -2251,50 +2251,9 @@ def _assert_type_impl(ctx: CallContext) -> Value:
 def _subclasses_impl(ctx: CallContext) -> Value:
     """Overridden because typeshed types make it (T) => List[T] instead."""
     self_obj = ctx.vars["self"]
-    self_composite = ctx.composite_for_arg("self")
-    if self_composite is not None:
-        self_obj = self_composite.value
     if isinstance(self_obj, KnownValue) and isinstance(self_obj.val, type):
         return KnownValue(self_obj.val.__subclasses__())
-    class_key = _exact_class_key_from_value(self_obj)
-    if class_key is not None:
-        subclasses = _synthetic_direct_subclasses(class_key, ctx)
-        if subclasses is not None:
-            return SequenceValue(list, [(False, subclass) for subclass in subclasses])
     return GenericValue(list, [TypedValue(type)])
-
-
-def _exact_class_key_from_value(value: Value) -> ClassKey | None:
-    value = replace_fallback(value)
-    if isinstance(value, KnownValue) and isinstance(value.val, type):
-        return value.val
-    if isinstance(value, SyntheticClassObjectValue):
-        if value.class_key is not None:
-            return value.class_key
-        if isinstance(value.class_type, TypedValue):
-            return value.class_type.typ
-    return None
-
-
-def _synthetic_direct_subclasses(
-    class_key: ClassKey, ctx: CallContext
-) -> tuple[Value, ...] | None:
-    synthetic_classes = ctx.visitor.checker.synthetic_classes
-    subclasses: list[Value] = []
-    for candidate_key, synthetic_class in synthetic_classes.items():
-        if candidate_key == class_key:
-            continue
-        direct_bases = ctx.visitor.checker.make_type_object(
-            candidate_key
-        ).get_direct_bases()
-        if any(
-            isinstance(base, TypedValue) and base.typ == class_key
-            for base in direct_bases
-        ):
-            subclasses.append(synthetic_class)
-    if not subclasses:
-        return None
-    return tuple(subclasses)
 
 
 def _type_impl(ctx: CallContext) -> Value:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -3684,7 +3684,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                 )
             with legacy_type_param_ctx as allowed_legacy_identities:
-                if is_pep695_generic:
+                if sys.version_info >= (3, 12) and node.type_params:
                     type_param_values = list(
                         self.visit_type_param_values(
                             node.type_params,

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -3663,17 +3663,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             for _, value, _ in decorator_values
         ):
             tobj.set_is_disjoint_base(True)
-        if sys.version_info >= (3, 12) and node.type_params:
+        is_pep695_generic = sys.version_info >= (3, 12) and node.type_params
+
+        if is_pep695_generic:
             ctx = self.scopes.add_scope(
                 ScopeType.annotation_scope, scope_node=node, scope_object=class_obj
             )
         else:
             ctx = contextlib.nullcontext()
-        with ctx:
+        with self.active_type_params.add_scope(class_key), ctx:
             legacy_type_param_ctx: AbstractContextManager[set[object] | None] = (
                 contextlib.nullcontext(None)
             )
-            if self._is_checking() and sys.version_info >= (3, 12) and node.type_params:
+            if self._is_checking() and is_pep695_generic:
                 legacy_type_param_ctx = (
                     self.active_type_params.reject_legacy_type_params(
                         "Class definition cannot combine old-style TypeVar declarations"
@@ -3681,7 +3683,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                 )
             with legacy_type_param_ctx as allowed_legacy_identities:
-                if sys.version_info >= (3, 12) and node.type_params:
+                if is_pep695_generic:
                     declared_type_param_nodes = node.type_params
                     type_param_values = list(
                         self.visit_type_param_values(
@@ -3709,7 +3711,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 )
                 self._check_type_parameter_base_argument_validity(node, base_values)
                 self._check_type_parameter_base_coverage(node, base_values)
-                if sys.version_info >= (3, 12) and declared_type_param_nodes:
+                if is_pep695_generic:
                     self._check_pep695_type_parameter_base_compatibility(
                         node, base_values
                     )

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -567,6 +567,39 @@ if asynq is not None:
     SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL.append(KnownValue(asynq.asynq))
 
 
+def _callable_from_signature(sig: MaybeSignature) -> object | None:
+    if isinstance(sig, Signature):
+        if isinstance(sig.callable, types.FunctionType) and sig.callable.__name__ in {
+            "__init__",
+            "__new__",
+            "__get__",
+            "__set__",
+            "__delete__",
+            "__call__",
+        }:
+            return None
+        return sig.callable
+    if isinstance(sig, BoundMethodSignature):
+        return _callable_from_signature(sig.signature)
+    if isinstance(sig, OverloadedSignature):
+        callables = {
+            subsig.callable for subsig in sig.signatures if subsig.callable is not None
+        }
+        if len(callables) == 1:
+            return next(iter(callables))
+    return None
+
+
+def _has_bound_receiver(sig: MaybeSignature) -> bool:
+    if isinstance(sig, Signature):
+        return sig.bound_receiver_param_name is not None
+    if isinstance(sig, BoundMethodSignature):
+        return True
+    if isinstance(sig, OverloadedSignature):
+        return all(_has_bound_receiver(subsig) for subsig in sig.signatures)
+    return False
+
+
 class _AsyncGeneratorDetector(ast.NodeVisitor):
     """Detect whether an async function body contains a yield."""
 
@@ -1786,6 +1819,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     """Path (relative to this class's file) to a pyproject.toml config file."""
 
     _argspec_to_retval: dict[int, tuple[Value, MaybeSignature]]
+    _callable_to_retval: dict[int, tuple[Value, object]]
     _pending_overload_blocks: dict[int, _PendingOverloadBlock]
     _function_decorator_kinds_by_node: dict[
         ast.FunctionDef | ast.AsyncFunctionDef, frozenset[FunctionDecorator]
@@ -1958,6 +1992,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         # infer types. Previously, we cached this globally, but that makes things non-
         # deterministic because we'll start depending on the order modules are checked.
         self._argspec_to_retval = {}
+        self._callable_to_retval = {}
         self._pending_overload_blocks = {}
         self._function_decorator_kinds_by_node = {}
         self._function_returns_self_by_node = {}
@@ -1973,7 +2008,14 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def get_local_return_value(self, sig: MaybeSignature) -> Value | None:
         val, saved_sig = self._argspec_to_retval.get(id(sig), (None, None))
         if sig is not saved_sig:
-            return None
+            callable_obj = _callable_from_signature(sig)
+            if callable_obj is None:
+                return None
+            val, saved_callable = self._callable_to_retval.get(
+                id(callable_obj), (None, None)
+            )
+            if callable_obj is not saved_callable:
+                return None
         return val
 
     @property
@@ -2176,6 +2218,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         # This is intentionally unsafe.
         self.tree = None  # static analysis: ignore[incompatible_assignment]
         self._argspec_to_retval.clear()
+        self._callable_to_retval.clear()
         end_time = time.time()
         message = f"{self.filename} took {end_time - start_time:.2f} s"
         self.logger.log(logging.INFO, message)
@@ -4364,10 +4407,28 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return all(
                 self._is_typeddict_generic_base(subval) for subval in base_value.vals
             )
+        if (
+            isinstance(base_value, PartialValue)
+            and base_value.operation is PartialValueOperation.SUBSCRIPT
+        ):
+            return self._is_typeddict_generic_base_root(base_value.root)
+        if isinstance(base_value, TypeAliasValue):
+            return self._is_typeddict_generic_base(base_value.get_value())
+        if isinstance(base_value, GenericValue):
+            return is_typing_name(base_value.typ, "Generic") and bool(base_value.args)
         if isinstance(base_value, KnownValue):
             origin = safe_getattr(base_value.val, "__origin__", None)
             return origin is not None and is_typing_name(origin, "Generic")
         return False
+
+    def _is_typeddict_generic_base_root(self, base_value: Value) -> bool:
+        if isinstance(base_value, TypeAliasValue):
+            return self._is_typeddict_generic_base_root(base_value.get_value())
+        if isinstance(base_value, GenericValue):
+            return is_typing_name(base_value.typ, "Generic")
+        return isinstance(base_value, KnownValue) and is_typing_name(
+            base_value.val, "Generic"
+        )
 
     def _is_namedtuple_generic_base(self, base_value: Value) -> bool:
         if isinstance(base_value, MultiValuedValue):
@@ -8351,6 +8412,13 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def _set_argspec_to_retval(
         self, val: Value, info: FunctionInfo, result: FunctionResult
     ) -> None:
+        def is_safe_decorator(decorator: Value) -> bool:
+            if decorator in SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL:
+                return True
+            return isinstance(decorator, KnownValue) and AsynqDecorators.contains(
+                decorator.val, self.options
+            )
+
         if isinstance(info.node, ast.Lambda) or info.node.returns is not None:
             return
         if info.async_kind == AsyncFunctionKind.async_proxy:
@@ -8362,7 +8430,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             if len(info.decorators) != 1:
                 return  # With decorators we don't know what it will return
             unapplied_decorator, _, _ = next(iter(info.decorators))
-            if unapplied_decorator not in SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL:
+            if not is_safe_decorator(unapplied_decorator):
                 return  # With decorators we don't know what it will return
         return_value = result.return_value
 
@@ -8390,6 +8458,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if sig is None or sig.has_return_value():
             return
         self._argspec_to_retval[id(sig)] = (return_value, sig)
+        callable_obj = _callable_from_signature(sig)
+        if callable_obj is not None:
+            self._callable_to_retval[id(callable_obj)] = (return_value, callable_obj)
 
     def _get_potential_function(self, node: FunctionDefNode) -> object | None:
         scope_type = self.scopes.scope_type()
@@ -8520,6 +8591,16 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             scope = self.scopes.current_scope()
             assert isinstance(scope, FunctionScope)
 
+            def value_for_param_scope(param: SigParameter) -> Value:
+                if param.kind is not ParameterKind.VAR_POSITIONAL:
+                    return param.annotation
+                annotation = param.annotation
+                if isinstance(annotation, TypeVarTupleBindingValue):
+                    return SequenceValue(tuple, list(annotation.binding))
+                if isinstance(annotation, TypeVarTupleValue):
+                    return SequenceValue(tuple, [(True, annotation)])
+                return param.annotation
+
             for info in infos:
                 scope.set_declared_type(
                     info.param.name, info.param.annotation, False, info.node
@@ -8534,7 +8615,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                 self.scopes.set(
                     info.param.name,
-                    info.param.annotation,
+                    value_for_param_scope(info.param),
                     info.node,
                     VisitorState.check_names,
                 )
@@ -8972,7 +9053,18 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                 return True
             return self.check_deprecation(node, value.value)
-        if isinstance(value, InputSigValue):
+        if isinstance(
+            value,
+            (
+                InputSigValue,
+                PartialCallValue,
+                TypeVarTupleBindingValue,
+                TypeVarTupleValue,
+                TypeVarValue,
+                ParamSpecArgsValue,
+                ParamSpecKwargsValue,
+            ),
+        ):
             return False
         value = replace_fallback(value)
         if isinstance(value, UnboundMethodValue):
@@ -11715,6 +11807,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if has_unpack:
             return
 
+    def _implicit_type_form_error(self, node: ast.expr, value: Value) -> str | None:
+        if _contains_unpack_annotation_syntax(node):
+            return f"{value} is not a TypeForm"
+        for subnode in ast.walk(node):
+            if not isinstance(subnode, (ast.Name, ast.Attribute)):
+                continue
+            type_param = _type_param_value_from_value(
+                self.composite_from_node(subnode).value, self
+            )
+            if type_param is not None and type_param.owner is None:
+                return f"{value} is not a TypeForm"
+        return None
+
     def is_in_typeddict_definition(self) -> bool:
         return (
             is_instance_of_typing_name(self.current_class, "_TypedDictMeta")
@@ -12068,10 +12173,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                                 specialized_converter_input_type
                             )
 
-                    if not (is_current_class_dataclass and field_options is not None):
-                        can_assign = has_relation(
-                            expected_type, value, Relation.ASSIGNABLE, self
+                    implicit_type_form_error = None
+                    if isinstance(expected_type, TypeFormValue):
+                        implicit_type_form_error = self._implicit_type_form_error(
+                            node.value, value
                         )
+                    if not (is_current_class_dataclass and field_options is not None):
+                        can_assign: CanAssign | CanAssignError
+                        if implicit_type_form_error is not None:
+                            can_assign = CanAssignError(implicit_type_form_error)
+                        else:
+                            can_assign = has_relation(
+                                expected_type, value, Relation.ASSIGNABLE, self
+                            )
                         if isinstance(can_assign, CanAssignError):
                             self._show_error_if_checking(
                                 node,
@@ -13532,14 +13646,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         else:
                             with self.catch_errors():
                                 getitem = self._get_dunder(
-                                    node.value, stripped_root.value, "__getitem__"
+                                    node.value, stripped_root, "__getitem__"
                                 )
                             if getitem is not UNINITIALIZED_VALUE:
+                                resolved_getitem = replace_fallback(getitem)
+                                if (
+                                    isinstance(resolved_getitem, KnownValue)
+                                    and safe_getattr(
+                                        resolved_getitem.val, "__self__", None
+                                    )
+                                    is not None
+                                ) or isinstance(getitem, UnboundMethodValue):
+                                    call_args = [index_composite]
+                                else:
+                                    call_args = [stripped_root, index_composite]
                                 return_value = self.check_call(
-                                    node.value,
-                                    getitem,
-                                    [stripped_root, index_composite],
-                                    allow_call=True,
+                                    node.value, getitem, call_args, allow_call=True
                                 )
                             else:
                                 # If there was no __getitem__, try __class_getitem__ in 3.7+
@@ -13799,8 +13921,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         return None
 
     def _get_dunder(
-        self, node: ast.AST | None, callee_val: Value, method_name: str
+        self, node: ast.AST | None, callee: Composite | Value, method_name: str
     ) -> Value:
+        callee_composite = (
+            callee if isinstance(callee, Composite) else Composite(callee)
+        )
+        callee_val = callee_composite.value
         synthetic_lookup_val = callee_val
         resolved_self_value = callee_val
         if (
@@ -13854,7 +13980,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     return method_object
 
         method_object = self.get_attribute(
-            Composite(fallback_lookup_val),
+            Composite(
+                fallback_lookup_val, callee_composite.varname, callee_composite.node
+            ),
             method_name,
             node,
             ignore_none=self.options.get_value_for(IgnoreNoneAttributes),
@@ -13964,7 +14092,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 stripped_value, callee_composite.varname, callee_composite.node
             )
         )
-        method_object = self._get_dunder(node, stripped_callee.value, method_name)
+        method_object = self._get_dunder(node, stripped_callee, method_name)
         if method_object is UNINITIALIZED_VALUE:
             return AnyValue(AnySource.error), False
         with override(self, "caught_errors", None):
@@ -13972,11 +14100,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         resolved_method = replace_fallback(method_object)
         call_args: list[Composite]
         if (
-            isinstance(resolved_method, KnownValue)
-            and safe_getattr(resolved_method.val, "__self__", None) is not None
-        ) or (
-            isinstance(stripped_callee.value, KnownValueWithTypeVars)
-            and not isinstance(method_object, UnboundMethodValue)
+            (
+                isinstance(resolved_method, KnownValue)
+                and safe_getattr(resolved_method.val, "__self__", None) is not None
+            )
+            or (
+                isinstance(stripped_callee.value, KnownValueWithTypeVars)
+                and not isinstance(method_object, UnboundMethodValue)
+            )
+            or isinstance(method_object, UnboundMethodValue)
+            or (
+                isinstance(method_object, CallableValue)
+                and _has_bound_receiver(method_object.signature)
+            )
         ):
             call_args = list(args)
         else:
@@ -14722,6 +14858,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
         """
         resolved_self_value = self_value
+        is_special_lookup = (
+            self_value is not None and attr.startswith("__") and attr.endswith("__")
+        )
         if (
             isinstance(root_composite.value, PartialValue)
             and root_composite.value.operation is PartialValueOperation.SUBSCRIPT
@@ -14757,7 +14896,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             )
             if static_member is not UNINITIALIZED_VALUE:
                 return static_member
-        if self._is_instance_member_accessed_through_class(root_composite, attr, node):
+        if not is_special_lookup and self._is_instance_member_accessed_through_class(
+            root_composite, attr, node
+        ):
             if node is not None:
                 self._show_error_if_checking(
                     node,

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -125,6 +125,7 @@ from .functions import (
     FunctionNode,
     FunctionResult,
     GeneratorValue,
+    ParamInfo,
     ReturnParam,
     SendParam,
     YieldParam,
@@ -243,6 +244,11 @@ from .type_object import (
     lookup_declared_symbol_with_owner,
     typevar_map_from_generic_args,
 )
+from .type_params import (
+    ActiveTypeParams,
+    _compose_observed_variance_polarity,
+    _record_variance_polarity,
+)
 from .typeshed import TypeshedFinder
 from .value import (
     NO_RETURN_VALUE,
@@ -273,6 +279,7 @@ from .value import (
     DefiniteValueExtension,
     DeprecatedExtension,
     DictIncompleteValue,
+    FunctionOwner,
     GenericBases,
     GenericValue,
     IntersectionValue,
@@ -283,6 +290,8 @@ from .value import (
     NewTypeValue,
     NoReturnConstraintExtension,
     OverlapMode,
+    ParamSpecArgsValue,
+    ParamSpecKwargsValue,
     ParamSpecParam,
     PartialCallValue,
     PartialValue,
@@ -310,6 +319,7 @@ from .value import (
     TypeParam,
     TypeVarMap,
     TypeVarParam,
+    TypeVarTupleBindingValue,
     TypeVarTupleParam,
     TypeVarTupleValue,
     TypeVarValue,
@@ -343,21 +353,13 @@ from .value import (
     unite_and_simplify,
     unite_values,
     unpack_values,
+    with_type_param_owner,
 )
 from .yield_checker import YieldChecker
 
 _UNSET = object()
 
 _AST_TYPE_ALIAS = getattr(ast, "TypeAlias", None)
-_TYPE_PARAM_AST_NODE_TYPES = tuple(
-    typ
-    for typ in (
-        safe_getattr(ast, "TypeVar", None),
-        safe_getattr(ast, "ParamSpec", None),
-        safe_getattr(ast, "TypeVarTuple", None),
-    )
-    if isinstance(typ, type)
-)
 
 _TValueResult = TypeVar("_TValueResult")
 
@@ -389,7 +391,7 @@ def _consistent_value_result(
 ) -> _TValueResult | None:
     value = replace_fallback(value)
     if isinstance(value, (MultiValuedValue, IntersectionValue)):
-        results: list[_TValueResult | None] = []
+        results: list[object | None] = []
         for subval in value.vals:
             result = _consistent_value_result(
                 subval, evaluator, ignore_none=ignore_none
@@ -399,7 +401,7 @@ def _consistent_value_result(
             if not any(existing == result for existing in results):
                 results.append(result)
         if len(results) == 1:
-            return results[0]
+            return typing.cast("_TValueResult | None", results[0])
         return None
     return evaluator(value)
 
@@ -1754,365 +1756,10 @@ class _DataclassFieldCallOptions:
     converter_input_type: Value | None = None
 
 
-@dataclass
-class _LegacyTypeParamPolicy:
-    allowed_identities: set[object]
-    message: str
-    error_code: Error = ErrorCode.invalid_annotation
-    report_in_collecting: bool = True
-    triggered: bool = False
-
-
-@dataclass
-class _VarianceCollectionContext:
-    type_param_polarities: dict[object, set[int]]
-    polarity: int
-
-
 @dataclass(frozen=True)
 class _BaseTypeParamVarianceInfo:
     type_param_polarities: dict[object, set[int]]
     is_variance_declaration_base: bool
-
-
-class ActiveTypeParams:
-    def __init__(self, visitor: "NameCheckVisitor") -> None:
-        self.visitor = visitor
-        self._annotation_allowed_identities: list[set[object]] = []
-        self._active_pep695_identities: list[set[object]] = []
-        self._current_class_type_params: Sequence[TypeParam] | None = None
-        self._disallowed_identities: list[set[object]] = []
-        self._legacy_policies: list[_LegacyTypeParamPolicy] = []
-        self._variance_collections: list[_VarianceCollectionContext] = []
-        self._current_class_type_param_polarities: dict[object, set[int]] | None = None
-        self._current_is_protocol_class: bool = False
-        self._variance_polarity_stack: list[int] = []
-        self._variance_is_suspended = 0
-        self._variance_outside_annotations = 0
-        self._subscript_arg_polarities: list[tuple[tuple[int, bool], ...]] = []
-
-    def current_annotation_identities(self) -> set[object]:
-        identities: set[object] = set()
-        for allowed in self._annotation_allowed_identities:
-            identities.update(allowed)
-        for allowed in self._active_pep695_identities:
-            identities.update(allowed)
-        return identities
-
-    def current_pep695_identities(self) -> set[object]:
-        identities: set[object] = set()
-        for allowed in self._active_pep695_identities:
-            identities.update(allowed)
-        return identities
-
-    def current_class_type_params(self) -> Sequence[TypeParam] | None:
-        return self._current_class_type_params
-
-    @contextlib.contextmanager
-    def allow_in_annotations(self, identities: Iterable[object]) -> Generator[None]:
-        identities = set(identities)
-        if not identities:
-            yield
-            return
-        self._annotation_allowed_identities.append(identities)
-        try:
-            yield
-        finally:
-            self._annotation_allowed_identities.pop()
-
-    @contextlib.contextmanager
-    def push_pep695_scope(self, type_params: Sequence[TypeParam]) -> Generator[None]:
-        identities = {type_param.typevar for type_param in type_params}
-        if not identities:
-            yield
-            return
-        self._active_pep695_identities.append(identities)
-        try:
-            yield
-        finally:
-            self._active_pep695_identities.pop()
-
-    @contextlib.contextmanager
-    def push_class_type_params(
-        self, type_params: Sequence[TypeParam] | None
-    ) -> Generator[None]:
-        with override(self, "_current_class_type_params", type_params):
-            yield
-
-    @contextlib.contextmanager
-    def disallow(self, identities: Iterable[object]) -> Generator[None]:
-        identities = set(identities)
-        if not identities:
-            yield
-            return
-        self._disallowed_identities.append(identities)
-        try:
-            yield
-        finally:
-            self._disallowed_identities.pop()
-
-    @contextlib.contextmanager
-    def reject_legacy_type_params(
-        self,
-        message: str,
-        *,
-        error_code: Error = ErrorCode.invalid_annotation,
-        include_active_pep695: bool = True,
-        report_in_collecting: bool = True,
-    ) -> Generator[set[object]]:
-        allowed_identities = (
-            self.current_pep695_identities() if include_active_pep695 else set()
-        )
-        policy = _LegacyTypeParamPolicy(
-            allowed_identities,
-            message,
-            error_code=error_code,
-            report_in_collecting=report_in_collecting,
-        )
-        self._legacy_policies.append(policy)
-        try:
-            yield allowed_identities
-        finally:
-            self._legacy_policies.pop()
-
-    @contextlib.contextmanager
-    def collect_variance(
-        self, type_param_polarities: dict[object, set[int]], *, polarity: int
-    ) -> Generator[None]:
-        self._variance_collections.append(
-            _VarianceCollectionContext(type_param_polarities, polarity)
-        )
-        try:
-            yield
-        finally:
-            self._variance_collections.pop()
-
-    @contextlib.contextmanager
-    def compose_variance(self, polarity: int) -> Generator[None]:
-        self._variance_polarity_stack.append(polarity)
-        try:
-            yield
-        finally:
-            self._variance_polarity_stack.pop()
-
-    @contextlib.contextmanager
-    def suspend_variance(self) -> Generator[None]:
-        self._variance_is_suspended += 1
-        try:
-            yield
-        finally:
-            self._variance_is_suspended -= 1
-
-    @contextlib.contextmanager
-    def allow_variance_outside_annotations(self) -> Generator[None]:
-        self._variance_outside_annotations += 1
-        try:
-            yield
-        finally:
-            self._variance_outside_annotations -= 1
-
-    def has_variance_collection(self) -> bool:
-        return bool(self._variance_collections) and not self._variance_is_suspended
-
-    def current_class_type_param_polarities(self) -> dict[object, set[int]] | None:
-        return self._current_class_type_param_polarities
-
-    def current_variance_polarity(self, base_polarity: int) -> int:
-        polarity = base_polarity
-        for modifier in self._variance_polarity_stack:
-            polarity = _compose_observed_variance_polarity(polarity, modifier)
-        return polarity
-
-    @contextlib.contextmanager
-    def push_class_type_param_variance_collection(
-        self,
-        type_param_polarities: dict[object, set[int]] | None,
-        *,
-        is_protocol_class: bool,
-    ) -> Generator[None]:
-        with (
-            override(
-                self, "_current_class_type_param_polarities", type_param_polarities
-            ),
-            override(self, "_current_is_protocol_class", is_protocol_class),
-        ):
-            yield
-
-    @contextlib.contextmanager
-    def suspend_class_type_param_variance_collection(self) -> Generator[None]:
-        if self._current_class_type_param_polarities is None:
-            yield
-            return
-        with override(self, "_current_class_type_param_polarities", None):
-            yield
-
-    def function_param_type_param_variance_context(
-        self, *, parameter_index: int, is_staticmethod: bool
-    ) -> AbstractContextManager[None]:
-        if self._current_class_type_param_polarities is None:
-            return contextlib.nullcontext()
-        if (
-            self._current_is_protocol_class
-            and parameter_index == 0
-            and not is_staticmethod
-        ):
-            return self.suspend_variance()
-        return self.local_class_type_param_variance_context(polarity=-1)
-
-    def function_return_type_param_variance_context(
-        self,
-    ) -> AbstractContextManager[None]:
-        if self._current_class_type_param_polarities is None:
-            return contextlib.nullcontext()
-        return self.local_class_type_param_variance_context(polarity=1)
-
-    @contextlib.contextmanager
-    def local_class_type_param_variance_context(
-        self, *, polarity: int
-    ) -> Generator[None]:
-        target = self._current_class_type_param_polarities
-        if target is None:
-            yield
-            return
-        local_polarities: dict[object, set[int]] = {}
-        with (
-            self.collect_variance(local_polarities, polarity=1),
-            self.compose_variance(polarity),
-        ):
-            yield
-        self.visitor._merge_type_param_polarities(target, local_polarities, polarity=1)
-
-    @contextlib.contextmanager
-    def push_subscript_arg_polarities(
-        self, polarities: Sequence[tuple[int, bool]]
-    ) -> Generator[None]:
-        self._subscript_arg_polarities.append(tuple(polarities))
-        try:
-            yield
-        finally:
-            self._subscript_arg_polarities.pop()
-
-    @contextlib.contextmanager
-    def consume_subscript_arg_polarities(
-        self, arity: int
-    ) -> Generator[tuple[tuple[int, bool], ...] | None]:
-        polarities = (
-            self._subscript_arg_polarities.pop()
-            if self._subscript_arg_polarities
-            and len(self._subscript_arg_polarities[-1]) == arity
-            else None
-        )
-        try:
-            yield polarities
-        finally:
-            if polarities is not None:
-                self._subscript_arg_polarities.append(polarities)
-
-    def observe_value(self, node: ast.AST, value: Value) -> None:
-        if not (
-            self._legacy_policies
-            or self._disallowed_identities
-            or self.visitor.in_annotation
-            or self._variance_collections
-        ):
-            return
-        if self._variance_is_suspended and not (
-            self._legacy_policies or self._disallowed_identities
-        ):
-            return
-        if _is_type_param_declaration_node(node):
-            return
-
-        type_param = _type_param_value_from_value(value, self.visitor)
-        if type_param is not None:
-            self._check_direct_type_param_usage(node, type_param)
-            if (
-                isinstance(type_param, TypeVarParam)
-                and self._variance_collections
-                and not self._variance_is_suspended
-                and (
-                    self.visitor.in_annotation or self._variance_outside_annotations > 0
-                )
-            ):
-                for context in self._variance_collections:
-                    used_polarities = context.type_param_polarities.get(
-                        type_param.typevar
-                    )
-                    if used_polarities is None:
-                        used_polarities = context.type_param_polarities.setdefault(
-                            type_param.typevar, set()
-                        )
-                    _record_variance_polarity(
-                        used_polarities,
-                        self.current_variance_polarity(context.polarity),
-                    )
-
-    def _show_error(
-        self,
-        node: ast.AST,
-        message: str,
-        *,
-        error_code: Error,
-        report_in_collecting: bool,
-    ) -> None:
-        if report_in_collecting and self.visitor._is_collecting():
-            self.visitor.show_error(node, message, error_code=error_code)
-        else:
-            self.visitor._show_error_if_checking(node, message, error_code=error_code)
-
-    def _check_direct_type_param_usage(
-        self, error_node: ast.AST, type_param: TypeParam
-    ) -> None:
-        identity = type_param.typevar
-        narrowed_error_node = self._narrow_type_param_error_node(error_node, identity)
-        if narrowed_error_node is not error_node:
-            return
-        for policy in self._legacy_policies:
-            if policy.triggered:
-                continue
-            if identity in policy.allowed_identities:
-                continue
-            policy.triggered = True
-            self._show_error(
-                narrowed_error_node,
-                policy.message,
-                error_code=policy.error_code,
-                report_in_collecting=policy.report_in_collecting,
-            )
-            break
-
-        if not isinstance(type_param, TypeVarParam) or type_param.is_self:
-            return
-        if any(identity in disallowed for disallowed in self._disallowed_identities):
-            self.visitor._show_error_if_checking(
-                narrowed_error_node,
-                "Type parameter is not valid in this annotation context",
-                error_code=ErrorCode.invalid_annotation,
-            )
-            return
-        if self.visitor.in_type_alias_definition or not self.visitor.in_annotation:
-            return
-        if identity in self.current_annotation_identities():
-            return
-        self.visitor._show_error_if_checking(
-            narrowed_error_node,
-            "Type parameter is not valid in this annotation context",
-            error_code=ErrorCode.invalid_annotation,
-        )
-
-    # TODO: this is silly, find a better solution to prevent duplicate errors
-    def _narrow_type_param_error_node(self, node: ast.AST, identity: object) -> ast.AST:
-        if isinstance(node, ast.Name):
-            return node
-        for subnode in ast.walk(node):
-            if not isinstance(subnode, ast.Name):
-                continue
-            resolved, _ = self.visitor.resolve_name(
-                subnode, error_node=subnode, suppress_errors=True
-            )
-            if _type_param_identity(resolved, self.visitor) is identity:
-                return subnode
-        return node
 
 
 @used  # exposed as an API
@@ -2740,6 +2387,20 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     ):
                         current_scope.variables[varname] = value
                         return value, EMPTY_ORIGIN
+                    if isinstance(existing, KnownValue) and isinstance(
+                        value, PartialCallValue
+                    ):
+                        if (
+                            is_typing_object(existing, "TypeVar")
+                            or is_typing_object(existing, "ParamSpec")
+                            or is_typing_object(existing, "TypeVarTuple")
+                        ) and (
+                            is_typing_object(value, "TypeVar")
+                            or is_typing_object(value, "ParamSpec")
+                            or is_typing_object(value, "TypeVarTuple")
+                        ):
+                            current_scope.variables[varname] = value
+                            return value, EMPTY_ORIGIN
                     if isinstance(existing, TypeAliasValue) and not isinstance(
                         value, TypeAliasValue
                     ):
@@ -3796,9 +3457,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return AnyValue(AnySource.error), origin
         self.active_type_params.observe_value(error_node, value)
         assert not isinstance(value, (TypeVarParam, ParamSpecParam, TypeVarTupleParam))
-        if isinstance(value, InputSigValue):
+        if isinstance(value, (InputSigValue, TypeVarTupleBindingValue)):
             # ParamSpecs are stored as InputSigValues and cannot be converted to a
-            # gradual fallback.
+            # gradual fallback. TypeVarTuple bindings also are not gradual values.
             value_for_subvals = value
         else:
             value_for_subvals = replace_fallback(value)
@@ -4229,13 +3890,48 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         node.bases, effective_type_param_values
                     )
                 )
-            registered_type_param_values = effective_type_param_values
+            raw_registered_type_param_values = tuple(effective_type_param_values)
+            registered_type_param_values = raw_registered_type_param_values
             if not type_param_values:
                 registered_type_param_values = (
                     self._align_type_params_with_runtime_class(
                         runtime_class_for_type_params, registered_type_param_values
                     )
                 )
+            prebound_registered_type_param_values = tuple(registered_type_param_values)
+            registered_type_param_values = self._bind_type_param_owners(
+                registered_type_param_values, generic_class_key
+            )
+            raw_registered_type_param_replacements = {
+                candidate.typevar: registered_type_param
+                for raw_type_param, prebound_type_param, registered_type_param in zip(
+                    raw_registered_type_param_values,
+                    prebound_registered_type_param_values,
+                    registered_type_param_values,
+                )
+                for candidate in (raw_type_param, prebound_type_param)
+            }
+            registered_type_param_values = tuple(
+                self._normalize_type_param_identities_in_type_param(
+                    type_param, raw_registered_type_param_replacements
+                )
+                for type_param in registered_type_param_values
+            )
+            type_param_alias_identities: list[set[object]] = []
+            raw_type_params_by_identity: dict[object, TypeParam] = {}
+            for raw_type_param, prebound_type_param, registered_type_param in zip(
+                raw_registered_type_param_values,
+                prebound_registered_type_param_values,
+                registered_type_param_values,
+            ):
+                aliases: set[object] = set()
+                for candidate in (raw_type_param, prebound_type_param):
+                    if candidate.typevar is not registered_type_param.typevar:
+                        aliases.add(candidate.typevar)
+                    raw_type_params_by_identity[candidate.typevar] = (
+                        registered_type_param
+                    )
+                type_param_alias_identities.append(aliases)
             if registered_type_param_values:
                 tobj.set_declared_type_params(tuple(registered_type_param_values))
             else:
@@ -4256,6 +3952,13 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 base_values_for_registration = list(
                     self._base_values_for_generic_analysis(node, base_values)
                 )
+            if raw_type_params_by_identity:
+                base_values_for_registration = [
+                    self._normalize_type_param_identities_in_value(
+                        base, raw_type_params_by_identity
+                    )
+                    for base in base_values_for_registration
+                ]
             if should_register_generic_bases:
                 self.checker.register_synthetic_type_bases(
                     generic_class_key,
@@ -4264,11 +3967,16 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 )
             if isinstance(class_scope_object, type):
                 self._record_class_body_attributes(node, class_scope_object)
-            class_annotation_identities = {
+            class_annotation_identities: set[object] = {
                 type_param.typevar for type_param in class_scope_type_params
             }
+            for alias_identities in type_param_alias_identities:
+                class_annotation_identities.update(alias_identities)
             with (
-                self.active_type_params.push_pep695_scope(class_scope_type_params),
+                self.active_type_params.push_pep695_scope(
+                    class_scope_type_params,
+                    additional_identities=type_param_alias_identities,
+                ),
                 self.active_type_params.allow_in_annotations(
                     class_annotation_identities
                 ),
@@ -4321,11 +4029,25 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     if type_param_values
                     else effective_type_param_values
                 )
+                if raw_registered_type_param_replacements:
+                    declared_type_params = tuple(
+                        self._normalize_type_param_identities_in_type_param(
+                            type_param, raw_registered_type_param_replacements
+                        )
+                        for type_param in declared_type_params
+                    )
                 annotation_declared_type_params = (
                     self._type_params_from_base_annotations_for_default_rules(
                         node.bases
                     )
                 )
+                if raw_registered_type_param_replacements:
+                    annotation_declared_type_params = tuple(
+                        self._normalize_type_param_identities_in_type_param(
+                            type_param, raw_registered_type_param_replacements
+                        )
+                        for type_param in annotation_declared_type_params
+                    )
                 if annotation_declared_type_params:
                     declared_type_params = (
                         self._merge_type_params_using_declared_identities(
@@ -4652,9 +4374,18 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return all(
                 self._is_namedtuple_generic_base(subval) for subval in base_value.vals
             )
+        if (
+            isinstance(base_value, PartialValue)
+            and base_value.operation is PartialValueOperation.SUBSCRIPT
+        ):
+            return self._is_namedtuple_generic_base(base_value.root)
+        if isinstance(base_value, TypeAliasValue):
+            return self._is_namedtuple_generic_base(base_value.get_value())
         if isinstance(base_value, GenericValue):
             return is_typing_name(base_value.typ, "Generic")
         if isinstance(base_value, KnownValue):
+            if is_typing_name(base_value.val, "Generic"):
+                return True
             origin = safe_getattr(base_value.val, "__origin__", None)
             return origin is not None and is_typing_name(origin, "Generic")
         return False
@@ -5760,6 +5491,29 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return
         if not type_params:
             return
+        if isinstance(class_scope_object, (type, ClassOwner)):
+            canonical_type_params = tuple(
+                self.checker.get_type_parameters(class_scope_object)
+            )
+            if len(canonical_type_params) == len(type_params):
+                rebound_type_params: list[TypeParam] = []
+                for declared_type_param, canonical_type_param in zip(
+                    type_params, canonical_type_params
+                ):
+                    if isinstance(declared_type_param, TypeVarParam) and isinstance(
+                        canonical_type_param, TypeVarParam
+                    ):
+                        rebound_type_params.append(
+                            replace(
+                                canonical_type_param,
+                                variance=declared_type_param.variance,
+                            )
+                        )
+                    elif type(declared_type_param) is type(canonical_type_param):
+                        rebound_type_params.append(canonical_type_param)
+                    else:
+                        rebound_type_params.append(declared_type_param)
+                type_params = tuple(rebound_type_params)
         checked_type_params = [
             type_param
             for type_param in type_params
@@ -5847,8 +5601,37 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if class_obj is None:
             return type_params
         runtime_type_params = safe_getattr(class_obj, "__type_params__", ())
+        if not runtime_type_params:
+            runtime_type_params = safe_getattr(class_obj, "__parameters__", ())
+        if not isinstance(runtime_type_params, (tuple, list)):
+            return type_params
         if len(runtime_type_params) != len(type_params):
             return type_params
+        remaining_runtime_type_params = list(runtime_type_params)
+        aligned = []
+        for type_param in type_params:
+            matched_index = next(
+                (
+                    i
+                    for i, runtime_type_param in enumerate(
+                        remaining_runtime_type_params
+                    )
+                    if self._runtime_type_param_matches(type_param, runtime_type_param)
+                ),
+                None,
+            )
+            if matched_index is None:
+                aligned = []
+                break
+            runtime_type_param = remaining_runtime_type_params.pop(matched_index)
+            if isinstance(type_param, TypeVarParam):
+                aligned.append(replace(type_param, typevar=runtime_type_param))
+            elif isinstance(type_param, ParamSpecParam):
+                aligned.append(replace(type_param, param_spec=runtime_type_param))
+            else:
+                aligned.append(replace(type_param, typevar_tuple=runtime_type_param))
+        if aligned and not remaining_runtime_type_params:
+            return aligned
         aligned = []
         for type_param, runtime_type_param in zip(type_params, runtime_type_params):
             if isinstance(type_param, TypeVarParam):
@@ -5858,6 +5641,27 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             else:
                 aligned.append(replace(type_param, typevar_tuple=runtime_type_param))
         return aligned
+
+    def _runtime_type_param_matches(
+        self, type_param: TypeParam, runtime_type_param: object
+    ) -> bool:
+        if isinstance(type_param, TypeVarParam):
+            if not is_instance_of_typing_name(runtime_type_param, "TypeVar"):
+                return False
+        elif isinstance(type_param, ParamSpecParam):
+            if not is_instance_of_typing_name(runtime_type_param, "ParamSpec"):
+                return False
+        else:
+            if not is_instance_of_typing_name(runtime_type_param, "TypeVarTuple"):
+                return False
+        if (
+            runtime_type_param is type_param.typevar
+            or runtime_type_param == type_param.typevar
+        ):
+            return True
+        return safe_getattr(runtime_type_param, "__name__", None) == safe_getattr(
+            type_param.typevar, "__name__", None
+        )
 
     def _merge_type_params_using_declared_identities(
         self,
@@ -5883,6 +5687,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     replace(
                         ordered_type_param,
                         typevar=declared.typevar,
+                        owner=declared.owner,
                         variance=declared.variance,
                     )
                 )
@@ -5924,6 +5729,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         seen_default = False
         previous_was_typevartuple = False
         visible_type_params: set[object] = set()
+        visible_type_param_names: set[tuple[type[TypeParam], str]] = set()
         for type_param in type_params:
             has_default = type_param.default is not None
             is_typevartuple = isinstance(type_param, TypeVarTupleParam)
@@ -5932,6 +5738,21 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 for subval in type_param.default.walk_values():
                     identity = _type_param_identity(subval, self)
                     if identity is None or identity in visible_type_params:
+                        continue
+                    referenced_type_param = self.get_type_param_from_value(subval)
+                    referenced_name = (
+                        None
+                        if referenced_type_param is None
+                        else safe_getattr(
+                            referenced_type_param.typevar, "__name__", None
+                        )
+                    )
+                    if (
+                        isinstance(referenced_name, str)
+                        and referenced_type_param is not None
+                        and (type(referenced_type_param), referenced_name)
+                        in visible_type_param_names
+                    ):
                         continue
                     self._show_error_if_checking(
                         node,
@@ -5957,6 +5778,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             seen_default = seen_default or has_default
             previous_was_typevartuple = is_typevartuple
             visible_type_params.add(type_param.typevar)
+            type_param_name = safe_getattr(type_param.typevar, "__name__", None)
+            if isinstance(type_param_name, str):
+                visible_type_param_names.add((type(type_param), type_param_name))
 
     def _type_param_from_expr_for_default_rules(
         self, node: ast.expr
@@ -6038,6 +5862,91 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     seen.add(type_param.typevar)
                     type_params.append(type_param)
         return type_params
+
+    def _normalize_type_param_identities_in_value(
+        self, value: Value, replacements: Mapping[object, TypeParam]
+    ) -> Value:
+        type_param = _type_param_value_from_value(value, self)
+        if type_param is not None:
+            replacement = replacements.get(type_param.typevar)
+            if replacement is not None:
+                return type_param_to_value(replacement)
+            return value
+        if isinstance(value, AnnotatedValue):
+            normalized = self._normalize_type_param_identities_in_value(
+                value.value, replacements
+            )
+            if normalized is value.value:
+                return value
+            return replace(value, value=normalized)
+        if isinstance(value, GenericValue):
+            normalized_args = tuple(
+                self._normalize_type_param_identities_in_value(arg, replacements)
+                for arg in value.args
+            )
+            if normalized_args == value.args:
+                return value
+            return GenericValue(value.typ, normalized_args, weak=value.weak)
+        if isinstance(value, SequenceValue):
+            normalized_members = tuple(
+                (
+                    is_many,
+                    self._normalize_type_param_identities_in_value(
+                        member, replacements
+                    ),
+                )
+                for is_many, member in value.members
+            )
+            if normalized_members == value.members:
+                return value
+            return replace(value, members=normalized_members)
+        if isinstance(value, PartialValue):
+            normalized_root = self._normalize_type_param_identities_in_value(
+                value.root, replacements
+            )
+            normalized_members = tuple(
+                self._normalize_type_param_identities_in_value(member, replacements)
+                for member in value.members
+            )
+            normalized_runtime_value = self._normalize_type_param_identities_in_value(
+                value.runtime_value, replacements
+            )
+            if (
+                normalized_root is value.root
+                and normalized_members == value.members
+                and normalized_runtime_value is value.runtime_value
+            ):
+                return value
+            return replace(
+                value,
+                root=normalized_root,
+                members=normalized_members,
+                runtime_value=normalized_runtime_value,
+            )
+        if isinstance(value, SubclassValue):
+            normalized_typ = self._normalize_type_param_identities_in_value(
+                value.typ, replacements
+            )
+            if normalized_typ is value.typ:
+                return value
+            return replace(value, typ=normalized_typ)
+        if isinstance(value, MultiValuedValue):
+            normalized_vals = tuple(
+                self._normalize_type_param_identities_in_value(subval, replacements)
+                for subval in value.vals
+            )
+            if normalized_vals == value.vals:
+                return value
+            return MultiValuedValue(normalized_vals)
+        if isinstance(value, IntersectionValue):
+            normalized_vals = tuple(
+                self._normalize_type_param_identities_in_value(subval, replacements)
+                for subval in value.vals
+            )
+            if normalized_vals == value.vals:
+                return value
+            return IntersectionValue(normalized_vals)
+        return value
 
     def _order_type_params_by_base_annotation_appearance(
         self, base_nodes: Sequence[ast.expr], type_params: Sequence[TypeParam]
@@ -6346,6 +6255,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 return True
         return False
 
+    def get_type_param_from_value(self, value: Value) -> TypeParam | None:
+        return _type_param_value_from_value(value, self)
+
     def _is_generic_type_parameter_base(self, value: Value) -> bool:
         for candidate, _ in self._iter_type_parameter_base_candidates(value):
             if is_typing_name(candidate, "Generic"):
@@ -6361,14 +6273,29 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def _iter_type_parameter_base_candidates(
         self, value: Value
     ) -> Iterable[tuple[object, Sequence[object]]]:
-        for subval in flatten_values(replace_fallback(value)):
+        for subval in flatten_values(value):
             candidate = self._type_parameter_base_candidate(subval)
+            if candidate is not None:
+                yield candidate
+                continue
+            fallback = replace_fallback(subval)
+            if fallback is subval:
+                continue
+            candidate = self._type_parameter_base_candidate(fallback)
             if candidate is not None:
                 yield candidate
 
     def _type_parameter_base_candidate(
         self, value: Value
     ) -> tuple[object, Sequence[object]] | None:
+        if (
+            isinstance(value, PartialValue)
+            and value.operation is PartialValueOperation.SUBSCRIPT
+        ):
+            root_candidate = self._type_parameter_base_candidate(value.root)
+            if root_candidate is not None:
+                candidate, _ = root_candidate
+                return candidate, value.members
         if isinstance(value, SyntheticClassObjectValue):
             value = value.class_type
         if isinstance(value, GenericValue):
@@ -6485,10 +6412,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         return None
 
     def _get_synthetic_class_key(self, node: ast.ClassDef) -> ClassOwner:
-        if self.module is not None and hasattr(self.module, "__name__"):
-            module_name = self.module.__name__
-        else:
-            module_name = self.filename
+        module_name = self._type_param_owner_module_name()
         qualname = self._get_class_qualname_from_name(node.name)
         identity = ".".join((module_name, qualname)) if module_name else qualname
         return class_owner_from_qualname(module_name, qualname, identity=identity)
@@ -6513,15 +6437,55 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def _get_synthetic_class_fq_name_from_name_and_contexts(
         self, name: str, contexts: Sequence[ast.AST]
     ) -> str:
-        if self.module is not None and hasattr(self.module, "__name__"):
-            module_name = self.module.__name__
-        else:
-            module_name = self.filename
+        module_name = self._type_param_owner_module_name()
 
         qualname = self._get_class_qualname_from_name(name, contexts=contexts)
         if module_name:
             return ".".join((module_name, qualname))
         return qualname
+
+    def _type_param_owner_module_name(self) -> str:
+        if self.module is not None and hasattr(self.module, "__name__"):
+            return self.module.__name__
+        return self.filename
+
+    def _function_owner_from_node(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        *,
+        identity: object | None = None,
+    ) -> FunctionOwner:
+        module_name = self._type_param_owner_module_name()
+        qualname = self._get_class_qualname_from_name(node.name)
+        return FunctionOwner(
+            module_name, qualname, node if identity is None else identity
+        )
+
+    def _alias_owner_from_name(
+        self, name: str, *, identity: object | None = None
+    ) -> AliasOwner:
+        module_name = self._type_param_owner_module_name()
+        qualname = self._get_class_qualname_from_name(name)
+        return AliasOwner(
+            module_name, qualname, qualname if identity is None else identity
+        )
+
+    def _current_scope_type_param_owner(self) -> ClassKey | FunctionOwner | AliasOwner:
+        scope = self.scopes.current_scope()
+        scope_node = scope.scope_node
+        scope_object = scope.scope_object
+        if isinstance(scope_object, (type, ClassOwner)):
+            return scope_object
+        if isinstance(scope_node, ast.ClassDef):
+            return self._get_synthetic_class_key(scope_node)
+        if isinstance(scope_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return self._function_owner_from_node(scope_node, identity=scope_object)
+        if _AST_TYPE_ALIAS is not None and isinstance(scope_node, ast.TypeAlias):
+            assert isinstance(scope_node.name, ast.Name)
+            return self._alias_owner_from_name(
+                scope_node.name.id, identity=scope_object
+            )
+        raise AssertionError(f"unexpected type parameter scope {scope_node!r}")
 
     def _get_class_qualname_from_name(
         self, name: str, *, contexts: Sequence[ast.AST] | None = None
@@ -7072,6 +7036,15 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                                 error_code=ErrorCode.invalid_annotation,
                             )
                         return_annotation = AnyValue(AnySource.error)
+            if not type_params:
+                params, return_annotation, type_params = (
+                    self._legacy_function_type_params_from_annotations(
+                        node,
+                        params,
+                        return_annotation,
+                        potential_function=potential_function,
+                    )
+                )
             runtime_current_class = (
                 self.current_class if isinstance(self.current_class, type) else None
             )
@@ -12361,6 +12334,123 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 legacy_allowed_identities.add(extracted.typevar)
         return type_param_values
 
+    def _bind_type_param_owner(
+        self, type_param: TypeParam, owner: ClassKey | FunctionOwner | AliasOwner
+    ) -> TypeParam:
+        return with_type_param_owner(type_param, owner)
+
+    def _substitute_typevars_in_type_param(
+        self, type_param: TypeParam, substitutions: TypeVarMap
+    ) -> TypeParam:
+        if isinstance(type_param, TypeVarParam):
+            return replace(
+                type_param,
+                bound=(
+                    None
+                    if type_param.bound is None
+                    else type_param.bound.substitute_typevars(substitutions)
+                ),
+                default=(
+                    None
+                    if type_param.default is None
+                    else type_param.default.substitute_typevars(substitutions)
+                ),
+                constraints=tuple(
+                    constraint.substitute_typevars(substitutions)
+                    for constraint in type_param.constraints
+                ),
+            )
+        if isinstance(type_param, TypeVarTupleParam):
+            return replace(
+                type_param,
+                default=(
+                    None
+                    if type_param.default is None
+                    else type_param.default.substitute_typevars(substitutions)
+                ),
+            )
+        return replace(
+            type_param,
+            default=(
+                None
+                if type_param.default is None
+                else type_param.default.substitute_typevars(substitutions)
+            ),
+        )
+
+    def _normalize_type_param_identities_in_type_param(
+        self, type_param: TypeParam, replacements: Mapping[object, TypeParam]
+    ) -> TypeParam:
+        if isinstance(type_param, TypeVarParam):
+            return replace(
+                type_param,
+                bound=(
+                    None
+                    if type_param.bound is None
+                    else self._normalize_type_param_identities_in_value(
+                        type_param.bound, replacements
+                    )
+                ),
+                default=(
+                    None
+                    if type_param.default is None
+                    else self._normalize_type_param_identities_in_value(
+                        type_param.default, replacements
+                    )
+                ),
+                constraints=tuple(
+                    self._normalize_type_param_identities_in_value(
+                        constraint, replacements
+                    )
+                    for constraint in type_param.constraints
+                ),
+            )
+        if isinstance(type_param, TypeVarTupleParam):
+            return replace(
+                type_param,
+                default=(
+                    None
+                    if type_param.default is None
+                    else self._normalize_type_param_identities_in_value(
+                        type_param.default, replacements
+                    )
+                ),
+            )
+        return replace(
+            type_param,
+            default=(
+                None
+                if type_param.default is None
+                else self._normalize_type_param_identities_in_value(
+                    type_param.default, replacements
+                )
+            ),
+        )
+
+    def _bind_type_param_owners(
+        self,
+        type_params: Sequence[TypeParam],
+        owner: ClassKey | FunctionOwner | AliasOwner,
+    ) -> tuple[TypeParam, ...]:
+        owner_bound = tuple(
+            self._bind_type_param_owner(type_param, owner) for type_param in type_params
+        )
+        substitutions = TypeVarMap()
+        replacements: dict[object, TypeParam] = {}
+        for raw_type_param, bound_type_param in zip(type_params, owner_bound):
+            substitutions = substitutions.with_value(
+                raw_type_param, type_param_to_value(bound_type_param)
+            )
+            replacements[raw_type_param.typevar] = bound_type_param
+            replacements[bound_type_param.typevar] = bound_type_param
+        return tuple(
+            self._normalize_type_param_identities_in_type_param(
+                self._substitute_typevars_in_type_param(type_param, substitutions),
+                replacements,
+            )
+            for type_param in owner_bound
+        )
+
     def _current_scope_key(self) -> int:
         return id(self.scopes.current_scope())
 
@@ -12400,7 +12490,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         )
 
     def _infer_type_alias_type_params(
-        self, value_node: ast.AST, value: Value
+        self, value_node: ast.AST, value: Value, *, owner: AliasOwner | None = None
     ) -> tuple[TypeParam, ...]:
         type_params: list[TypeParam] = []
         seen_identities: set[object] = set()
@@ -12420,6 +12510,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
         def record_from_resolved(resolved: Value, node: ast.AST) -> bool:
             found_type_param = False
+            direct_type_param = make_type_param_from_value(
+                resolved, visitor=self, node=node
+            )
+            if direct_type_param is not None:
+                record_type_param(direct_type_param)
+                found_type_param = True
             for extracted in iter_type_params_in_value(resolved):
                 record_type_param(extracted)
                 found_type_param = True
@@ -12448,7 +12544,85 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 break
         for type_param in extracted_type_params:
             record_type_param(type_param)
-        return tuple(type_params)
+        if owner is None:
+            return tuple(type_params)
+        return self._bind_type_param_owners(type_params, owner)
+
+    def _legacy_function_type_params_from_annotations(
+        self,
+        node: FunctionDefNode | ast.Lambda,
+        params: Sequence[ParamInfo],
+        return_annotation: Value | None,
+        *,
+        potential_function: object | None,
+    ) -> tuple[Sequence[ParamInfo], Value | None, Sequence[TypeParam]]:
+        if isinstance(node, ast.Lambda):
+            return params, return_annotation, ()
+        owner = self._function_owner_from_node(node, identity=potential_function)
+        current_class_type_params = tuple(self.current_class_type_params or ())
+        current_class_identities = {
+            type_param.typevar for type_param in current_class_type_params
+        }
+        if current_class_type_params:
+            current_class_type_param_set = set(current_class_type_params)
+            for (
+                identity,
+                type_param,
+            ) in self.active_type_params.current_pep695_type_params().items():
+                if type_param in current_class_type_param_set:
+                    current_class_identities.add(identity)
+        raw_type_params: list[TypeParam] = []
+        seen: set[object] = set()
+        for param_info in params:
+            for type_param in iter_type_params_in_value(param_info.param.annotation):
+                if isinstance(type_param, TypeVarParam) and type_param.is_self:
+                    continue
+                if type_param.typevar in current_class_identities:
+                    continue
+                if type_param.owner is not None and type_param.owner != owner:
+                    continue
+                if type_param.typevar in seen:
+                    continue
+                seen.add(type_param.typevar)
+                raw_type_params.append(type_param)
+        if return_annotation is not None:
+            for type_param in iter_type_params_in_value(return_annotation):
+                if isinstance(type_param, TypeVarParam) and type_param.is_self:
+                    continue
+                if type_param.typevar in current_class_identities:
+                    continue
+                if type_param.owner is not None and type_param.owner != owner:
+                    continue
+                if type_param.typevar in seen:
+                    continue
+                seen.add(type_param.typevar)
+                raw_type_params.append(type_param)
+        if not raw_type_params:
+            return params, return_annotation, ()
+        bound_type_params = self._bind_type_param_owners(raw_type_params, owner)
+        substitutions = TypeVarMap()
+        for raw_type_param, bound_type_param in zip(raw_type_params, bound_type_params):
+            substitutions = substitutions.with_value(
+                raw_type_param, type_param_to_value(bound_type_param)
+            )
+        rebound_params = tuple(
+            replace(
+                param_info,
+                param=replace(
+                    param_info.param,
+                    annotation=param_info.param.annotation.substitute_typevars(
+                        substitutions
+                    ),
+                ),
+            )
+            for param_info in params
+        )
+        rebound_return = (
+            None
+            if return_annotation is None
+            else return_annotation.substitute_typevars(substitutions)
+        )
+        return rebound_params, rebound_return, bound_type_params
 
     def _resolve_call_target_value(self, node: ast.expr) -> Value:
         if isinstance(node, ast.Name):
@@ -12580,7 +12754,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return None
         type_params = tuple(
             type_param
-            for type_param in self._infer_type_alias_type_params(node.value, alias_type)
+            for type_param in self._infer_type_alias_type_params(
+                node.value, alias_type, owner=self._alias_owner_from_name(target_name)
+            )
             if _is_valid_inferred_type_alias_type_param(type_param)
         )
         if not type_params and not isinstance(alias_type, TypeAliasValue):
@@ -12632,9 +12808,17 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             alias_obj = runtime_existing.val
         else:
             alias_obj = None
+        alias_owner = self._alias_owner_from_name(name, identity=alias_obj)
         if self._is_collecting():
             self._record_type_alias_structure(name, node, value_node)
-        type_params = self._extract_runtime_type_alias_type_params(node.value)
+        type_params = tuple(
+            (
+                self._bind_type_param_owner(type_param, alias_owner)
+                if type_param.owner is None
+                else type_param
+            )
+            for type_param in self._extract_runtime_type_alias_type_params(node.value)
+        )
         declared_type_params = list(type_params)
         if self.current_class_type_params is not None:
             declared_type_params.extend(self.current_class_type_params)
@@ -12855,6 +13039,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return None
 
         def visit_TypeVar(self, node: ast.TypeVar) -> Value:
+            owner = self._current_scope_type_param_owner()
             bound = constraints = default = None
             if node.bound is not None:
                 if isinstance(node.bound, ast.Tuple):
@@ -12908,6 +13093,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             typevar = TypeVarValue(
                 TypeVarParam(
                     tv,
+                    owner=owner,
                     bound=bound,
                     constraints=tuple(constraints) if constraints is not None else (),
                     default=default if default is not None else None,
@@ -12918,6 +13104,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return typevar
 
         def visit_ParamSpec(self, node: ast.ParamSpec) -> Value:
+            owner = self._current_scope_type_param_owner()
             maybe_runtime_param_spec = self._get_runtime_type_param_for_current_scope(
                 node.name, expected_kind="ParamSpec"
             )
@@ -12925,11 +13112,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 ps = typing.ParamSpec(node.name)
             else:
                 ps = typing.cast(Any, maybe_runtime_param_spec)
-            typevar = InputSigValue(ParamSpecParam(ps))
+            typevar = InputSigValue(ParamSpecParam(ps, owner=owner))
             self._set_name_in_scope(node.name, node, typevar)
             return typevar
 
         def visit_TypeVarTuple(self, node: ast.TypeVarTuple) -> Value:
+            owner = self._current_scope_type_param_owner()
             maybe_runtime_typevar_tuple = (
                 self._get_runtime_type_param_for_current_scope(
                     node.name, expected_kind="TypeVarTuple"
@@ -12939,7 +13127,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 tv = typing.cast(Any, getattr(typing, "TypeVarTuple"))(node.name)
             else:
                 tv = typing.cast(Any, maybe_runtime_typevar_tuple)
-            typevar = TypeVarTupleValue(TypeVarTupleParam(tv))
+            typevar = TypeVarTupleValue(TypeVarTupleParam(tv, owner=owner))
             self._set_name_in_scope(node.name, node, typevar)
             return typevar
 
@@ -13334,17 +13522,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         return_value = synthetic_subscript
                     else:
                         runtime_class_getitem: Value | None = None
-                        if isinstance(stripped_root.value, KnownValue) and isinstance(
-                            stripped_root.value.val, type
-                        ):
-                            bound_getitem = safe_getattr(
-                                stripped_root.value.val, "__getitem__", None
-                            )
-                            if (
-                                isinstance(bound_getitem, types.MethodType)
-                                and bound_getitem.__self__ is stripped_root.value.val
-                            ):
-                                runtime_class_getitem = KnownValue(bound_getitem)
                         if runtime_class_getitem is not None:
                             return_value = self.check_call(
                                 node.value,
@@ -13887,6 +14064,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return Composite(self.being_assigned, composite, node)
         elif isinstance(node.ctx, ast.Load):
             root_composite = self._get_locally_narrowed_composite(root_composite, node)
+            partial_paramspec_component = self._partial_paramspec_component(
+                root_composite.value, node.attr
+            )
+            if partial_paramspec_component is not None:
+                return Composite(partial_paramspec_component, composite, node)
             if self.in_annotation and isinstance(root_composite.value, KnownValue):
                 try:
                     attr_value = getattr(root_composite.value.val, node.attr)
@@ -13912,6 +14094,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 use_fallback=True,
                 ignore_none=self.options.get_value_for(IgnoreNoneAttributes),
             )
+            value = self._preserve_attribute_receiver_composite(value, root_composite)
             self._check_deprecated_property_getter(node, root_composite.value)
             self.check_deprecation(node, value)
             if self._should_use_varname_value(value):
@@ -13942,6 +14125,73 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         else:
             self.show_error(node, "Unknown context", ErrorCode.unexpected_node)
             return Composite(AnyValue(AnySource.error), composite, node)
+
+    def _partial_paramspec_component(self, value: Value, attr: str) -> Value | None:
+        if attr not in ("args", "kwargs") or not isinstance(value, PartialCallValue):
+            return None
+        runtime_value = replace_fallback(value.runtime_value)
+        if not (
+            isinstance(runtime_value, TypedValue)
+            and is_typing_name(runtime_value.typ, "ParamSpec")
+        ):
+            return None
+        type_param = make_type_param_from_value(value, visitor=self)
+        if not isinstance(type_param, ParamSpecParam):
+            return None
+        if attr == "args":
+            return ParamSpecArgsValue(type_param.param_spec)
+        return ParamSpecKwargsValue(type_param.param_spec)
+
+    def _preserve_attribute_receiver_composite(
+        self, value: Value, root_composite: Composite
+    ) -> Value:
+        if root_composite.varname is None:
+            return value
+        if isinstance(value, CallableValue):
+            signature = self._signature_with_bound_receiver_composite(
+                value.signature, root_composite
+            )
+            if (
+                isinstance(signature, (Signature, OverloadedSignature))
+                and signature is not value.signature
+            ):
+                return CallableValue(signature, value.typ)
+        elif isinstance(value, AnnotatedValue):
+            inner = self._preserve_attribute_receiver_composite(
+                value.value, root_composite
+            )
+            if inner is not value.value:
+                return replace(value, value=inner)
+        return value
+
+    def _signature_with_bound_receiver_composite(
+        self, signature: MaybeSignature, root_composite: Composite
+    ) -> MaybeSignature:
+        if isinstance(signature, Signature):
+            if signature.bound_receiver_param_name is None:
+                return signature
+            if (
+                signature.bound_receiver_composite is not None
+                and signature.bound_receiver_composite.varname is not None
+            ):
+                return signature
+            return replace(signature, bound_receiver_composite=root_composite)
+        if isinstance(signature, OverloadedSignature):
+            new_signatures = [
+                self._signature_with_bound_receiver_composite(subsig, root_composite)
+                for subsig in signature.signatures
+            ]
+            if all(
+                new_signature is old_signature
+                for new_signature, old_signature in zip(
+                    new_signatures, signature.signatures
+                )
+            ):
+                return signature
+            return OverloadedSignature(
+                typing.cast("Sequence[Signature]", new_signatures)
+            )
+        return signature
 
     def _normalize_expected_attribute_type_for_assignment(self, value: Value) -> Value:
         # TODO: this should be unnecessary if we get better at
@@ -15374,6 +15624,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
     def _should_perform_runtime_call(self, callee: KnownValue) -> bool:
         callee_obj = callee.val
+        if (
+            is_typing_name(callee_obj, "TypeVar")
+            or is_typing_name(callee_obj, "ParamSpec")
+            or is_typing_name(callee_obj, "TypeVarTuple")
+        ):
+            return False
         return not (
             isinstance(callee_obj, type)
             and is_namedtuple_class(callee_obj)
@@ -16782,25 +17038,12 @@ def _get_dataclass_post_init_node(
     return None
 
 
-def _compose_observed_variance_polarity(polarity: int, modifier: int) -> int:
-    if polarity == 0 or modifier == 0:
-        return 0
-    return polarity * modifier
-
-
 def _variance_to_observed_polarity(variance: Variance) -> int:
     if variance is Variance.COVARIANT:
         return 1
     if variance is Variance.CONTRAVARIANT:
         return -1
     return 0
-
-
-def _record_variance_polarity(used_polarities: set[int], polarity: int) -> None:
-    if polarity == 0:
-        used_polarities.update({-1, 1})
-    else:
-        used_polarities.add(polarity)
 
 
 def _variance_is_compatible_with_usage(
@@ -16851,12 +17094,6 @@ def _type_param_value_from_value(
             return value.input_sig
         return None
     return make_type_param_from_value(value, visitor=visitor)
-
-
-def _is_type_param_declaration_node(node: ast.AST) -> bool:
-    return bool(_TYPE_PARAM_AST_NODE_TYPES) and isinstance(
-        node, _TYPE_PARAM_AST_NODE_TYPES
-    )
 
 
 def _count_starred_type_param_args(slice_node: ast.AST) -> int:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -14230,7 +14230,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 use_fallback=True,
                 ignore_none=self.options.get_value_for(IgnoreNoneAttributes),
             )
-            value = self._preserve_attribute_receiver_composite(value, root_composite)
             self._check_deprecated_property_getter(node, root_composite.value)
             self.check_deprecation(node, value)
             if self._should_use_varname_value(value):
@@ -14277,57 +14276,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if attr == "args":
             return ParamSpecArgsValue(type_param.param_spec)
         return ParamSpecKwargsValue(type_param.param_spec)
-
-    def _preserve_attribute_receiver_composite(
-        self, value: Value, root_composite: Composite
-    ) -> Value:
-        if root_composite.varname is None:
-            return value
-        if isinstance(value, CallableValue):
-            signature = self._signature_with_bound_receiver_composite(
-                value.signature, root_composite
-            )
-            if (
-                isinstance(signature, (Signature, OverloadedSignature))
-                and signature is not value.signature
-            ):
-                return CallableValue(signature, value.typ)
-        elif isinstance(value, AnnotatedValue):
-            inner = self._preserve_attribute_receiver_composite(
-                value.value, root_composite
-            )
-            if inner is not value.value:
-                return replace(value, value=inner)
-        return value
-
-    def _signature_with_bound_receiver_composite(
-        self, signature: MaybeSignature, root_composite: Composite
-    ) -> MaybeSignature:
-        if isinstance(signature, Signature):
-            if signature.bound_receiver_param_name is None:
-                return signature
-            if (
-                signature.bound_receiver_composite is not None
-                and signature.bound_receiver_composite.varname is not None
-            ):
-                return signature
-            return replace(signature, bound_receiver_composite=root_composite)
-        if isinstance(signature, OverloadedSignature):
-            new_signatures = [
-                self._signature_with_bound_receiver_composite(subsig, root_composite)
-                for subsig in signature.signatures
-            ]
-            if all(
-                new_signature is old_signature
-                for new_signature, old_signature in zip(
-                    new_signatures, signature.signatures
-                )
-            ):
-                return signature
-            return OverloadedSignature(
-                typing.cast("Sequence[Signature]", new_signatures)
-            )
-        return signature
 
     def _normalize_expected_attribute_type_for_assignment(self, value: Value) -> Value:
         # TODO: this should be unnecessary if we get better at

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -6491,23 +6491,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             module_name, qualname, qualname if identity is None else identity
         )
 
-    def _current_scope_type_param_owner(self) -> ClassKey | FunctionOwner | AliasOwner:
-        scope = self.scopes.current_scope()
-        scope_node = scope.scope_node
-        scope_object = scope.scope_object
-        if isinstance(scope_object, (type, ClassOwner)):
-            return scope_object
-        if isinstance(scope_node, ast.ClassDef):
-            return self._get_synthetic_class_key(scope_node)
-        if isinstance(scope_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            return self._function_owner_from_node(scope_node, identity=scope_object)
-        if _AST_TYPE_ALIAS is not None and isinstance(scope_node, ast.TypeAlias):
-            assert isinstance(scope_node.name, ast.Name)
-            return self._alias_owner_from_name(
-                scope_node.name.id, identity=scope_object
-            )
-        raise AssertionError(f"unexpected type parameter scope {scope_node!r}")
-
     def _get_class_qualname_from_name(
         self, name: str, *, contexts: Sequence[ast.AST] | None = None
     ) -> str:
@@ -12958,6 +12941,25 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         )
 
     if sys.version_info >= (3, 12):
+
+        def _current_scope_type_param_owner(
+            self,
+        ) -> ClassKey | FunctionOwner | AliasOwner:
+            scope = self.scopes.current_scope()
+            scope_node = scope.scope_node
+            scope_object = scope.scope_object
+            if isinstance(scope_object, (type, ClassOwner)):
+                return scope_object
+            if isinstance(scope_node, ast.ClassDef):
+                return self._get_synthetic_class_key(scope_node)
+            if isinstance(scope_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                return self._function_owner_from_node(scope_node, identity=scope_object)
+            if isinstance(scope_node, ast.TypeAlias):
+                assert isinstance(scope_node.name, ast.Name)
+                return self._alias_owner_from_name(
+                    scope_node.name.id, identity=scope_object
+                )
+            raise AssertionError(f"unexpected type parameter scope {scope_node!r}")
 
         def _pep695_type_param_expr_needs_string_forward_ref(
             self, node: ast.expr

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -567,39 +567,6 @@ if asynq is not None:
     SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL.append(KnownValue(asynq.asynq))
 
 
-def _callable_from_signature(sig: MaybeSignature) -> object | None:
-    if isinstance(sig, Signature):
-        if isinstance(sig.callable, types.FunctionType) and sig.callable.__name__ in {
-            "__init__",
-            "__new__",
-            "__get__",
-            "__set__",
-            "__delete__",
-            "__call__",
-        }:
-            return None
-        return sig.callable
-    if isinstance(sig, BoundMethodSignature):
-        return _callable_from_signature(sig.signature)
-    if isinstance(sig, OverloadedSignature):
-        callables = {
-            subsig.callable for subsig in sig.signatures if subsig.callable is not None
-        }
-        if len(callables) == 1:
-            return next(iter(callables))
-    return None
-
-
-def _has_bound_receiver(sig: MaybeSignature) -> bool:
-    if isinstance(sig, Signature):
-        return sig.bound_receiver_param_name is not None
-    if isinstance(sig, BoundMethodSignature):
-        return True
-    if isinstance(sig, OverloadedSignature):
-        return all(_has_bound_receiver(subsig) for subsig in sig.signatures)
-    return False
-
-
 class _AsyncGeneratorDetector(ast.NodeVisitor):
     """Detect whether an async function body contains a yield."""
 
@@ -1819,7 +1786,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     """Path (relative to this class's file) to a pyproject.toml config file."""
 
     _argspec_to_retval: dict[int, tuple[Value, MaybeSignature]]
-    _callable_to_retval: dict[int, tuple[Value, object]]
     _pending_overload_blocks: dict[int, _PendingOverloadBlock]
     _function_decorator_kinds_by_node: dict[
         ast.FunctionDef | ast.AsyncFunctionDef, frozenset[FunctionDecorator]
@@ -1992,7 +1958,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         # infer types. Previously, we cached this globally, but that makes things non-
         # deterministic because we'll start depending on the order modules are checked.
         self._argspec_to_retval = {}
-        self._callable_to_retval = {}
         self._pending_overload_blocks = {}
         self._function_decorator_kinds_by_node = {}
         self._function_returns_self_by_node = {}
@@ -2008,14 +1973,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def get_local_return_value(self, sig: MaybeSignature) -> Value | None:
         val, saved_sig = self._argspec_to_retval.get(id(sig), (None, None))
         if sig is not saved_sig:
-            callable_obj = _callable_from_signature(sig)
-            if callable_obj is None:
-                return None
-            val, saved_callable = self._callable_to_retval.get(
-                id(callable_obj), (None, None)
-            )
-            if callable_obj is not saved_callable:
-                return None
+            return None
         return val
 
     @property
@@ -2218,7 +2176,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         # This is intentionally unsafe.
         self.tree = None  # static analysis: ignore[incompatible_assignment]
         self._argspec_to_retval.clear()
-        self._callable_to_retval.clear()
         end_time = time.time()
         message = f"{self.filename} took {end_time - start_time:.2f} s"
         self.logger.log(logging.INFO, message)
@@ -8458,9 +8415,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if sig is None or sig.has_return_value():
             return
         self._argspec_to_retval[id(sig)] = (return_value, sig)
-        callable_obj = _callable_from_signature(sig)
-        if callable_obj is not None:
-            self._callable_to_retval[id(callable_obj)] = (return_value, callable_obj)
 
     def _get_potential_function(self, node: FunctionDefNode) -> object | None:
         scope_type = self.scopes.scope_type()
@@ -14109,10 +14063,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 and not isinstance(method_object, UnboundMethodValue)
             )
             or isinstance(method_object, UnboundMethodValue)
-            or (
-                isinstance(method_object, CallableValue)
-                and _has_bound_receiver(method_object.signature)
-            )
         ):
             call_args = list(args)
         else:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -246,6 +246,7 @@ from .type_object import (
 )
 from .type_params import (
     ActiveTypeParams,
+    TypeParamIdentity,
     _compose_observed_variance_polarity,
     _record_variance_polarity,
 )
@@ -353,7 +354,6 @@ from .value import (
     unite_and_simplify,
     unite_values,
     unpack_values,
-    with_type_param_owner,
 )
 from .yield_checker import YieldChecker
 
@@ -3148,7 +3148,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if self.scopes.scope_type() != ScopeType.class_scope:
             return None
         identities = self.active_type_params.current_annotation_identities()
-        return identities or None
+        result: set[object] = set()
+        for identity in identities:
+            result.add(identity)
+        return result or None
 
     def _evaluate_type_alias_node(
         self,
@@ -3671,7 +3674,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             )
         else:
             ctx = contextlib.nullcontext()
-        with self.active_type_params.add_scope(class_key), ctx:
+        with self.active_type_params.push_scope(class_key), ctx:
             legacy_type_param_ctx: AbstractContextManager[set[object] | None] = (
                 contextlib.nullcontext(None)
             )
@@ -3684,17 +3687,15 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 )
             with legacy_type_param_ctx as allowed_legacy_identities:
                 if is_pep695_generic:
-                    declared_type_param_nodes = node.type_params
                     type_param_values = list(
                         self.visit_type_param_values(
-                            declared_type_param_nodes,
+                            node.type_params,
                             legacy_allowed_identities=allowed_legacy_identities,
                         )
                     )
                 else:
                     assert allowed_legacy_identities is None
                     type_param_values = []
-                    declared_type_param_nodes = []
 
                 disallowed_type_params = (
                     self.active_type_params.current_annotation_identities()
@@ -3907,39 +3908,29 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                 )
             prebound_registered_type_param_values = tuple(registered_type_param_values)
-            registered_type_param_values = self._bind_type_param_owners(
-                registered_type_param_values, generic_class_key
-            )
-            raw_registered_type_param_replacements = {
-                candidate.typevar: registered_type_param
-                for raw_type_param, prebound_type_param, registered_type_param in zip(
-                    raw_registered_type_param_values,
-                    prebound_registered_type_param_values,
-                    registered_type_param_values,
-                )
-                for candidate in (raw_type_param, prebound_type_param)
-            }
-            registered_type_param_values = tuple(
-                self._normalize_type_param_identities_in_type_param(
-                    type_param, raw_registered_type_param_replacements
-                )
-                for type_param in registered_type_param_values
-            )
-            type_param_alias_identities: list[set[object]] = []
-            raw_type_params_by_identity: dict[object, TypeParam] = {}
-            for raw_type_param, prebound_type_param, registered_type_param in zip(
-                raw_registered_type_param_values,
-                prebound_registered_type_param_values,
-                registered_type_param_values,
+            type_param_alias_identities: list[set[TypeParamIdentity]] = []
+            raw_type_param_aliases: list[set[object]] = []
+            for raw_type_param, prebound_type_param in zip(
+                raw_registered_type_param_values, prebound_registered_type_param_values
             ):
-                aliases: set[object] = set()
-                for candidate in (raw_type_param, prebound_type_param):
-                    if candidate.typevar is not registered_type_param.typevar:
-                        aliases.add(candidate.typevar)
-                    raw_type_params_by_identity[candidate.typevar] = (
-                        registered_type_param
-                    )
-                type_param_alias_identities.append(aliases)
+                aliases: set[object] = {raw_type_param.typevar}
+                if raw_type_param.typevar is not prebound_type_param.typevar:
+                    aliases.add(prebound_type_param.typevar)
+                raw_type_param_aliases.append(aliases)
+            binding_result = self.active_type_params.bind_all(
+                registered_type_param_values,
+                generic_class_key,
+                aliases=raw_type_param_aliases,
+                normalize_value=self._normalize_type_param_identities_in_value,
+            )
+            registered_type_param_values = binding_result.type_params
+            raw_type_params_by_identity: dict[object, TypeParam] = {}
+            for param_aliases, registered_type_param in zip(
+                binding_result.aliases, registered_type_param_values
+            ):
+                type_param_alias_identities.append(set(param_aliases))
+                for identity in param_aliases:
+                    raw_type_params_by_identity[identity] = registered_type_param
             if registered_type_param_values:
                 tobj.set_declared_type_params(tuple(registered_type_param_values))
             else:
@@ -3982,8 +3973,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 class_annotation_identities.update(alias_identities)
             with (
                 self.active_type_params.push_pep695_scope(
-                    class_scope_type_params,
-                    additional_identities=type_param_alias_identities,
+                    class_scope_type_params, aliases=type_param_alias_identities
                 ),
                 self.active_type_params.allow_in_annotations(
                     class_annotation_identities
@@ -4037,10 +4027,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     if type_param_values
                     else effective_type_param_values
                 )
-                if raw_registered_type_param_replacements:
+                if raw_type_params_by_identity:
                     declared_type_params = tuple(
-                        self._normalize_type_param_identities_in_type_param(
-                            type_param, raw_registered_type_param_replacements
+                        self.active_type_params.normalize_type_param_identities(
+                            type_param,
+                            raw_type_params_by_identity,
+                            normalize_value=self._normalize_type_param_identities_in_value,
                         )
                         for type_param in declared_type_params
                     )
@@ -4049,10 +4041,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         node.bases
                     )
                 )
-                if raw_registered_type_param_replacements:
+                if raw_type_params_by_identity:
                     annotation_declared_type_params = tuple(
-                        self._normalize_type_param_identities_in_type_param(
-                            type_param, raw_registered_type_param_replacements
+                        self.active_type_params.normalize_type_param_identities(
+                            type_param,
+                            raw_type_params_by_identity,
+                            normalize_value=self._normalize_type_param_identities_in_value,
                         )
                         for type_param in annotation_declared_type_params
                     )
@@ -6957,14 +6951,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             and not isinstance(node, ast.Lambda)
             and node.type_params
         ):
+            function_owner = self._function_owner_from_node(
+                node, identity=potential_function
+            )
             ctx = self.scopes.add_scope(
                 ScopeType.annotation_scope,
                 scope_node=node,
                 scope_object=potential_function,
             )
+            type_param_scope = self.active_type_params.push_scope(function_owner)
         else:
             ctx = contextlib.nullcontext()
-        with ctx:
+            type_param_scope = contextlib.nullcontext()
+        with ctx, type_param_scope:
             legacy_type_param_ctx: AbstractContextManager[set[object] | None] = (
                 contextlib.nullcontext(None)
             )
@@ -12383,118 +12382,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 legacy_allowed_identities.add(extracted.typevar)
         return type_param_values
 
-    def _substitute_typevars_in_type_param(
-        self, type_param: TypeParam, substitutions: TypeVarMap
-    ) -> TypeParam:
-        if isinstance(type_param, TypeVarParam):
-            return replace(
-                type_param,
-                bound=(
-                    None
-                    if type_param.bound is None
-                    else type_param.bound.substitute_typevars(substitutions)
-                ),
-                default=(
-                    None
-                    if type_param.default is None
-                    else type_param.default.substitute_typevars(substitutions)
-                ),
-                constraints=tuple(
-                    constraint.substitute_typevars(substitutions)
-                    for constraint in type_param.constraints
-                ),
-            )
-        if isinstance(type_param, TypeVarTupleParam):
-            return replace(
-                type_param,
-                default=(
-                    None
-                    if type_param.default is None
-                    else type_param.default.substitute_typevars(substitutions)
-                ),
-            )
-        return replace(
-            type_param,
-            default=(
-                None
-                if type_param.default is None
-                else type_param.default.substitute_typevars(substitutions)
-            ),
-        )
-
-    def _normalize_type_param_identities_in_type_param(
-        self, type_param: TypeParam, replacements: Mapping[object, TypeParam]
-    ) -> TypeParam:
-        if isinstance(type_param, TypeVarParam):
-            return replace(
-                type_param,
-                bound=(
-                    None
-                    if type_param.bound is None
-                    else self._normalize_type_param_identities_in_value(
-                        type_param.bound, replacements
-                    )
-                ),
-                default=(
-                    None
-                    if type_param.default is None
-                    else self._normalize_type_param_identities_in_value(
-                        type_param.default, replacements
-                    )
-                ),
-                constraints=tuple(
-                    self._normalize_type_param_identities_in_value(
-                        constraint, replacements
-                    )
-                    for constraint in type_param.constraints
-                ),
-            )
-        if isinstance(type_param, TypeVarTupleParam):
-            return replace(
-                type_param,
-                default=(
-                    None
-                    if type_param.default is None
-                    else self._normalize_type_param_identities_in_value(
-                        type_param.default, replacements
-                    )
-                ),
-            )
-        return replace(
-            type_param,
-            default=(
-                None
-                if type_param.default is None
-                else self._normalize_type_param_identities_in_value(
-                    type_param.default, replacements
-                )
-            ),
-        )
-
-    def _bind_type_param_owners(
-        self,
-        type_params: Sequence[TypeParam],
-        owner: ClassKey | FunctionOwner | AliasOwner,
-    ) -> tuple[TypeParam, ...]:
-        owner_bound = tuple(
-            with_type_param_owner(type_param, owner) for type_param in type_params
-        )
-        substitutions = TypeVarMap()
-        replacements: dict[object, TypeParam] = {}
-        for raw_type_param, bound_type_param in zip(type_params, owner_bound):
-            substitutions = substitutions.with_value(
-                raw_type_param, type_param_to_value(bound_type_param)
-            )
-            replacements[raw_type_param.typevar] = bound_type_param
-            replacements[bound_type_param.typevar] = bound_type_param
-        return tuple(
-            self._normalize_type_param_identities_in_type_param(
-                self._substitute_typevars_in_type_param(type_param, substitutions),
-                replacements,
-            )
-            for type_param in owner_bound
-        )
-
     def _record_type_alias_structure(
         self, name: str, alias_node: ast.AST, value_node: ast.AST
     ) -> None:
@@ -12591,7 +12478,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             record_type_param(type_param)
         if owner is None:
             return tuple(type_params)
-        return self._bind_type_param_owners(type_params, owner)
+        return self.active_type_params.bind_all(
+            type_params,
+            owner,
+            normalize_value=self._normalize_type_param_identities_in_value,
+        ).type_params
 
     def _legacy_function_type_params_from_annotations(
         self,
@@ -12644,12 +12535,13 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 raw_type_params.append(type_param)
         if not raw_type_params:
             return params, return_annotation, ()
-        bound_type_params = self._bind_type_param_owners(raw_type_params, owner)
-        substitutions = TypeVarMap()
-        for raw_type_param, bound_type_param in zip(raw_type_params, bound_type_params):
-            substitutions = substitutions.with_value(
-                raw_type_param, type_param_to_value(bound_type_param)
-            )
+        binding_result = self.active_type_params.bind_all(
+            raw_type_params,
+            owner,
+            normalize_value=self._normalize_type_param_identities_in_value,
+        )
+        bound_type_params = binding_result.type_params
+        substitutions = binding_result.substitutions
         rebound_params = tuple(
             replace(
                 param_info,
@@ -12856,14 +12748,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         alias_owner = self._alias_owner_from_name(name, identity=alias_obj)
         if self._is_collecting():
             self._record_type_alias_structure(name, node, value_node)
-        type_params = tuple(
-            (
-                with_type_param_owner(type_param, alias_owner)
-                if type_param.owner is None
-                else type_param
-            )
-            for type_param in self._extract_runtime_type_alias_type_params(node.value)
-        )
+        type_params = self.active_type_params.bind_all(
+            self._extract_runtime_type_alias_type_params(node.value),
+            alias_owner,
+            normalize_value=self._normalize_type_param_identities_in_value,
+        ).type_params
         declared_type_params = list(type_params)
         if self.current_class_type_params is not None:
             declared_type_params.extend(self.current_class_type_params)
@@ -12943,25 +12832,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         )
 
     if sys.version_info >= (3, 12):
-
-        def _current_scope_type_param_owner(
-            self,
-        ) -> ClassKey | FunctionOwner | AliasOwner:
-            scope = self.scopes.current_scope()
-            scope_node = scope.scope_node
-            scope_object = scope.scope_object
-            if isinstance(scope_object, (type, ClassOwner)):
-                return scope_object
-            if isinstance(scope_node, ast.ClassDef):
-                return self._get_synthetic_class_key(scope_node)
-            if isinstance(scope_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                return self._function_owner_from_node(scope_node, identity=scope_object)
-            if isinstance(scope_node, ast.TypeAlias):
-                assert isinstance(scope_node.name, ast.Name)
-                return self._alias_owner_from_name(
-                    scope_node.name.id, identity=scope_object
-                )
-            raise AssertionError(f"unexpected type parameter scope {scope_node!r}")
 
         def _pep695_type_param_expr_needs_string_forward_ref(
             self, node: ast.expr
@@ -13057,6 +12927,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         scope_node=node,
                         scope_object=alias_obj,
                     ),
+                    self.active_type_params.push_scope(
+                        self._alias_owner_from_name(name, identity=alias_obj)
+                    ),
                     self.active_type_params.reject_legacy_type_params(
                         legacy_param_message,
                         error_code=ErrorCode.invalid_type_alias,
@@ -13120,7 +12993,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return None
 
         def visit_TypeVar(self, node: ast.TypeVar) -> Value:
-            owner = self._current_scope_type_param_owner()
+            owner = self.active_type_params.current_owner()
             bound = constraints = default = None
             if node.bound is not None:
                 if isinstance(node.bound, ast.Tuple):
@@ -13185,7 +13058,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return typevar
 
         def visit_ParamSpec(self, node: ast.ParamSpec) -> Value:
-            owner = self._current_scope_type_param_owner()
+            owner = self.active_type_params.current_owner()
             maybe_runtime_param_spec = self._get_runtime_type_param_for_current_scope(
                 node.name, expected_kind="ParamSpec"
             )
@@ -13198,7 +13071,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return typevar
 
         def visit_TypeVarTuple(self, node: ast.TypeVarTuple) -> Value:
-            owner = self._current_scope_type_param_owner()
+            owner = self.active_type_params.current_owner()
             maybe_runtime_typevar_tuple = (
                 self._get_runtime_type_param_for_current_scope(
                     node.name, expected_kind="TypeVarTuple"

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -737,13 +737,17 @@ class _AttrContext(CheckerAttrContext):
     def get_type_object_attribute_policy(
         self, *, on_class: bool, receiver: Value
     ) -> AttributePolicy:
+        is_dunder = self.attr.startswith("__") and self.attr.endswith("__")
+        is_special_lookup = (
+            self.self_value is not None
+            and _attribute_root_class_info(self.self_value).is_class_object is True
+            and is_dunder
+        )
         return AttributePolicy(
             on_class=on_class,
-            is_special_lookup=self.self_value is not None
-            and self.attr.startswith("__")
-            and self.attr.endswith("__")
-            and _attribute_root_class_info(self.self_value).is_class_object is True,
+            is_special_lookup=is_special_lookup,
             receiver=receiver,
+            self_value=self.self_value if is_dunder else None,
             visitor=self.visitor,
             node=self.node,
             receiver_composite=self.root_composite,
@@ -3602,7 +3606,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 for base in base_values
             ) and isinstance(tobj.typ, ClassOwner):
                 tobj.set_direct_bases(
-                    direct_bases_from_values(base_values, self.checker)
+                    direct_bases_from_values(base_values, self.checker, owner=tobj.typ)
                 )
         elif isinstance(tobj.typ, ClassOwner):
             tobj.set_direct_bases([TypedValue(object)])
@@ -3949,6 +3953,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 base_values_for_registration = list(
                     self._base_values_for_generic_analysis(node, base_values)
                 )
+            elif any(
+                _base_conversion_is_imprecise(
+                    base, self.checker, owner=generic_class_key
+                )
+                for base in base_values
+            ):
+                analyzed_bases = self._base_values_for_generic_analysis(
+                    node, base_values
+                )
+                if any(
+                    not _base_conversion_is_imprecise(
+                        base, self.checker, owner=generic_class_key
+                    )
+                    for base in analyzed_bases
+                ):
+                    base_values_for_registration = list(analyzed_bases)
             if raw_type_params_by_identity:
                 base_values_for_registration = [
                     self._normalize_type_param_identities_in_value(
@@ -17006,6 +17026,13 @@ def _count_starred_type_param_args(slice_node: ast.AST) -> int:
     if isinstance(slice_node, ast.Tuple):
         return sum(isinstance(elt, ast.Starred) for elt in slice_node.elts)
     return int(isinstance(slice_node, ast.Starred))
+
+
+def _base_conversion_is_imprecise(
+    base_value: Value, checker: Checker, *, owner: ClassKey
+) -> bool:
+    converted = direct_bases_from_values([base_value], checker, owner=owner)
+    return any(isinstance(base, AnyValue) for base in converted)
 
 
 def _mangle_class_attribute_name(class_name: str, attribute_name: str) -> str:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -1791,6 +1791,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         ast.FunctionDef | ast.AsyncFunctionDef, frozenset[FunctionDecorator]
     ]
     _function_returns_self_by_node: dict[ast.FunctionDef | ast.AsyncFunctionDef, bool]
+    _type_alias_first_definition_by_scope: dict[int, dict[str, ast.AST]]
     _type_alias_unguarded_refs_by_scope: dict[int, dict[str, set[str]]]
     _method_cache: dict[type[ast.AST], Callable[[Any], Value | None]]
     _name_node_to_statement: dict[ast.AST, ast.AST | None] | None
@@ -1961,6 +1962,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         self._pending_overload_blocks = {}
         self._function_decorator_kinds_by_node = {}
         self._function_returns_self_by_node = {}
+        self._type_alias_first_definition_by_scope = {}
         self._type_alias_unguarded_refs_by_scope = {}
         self._method_cache = {}
         self._statement_types = set()
@@ -5719,9 +5721,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 if declared.typevar not in seen:
                     merged.append(declared)
         return merged
-
-    def _type_parameter_value_has_default(self, type_param: TypeParam) -> bool:
-        return type_param.default is not None
 
     def _walk_values_for_type_param_collection(
         self, value: Value
@@ -12402,11 +12401,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 legacy_allowed_identities.add(extracted.typevar)
         return type_param_values
 
-    def _bind_type_param_owner(
-        self, type_param: TypeParam, owner: ClassKey | FunctionOwner | AliasOwner
-    ) -> TypeParam:
-        return with_type_param_owner(type_param, owner)
-
     def _substitute_typevars_in_type_param(
         self, type_param: TypeParam, substitutions: TypeVarMap
     ) -> TypeParam:
@@ -12501,7 +12495,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         owner: ClassKey | FunctionOwner | AliasOwner,
     ) -> tuple[TypeParam, ...]:
         owner_bound = tuple(
-            self._bind_type_param_owner(type_param, owner) for type_param in type_params
+            with_type_param_owner(type_param, owner) for type_param in type_params
         )
         substitutions = TypeVarMap()
         replacements: dict[object, TypeParam] = {}
@@ -12519,13 +12513,14 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             for type_param in owner_bound
         )
 
-    def _current_scope_key(self) -> int:
-        return id(self.scopes.current_scope())
-
     def _record_type_alias_structure(
         self, name: str, alias_node: ast.AST, value_node: ast.AST
     ) -> None:
         scope_key = self._current_scope_key()
+        first_by_name = self._type_alias_first_definition_by_scope.setdefault(
+            scope_key, {}
+        )
+        first_by_name.setdefault(name, alias_node)
         refs_by_name = self._type_alias_unguarded_refs_by_scope.setdefault(
             scope_key, {}
         )
@@ -12535,7 +12530,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
     def _type_alias_has_unguarded_cycle(self, name: str) -> bool:
         scope_refs = self._type_alias_unguarded_refs_by_scope.get(
-            self._current_scope_key(), {}
+            id(self.scopes.current_scope()), {}
         )
         if name not in scope_refs:
             return False
@@ -12881,7 +12876,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             self._record_type_alias_structure(name, node, value_node)
         type_params = tuple(
             (
-                self._bind_type_param_owner(type_param, alias_owner)
+                with_type_param_owner(type_param, alias_owner)
                 if type_param.owner is None
                 else type_param
             )
@@ -13021,7 +13016,24 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             else:
                 alias_obj = None
             type_param_values = []
+            disallow_in_function = self.scopes.scope_type() == ScopeType.function_scope
             if self._is_checking():
+                if disallow_in_function:
+                    self._show_error_if_checking(
+                        node,
+                        "Type alias statements are not allowed inside functions",
+                        error_code=ErrorCode.invalid_type_alias,
+                    )
+                first_by_name = self._type_alias_first_definition_by_scope.get(
+                    self._current_scope_key(), {}
+                )
+                first_definition = first_by_name.get(name)
+                if first_definition is not None and first_definition is not node:
+                    self._show_error_if_checking(
+                        node,
+                        f"Type alias {name} is already defined",
+                        error_code=ErrorCode.already_declared,
+                    )
                 if self._type_alias_has_unguarded_cycle(name):
                     self._show_error_if_checking(
                         node,
@@ -13814,8 +13826,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         minimum_required_len = sum(
             1
             for i, type_param in enumerate(type_parameters)
-            if i not in variadic_type_param_indexes
-            and not self._type_parameter_value_has_default(type_param)
+            if i not in variadic_type_param_indexes and type_param.default is None
         )
         if variadic_type_param_indexes:
             # A TypeVarTuple can absorb any number of type arguments.

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -11215,7 +11215,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         for member in members:
             val = GenericValue(
                 protocol,
-                [TypeVarValue(TypeVarParam(T_co)), TypeVarValue(TypeVarParam(U_co))],
+                [
+                    TypeVarValue(TypeVarParam(T_co, owner=None)),
+                    TypeVarValue(TypeVarParam(U_co, owner=None)),
+                ],
             )
             can_assign = self.get_tv_map(val, member)
             if isinstance(can_assign, CanAssignError):
@@ -11224,10 +11227,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             inferred.append(
                 (
                     can_assign.get_typevar(
-                        TypeVarParam(T_co), AnyValue(AnySource.generic_argument)
+                        TypeVarParam(T_co, owner=None),
+                        AnyValue(AnySource.generic_argument),
                     ),
                     can_assign.get_typevar(
-                        TypeVarParam(U_co), AnyValue(AnySource.generic_argument)
+                        TypeVarParam(U_co, owner=None),
+                        AnyValue(AnySource.generic_argument),
                     ),
                 )
             )

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -1795,7 +1795,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         ast.FunctionDef | ast.AsyncFunctionDef, frozenset[FunctionDecorator]
     ]
     _function_returns_self_by_node: dict[ast.FunctionDef | ast.AsyncFunctionDef, bool]
-    _type_alias_first_definition_by_scope: dict[int, dict[str, ast.AST]]
     _type_alias_unguarded_refs_by_scope: dict[int, dict[str, set[str]]]
     _method_cache: dict[type[ast.AST], Callable[[Any], Value | None]]
     _name_node_to_statement: dict[ast.AST, ast.AST | None] | None
@@ -1966,7 +1965,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         self._pending_overload_blocks = {}
         self._function_decorator_kinds_by_node = {}
         self._function_returns_self_by_node = {}
-        self._type_alias_first_definition_by_scope = {}
         self._type_alias_unguarded_refs_by_scope = {}
         self._method_cache = {}
         self._statement_types = set()
@@ -12390,11 +12388,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def _record_type_alias_structure(
         self, name: str, alias_node: ast.AST, value_node: ast.AST
     ) -> None:
-        scope_key = self._current_scope_key()
-        first_by_name = self._type_alias_first_definition_by_scope.setdefault(
-            scope_key, {}
-        )
-        first_by_name.setdefault(name, alias_node)
+        scope_key = id(self.scopes.current_scope())
         refs_by_name = self._type_alias_unguarded_refs_by_scope.setdefault(
             scope_key, {}
         )
@@ -12892,24 +12886,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             else:
                 alias_obj = None
             type_param_values = []
-            disallow_in_function = self.scopes.scope_type() == ScopeType.function_scope
             if self._is_checking():
-                if disallow_in_function:
-                    self._show_error_if_checking(
-                        node,
-                        "Type alias statements are not allowed inside functions",
-                        error_code=ErrorCode.invalid_type_alias,
-                    )
-                first_by_name = self._type_alias_first_definition_by_scope.get(
-                    self._current_scope_key(), {}
-                )
-                first_definition = first_by_name.get(name)
-                if first_definition is not None and first_definition is not node:
-                    self._show_error_if_checking(
-                        node,
-                        f"Type alias {name} is already defined",
-                        error_code=ErrorCode.already_declared,
-                    )
                 if self._type_alias_has_unguarded_cycle(name):
                     self._show_error_if_checking(
                         node,

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -8372,13 +8372,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def _set_argspec_to_retval(
         self, val: Value, info: FunctionInfo, result: FunctionResult
     ) -> None:
-        def is_safe_decorator(decorator: Value) -> bool:
-            if decorator in SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL:
-                return True
-            return isinstance(decorator, KnownValue) and AsynqDecorators.contains(
-                decorator.val, self.options
-            )
-
         if isinstance(info.node, ast.Lambda) or info.node.returns is not None:
             return
         if info.async_kind == AsyncFunctionKind.async_proxy:
@@ -8390,7 +8383,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             if len(info.decorators) != 1:
                 return  # With decorators we don't know what it will return
             unapplied_decorator, _, _ = next(iter(info.decorators))
-            if not is_safe_decorator(unapplied_decorator):
+            if unapplied_decorator not in SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL:
                 return  # With decorators we don't know what it will return
         return_value = result.return_value
 

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -739,6 +739,10 @@ class _AttrContext(CheckerAttrContext):
     ) -> AttributePolicy:
         return AttributePolicy(
             on_class=on_class,
+            is_special_lookup=self.self_value is not None
+            and self.attr.startswith("__")
+            and self.attr.endswith("__")
+            and _attribute_root_class_info(self.self_value).is_class_object is True,
             receiver=receiver,
             visitor=self.visitor,
             node=self.node,

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -973,18 +973,6 @@ def _has_relation(
             generic_args = right_tobj.get_generic_args_for_base(
                 left.typ, right.args if isinstance(right, GenericValue) else ()
             )
-            if generic_args is None:
-                fallback_bases = ctx.get_generic_bases(
-                    right.typ, right.args if isinstance(right, GenericValue) else ()
-                )
-                fallback_tv_map = fallback_bases.get(left.typ)
-                if fallback_tv_map is not None:
-                    generic_args = [
-                        fallback_tv_map.get_value(
-                            type_param, default_value_for_type_param(type_param)
-                        )
-                        for type_param in ctx.get_type_parameters(left.typ)
-                    ]
             if generic_args is not None:
                 comparison_left = left
                 left_tobj = left.get_type_object(ctx)

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -21,7 +21,7 @@ from typing_extensions import Sentinel, assert_never
 
 import pycroscope
 from pycroscope.find_unused import used
-from pycroscope.safe import safe_equals, safe_isinstance
+from pycroscope.safe import is_typing_name, safe_equals, safe_isinstance
 from pycroscope.typevar import resolve_bounds_map
 from pycroscope.value import (
     NO_RETURN_VALUE,
@@ -53,6 +53,7 @@ from pycroscope.value import (
     ParamSpecParam,
     PartialCallValue,
     PartialValue,
+    PartialValueOperation,
     PredicateValue,
     SequenceValue,
     SimpleType,
@@ -972,6 +973,18 @@ def _has_relation(
             generic_args = right_tobj.get_generic_args_for_base(
                 left.typ, right.args if isinstance(right, GenericValue) else ()
             )
+            if generic_args is None:
+                fallback_bases = ctx.get_generic_bases(
+                    right.typ, right.args if isinstance(right, GenericValue) else ()
+                )
+                fallback_tv_map = fallback_bases.get(left.typ)
+                if fallback_tv_map is not None:
+                    generic_args = [
+                        fallback_tv_map.get_value(
+                            type_param, default_value_for_type_param(type_param)
+                        )
+                        for type_param in ctx.get_type_parameters(left.typ)
+                    ]
             if generic_args is not None:
                 comparison_left = left
                 left_tobj = left.get_type_object(ctx)
@@ -1339,12 +1352,24 @@ def _extract_type_form(value: Value, ctx: CanAssignContext) -> Value | CanAssign
         # Annotated metadata is ignored for implicit TypeForm extraction.
         return _extract_type_form(value.value, ctx)
     elif isinstance(value, (PartialValue, PartialCallValue)):
-        from pycroscope.annotations import type_from_value
+        from pycroscope.annotations import make_type_param_from_value, type_from_value
+
+        if (
+            isinstance(value, PartialValue)
+            and value.operation is PartialValueOperation.SUBSCRIPT
+            and isinstance(value.root, KnownValue)
+            and is_typing_name(value.root.val, "Unpack")
+        ):
+            return CanAssignError(f"{value} is not a TypeForm")
+        if isinstance(value, PartialCallValue):
+            type_param = make_type_param_from_value(value, visitor=ctx)
+            if type_param is not None and type_param.owner is None:
+                return CanAssignError(f"{value} is not a TypeForm")
 
         extracted = type_from_value(value, visitor=ctx, suppress_errors=True)
         if extracted != AnyValue(AnySource.error):
             return _extract_type_form(extracted, ctx)
-        return _extract_type_form(value.get_fallback_value(), ctx)
+        return CanAssignError(f"{value} is not a TypeForm")
     elif isinstance(value, MultiValuedValue):
         vals: list[Value] = []
         for subval in value.vals:
@@ -1389,9 +1414,11 @@ def _extract_type_form(value: Value, ctx: CanAssignContext) -> Value | CanAssign
         if isinstance(type_form, AnyValue) and type_form.source is AnySource.error:
             return CanAssignError(f"{value} is not a TypeForm")
         extracted = gradualize(type_form)
-        if isinstance(extracted, (TypeVarValue, TypeVarTupleValue)) and (
-            isinstance(extracted, TypeVarTupleValue) or extracted.typevar_param.is_self
+        if isinstance(extracted, TypeVarValue) and (
+            extracted.typevar_param.owner is None or extracted.typevar_param.is_self
         ):
+            return CanAssignError(f"{value} is not a TypeForm")
+        if isinstance(extracted, TypeVarTupleValue):
             return CanAssignError(f"{value} is not a TypeForm")
         if isinstance(extracted, (ParamSpecArgsValue, ParamSpecKwargsValue)):
             return CanAssignError(f"{value} is not a TypeForm")
@@ -1404,10 +1431,14 @@ def _extract_type_form(value: Value, ctx: CanAssignContext) -> Value | CanAssign
         return AnyValue(AnySource.inference)
     elif isinstance(value, TypedValue):
         return CanAssignError(f"{value} is not a TypeForm")
-    elif isinstance(value, (AnyValue, TypeAliasValue)):
+    elif isinstance(value, AnyValue):
+        if value.source is AnySource.error:
+            return CanAssignError(f"{value} is not a TypeForm")
+        return value
+    elif isinstance(value, TypeAliasValue):
         return value
     elif isinstance(value, TypeVarValue):
-        if value.typevar_param.is_self:
+        if value.typevar_param.owner is None or value.typevar_param.is_self:
             return CanAssignError(f"{value} is not a TypeForm")
         return value
     elif isinstance(

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -1370,7 +1370,7 @@ class Signature:
                 ):
                     star_kwargs_consumed = True
                     star_args_consumed = True
-                    sig = ParamSpecParam(actual_args.star_kwargs.param_spec)
+                    sig = ParamSpecParam(actual_args.star_kwargs.param_spec, owner=None)
                     composite = Composite(InputSigValue(sig))
                     bound_args[param.name] = KWARGS, composite
                 else:
@@ -2432,11 +2432,13 @@ def preprocess_args(
                 processed_args.append(
                     (
                         Composite(
-                            InputSigValue(ParamSpecParam(arg.value.param_spec)),
+                            InputSigValue(
+                                ParamSpecParam(arg.value.param_spec, owner=None)
+                            ),
                             arg.varname,
                             arg.node,
                         ),
-                        ParamSpecParam(arg.value.param_spec),
+                        ParamSpecParam(arg.value.param_spec, owner=None),
                     )
                 )
                 continue
@@ -2634,10 +2636,10 @@ def _preprocess_kwargs_no_mvv(
             ctx.on_error(f"{value} is not a mapping", detail=str(mapping_tv_map))
             return None
         key_type = mapping_tv_map.get_typevar(
-            TypeVarParam(K), AnyValue(AnySource.generic_argument)
+            TypeVarParam(K, owner=None), AnyValue(AnySource.generic_argument)
         )
         value_type = mapping_tv_map.get_typevar(
-            TypeVarParam(V), AnyValue(AnySource.generic_argument)
+            TypeVarParam(V, owner=None), AnyValue(AnySource.generic_argument)
         )
         return _preprocess_kwargs_kv_pairs(
             [KVPair(key_type, value_type, is_many=True)], ctx
@@ -3186,7 +3188,10 @@ K = TypeVar("K")
 V = TypeVar("V")
 MappingValue = GenericValue(
     collections.abc.Mapping,
-    [TypeVarValue(TypeVarParam(K)), TypeVarValue(TypeVarParam(V))],
+    [
+        TypeVarValue(TypeVarParam(K, owner=None)),
+        TypeVarValue(TypeVarParam(V, owner=None)),
+    ],
 )
 
 
@@ -4313,7 +4318,7 @@ def has_relation_var_keyword(
                 f"{kwargs_annotation} is not a mapping type", [mapping_tv_map]
             )
         key_arg = mapping_tv_map.get_typevar(
-            TypeVarParam(K), AnyValue(AnySource.generic_argument)
+            TypeVarParam(K, owner=None), AnyValue(AnySource.generic_argument)
         )
         can_assign = has_relation(key_arg, KnownValue(my_param.name), relation, ctx)
         if isinstance(can_assign, CanAssignError):
@@ -4323,7 +4328,7 @@ def has_relation_var_keyword(
             )
         bounds_maps.append(can_assign)
         value_arg = mapping_tv_map.get_typevar(
-            TypeVarParam(V), AnyValue(AnySource.generic_argument)
+            TypeVarParam(V, owner=None), AnyValue(AnySource.generic_argument)
         )
         can_assign = has_relation(value_arg, my_annotation, relation, ctx)
         if isinstance(can_assign, CanAssignError):
@@ -4347,5 +4352,5 @@ def _get_var_keyword_value_type(
     if isinstance(mapping_tv_map, CanAssignError):
         return None
     return mapping_tv_map.get_typevar(
-        TypeVarParam(V), AnyValue(AnySource.generic_argument)
+        TypeVarParam(V, owner=None), AnyValue(AnySource.generic_argument)
     )

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -2063,6 +2063,8 @@ class Signature:
                     params.append((name, param.substitute_typevars(typevars)))
             else:
                 substituted = param.substitute_typevars(typevars)
+                # TODO: this seems to be a workaround for some poor handling of
+                # TypeVarTuple.
                 if (
                     substituted.name.startswith("@")
                     and substituted.kind is ParameterKind.POSITIONAL_ONLY

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -721,6 +721,7 @@ class Signature:
                 self.has_return_annotation,
                 self.allow_call,
                 self.allow_partial_call,
+                self.evaluator,
             )
         )
 
@@ -2061,7 +2062,29 @@ class Signature:
                 else:
                     params.append((name, param.substitute_typevars(typevars)))
             else:
-                params.append((name, param.substitute_typevars(typevars)))
+                substituted = param.substitute_typevars(typevars)
+                if (
+                    substituted.name.startswith("@")
+                    and substituted.kind is ParameterKind.POSITIONAL_ONLY
+                    and isinstance(substituted.annotation, TypeVarTupleBindingValue)
+                    and not any(
+                        is_many for is_many, _ in substituted.annotation.binding
+                    )
+                ):
+                    for member in substituted.annotation.binding:
+                        expanded_name = f"@expanded{len(params)}"
+                        params.append(
+                            (
+                                expanded_name,
+                                replace(
+                                    substituted,
+                                    name=expanded_name,
+                                    annotation=member[1],
+                                ),
+                            )
+                        )
+                else:
+                    params.append((name, substituted))
         params_dict = dict(params)
         return_value = self.return_value.substitute_typevars(typevars)
         bound_receiver_composite = (
@@ -3051,12 +3074,7 @@ class BoundMethodSignature:
     return_override: Value | None = None
 
     def check_call(self, args: Iterable[Argument], ctx: CheckCallContext) -> Value:
-        bound_signature = self.get_signature(ctx=ctx.can_assign_ctx, preserve_impl=True)
-        if bound_signature is None:
-            return AnyValue(AnySource.error)
-        if isinstance(bound_signature, Signature) and bound_signature.allow_call:
-            bound_signature = replace(bound_signature, allow_call=False)
-        ret = bound_signature.check_call(list(args), ctx)
+        ret = self.signature.check_call([(self.self_composite, None), *args], ctx)
         if self.return_override is not None and not self.signature.has_return_value():
             if isinstance(ret, AnnotatedValue):
                 return annotate_value(self.return_override, ret.metadata)
@@ -3229,10 +3247,23 @@ def _typevartuple_param_index(params: Sequence[SigParameter]) -> int | None:
     indices = [
         i
         for i, param in enumerate(params)
-        if isinstance(param.annotation, TypeVarTupleValue)
+        if _callable_typevartuple_marker(param.annotation) is not None
     ]
     if len(indices) == 1:
         return indices[0]
+    return None
+
+
+def _callable_typevartuple_marker(annotation: Value) -> TypeVarTupleValue | None:
+    if isinstance(annotation, TypeVarTupleValue):
+        return annotation
+    if (
+        isinstance(annotation, TypeVarTupleBindingValue)
+        and len(annotation.binding) == 1
+        and annotation.binding[0][0]
+        and isinstance(annotation.binding[0][1], TypeVarTupleValue)
+    ):
+        return annotation.binding[0][1]
     return None
 
 
@@ -3445,8 +3476,8 @@ def _try_typevartuple_callable_relation(
             )
         captured_bounds_maps.append(tv_map)
 
-    marker_annotation = marker_param.annotation
-    assert isinstance(marker_annotation, TypeVarTupleValue), marker_annotation
+    marker_annotation = _callable_typevartuple_marker(marker_param.annotation)
+    assert marker_annotation is not None, marker_param.annotation
     captured_members = [
         (False, _widen_typevartuple_inferred_value(param.get_annotation()))
         for param in middle

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -721,7 +721,6 @@ class Signature:
                 self.has_return_annotation,
                 self.allow_call,
                 self.allow_partial_call,
-                self.evaluator,
             )
         )
 
@@ -3052,7 +3051,12 @@ class BoundMethodSignature:
     return_override: Value | None = None
 
     def check_call(self, args: Iterable[Argument], ctx: CheckCallContext) -> Value:
-        ret = self.signature.check_call([(self.self_composite, None), *args], ctx)
+        bound_signature = self.get_signature(ctx=ctx.can_assign_ctx, preserve_impl=True)
+        if bound_signature is None:
+            return AnyValue(AnySource.error)
+        if isinstance(bound_signature, Signature) and bound_signature.allow_call:
+            bound_signature = replace(bound_signature, allow_call=False)
+        ret = bound_signature.check_call(list(args), ctx)
         if self.return_override is not None and not self.signature.has_return_value():
             if isinstance(ret, AnnotatedValue):
                 return annotate_value(self.return_override, ret.metadata)

--- a/pycroscope/test_annotations.py
+++ b/pycroscope/test_annotations.py
@@ -1236,15 +1236,11 @@ class TestCallable(TestNameCheckVisitorBase):
 class TestTypeVar(TestNameCheckVisitorBase):
     @assert_passes(allow_import_failures=True)
     def test_invalid_typevar_constructor_args(self):
-        from typing_extensions import TypeVar
+        from typing_extensions import TypeVar as TV
 
-        TypeVar("SingleConstraint", str)  # E: incompatible_call
-        TypeVar(
-            "InferCovariant", infer_variance=True, covariant=True
-        )  # E: incompatible_call
-        TypeVar(
-            "InferContravariant", infer_variance=True, contravariant=True
-        )  # E: incompatible_call
+        TV("Single", str)  # E: incompatible_call
+        TV("ICo", infer_variance=True, covariant=True)  # E: incompatible_call
+        TV("IContra", infer_variance=True, contravariant=True)  # E: incompatible_call
 
     @assert_passes()
     def test_bound(self):

--- a/pycroscope/test_annotations.py
+++ b/pycroscope/test_annotations.py
@@ -1,14 +1,17 @@
 # static analysis: ignore
 
+import ast
 import sys
 
-from .annotations import has_invalid_paramspec_usage
+from .annotations import _DefaultContext, has_invalid_paramspec_usage, type_from_runtime
 from .error_code import ErrorCode
 from .signature import OverloadedSignature, Signature, SigParameter
-from .test_name_check_visitor import TestNameCheckVisitorBase
+from .test_name_check_visitor import TestNameCheckVisitorBase, _make_checked_visitor
 from .test_node_visitor import assert_passes, skip_before, skip_if_not_installed
 from .tests import make_simple_sequence
+from .type_params import ActiveTypeParams
 from .value import (
+    AliasOwner,
     AnnotatedValue,
     AnySource,
     AnyValue,
@@ -18,6 +21,7 @@ from .value import (
     MultiValuedValue,
     NewTypeValue,
     SequenceValue,
+    TypeAliasValue,
     TypedDictEntry,
     TypedDictValue,
     TypedValue,
@@ -38,6 +42,46 @@ _ABSTRACT_CONTEXT_MANAGER_INT = GenericValue(
         else [TypedValue(int)]
     ),
 )
+
+
+def test_default_context_has_active_type_params() -> None:
+    ctx = _DefaultContext(visitor=None, node=None)
+    assert isinstance(ctx.active_type_params, ActiveTypeParams)
+
+
+@skip_before((3, 12))
+def test_default_context_reuses_visitor_active_type_params() -> None:
+    visitor, tree = _make_checked_visitor("""
+        def f[T](x: T) -> T:
+            return x
+        """)
+    function = tree.body[0]
+    assert isinstance(function, ast.FunctionDef)
+    ctx = _DefaultContext(visitor=visitor, node=function)
+    assert ctx.active_type_params is visitor.active_type_params
+
+
+@skip_before((3, 12))
+def test_runtime_type_alias_type_params_get_alias_owner() -> None:
+    ns: dict[str, object] = {}
+    exec(
+        """
+type Alias[T] = list[T]
+""",
+        ns,
+        ns,
+    )
+    value = type_from_runtime(ns["Alias"], ctx=_DefaultContext(visitor=None, node=None))
+    assert isinstance(value, TypeAliasValue)
+    (type_param,) = value.alias.get_type_params()
+    assert isinstance(type_param.owner, AliasOwner)
+    assert type_param.owner.identity is ns["Alias"]
+    assert str(type_param.owner).endswith(".Alias")
+    alias_value = value.alias.get_value()
+    assert isinstance(alias_value, GenericValue)
+    (inner_arg,) = alias_value.args
+    assert isinstance(inner_arg, TypeVarValue)
+    assert inner_arg.typevar_param.owner == type_param.owner
 
 
 class TestAnnotations(TestNameCheckVisitorBase):
@@ -1216,10 +1260,8 @@ class TestTypeVar(TestNameCheckVisitorBase):
         from typing_extensions import Literal
 
         IntT = TypeVar("IntT", bound=int)
-        expected = TypeVarValue(TypeVarParam(IntT, bound=TypedValue(int)))
 
         def f(x: IntT) -> IntT:
-            assert_is_value(x, expected)
             print(x + 1)
             return x
 

--- a/pycroscope/test_annotations.py
+++ b/pycroscope/test_annotations.py
@@ -2,14 +2,13 @@
 
 import sys
 
-from .annotations import _DefaultContext, has_invalid_paramspec_usage, type_from_runtime
+from .annotations import has_invalid_paramspec_usage
 from .error_code import ErrorCode
 from .signature import OverloadedSignature, Signature, SigParameter
 from .test_name_check_visitor import TestNameCheckVisitorBase
 from .test_node_visitor import assert_passes, skip_before, skip_if_not_installed
 from .tests import make_simple_sequence
 from .value import (
-    AliasOwner,
     AnnotatedValue,
     AnySource,
     AnyValue,
@@ -19,12 +18,10 @@ from .value import (
     MultiValuedValue,
     NewTypeValue,
     SequenceValue,
-    TypeAliasValue,
     TypedDictEntry,
     TypedDictValue,
     TypedValue,
     TypeVarParam,
-    TypeVarValue,
     assert_is_value,
     class_owner_from_key,
 )
@@ -40,29 +37,6 @@ _ABSTRACT_CONTEXT_MANAGER_INT = GenericValue(
         else [TypedValue(int)]
     ),
 )
-
-
-@skip_before((3, 12))
-def test_runtime_type_alias_type_params_get_alias_owner() -> None:
-    ns: dict[str, object] = {}
-    exec(
-        """
-type Alias[T] = list[T]
-""",
-        ns,
-        ns,
-    )
-    value = type_from_runtime(ns["Alias"], ctx=_DefaultContext(visitor=None, node=None))
-    assert isinstance(value, TypeAliasValue)
-    (type_param,) = value.alias.get_type_params()
-    assert isinstance(type_param.owner, AliasOwner)
-    assert type_param.owner.identity is ns["Alias"]
-    assert str(type_param.owner).endswith(".Alias")
-    alias_value = value.alias.get_value()
-    assert isinstance(alias_value, GenericValue)
-    (inner_arg,) = alias_value.args
-    assert isinstance(inner_arg, TypeVarValue)
-    assert inner_arg.typevar_param.owner == type_param.owner
 
 
 class TestAnnotations(TestNameCheckVisitorBase):

--- a/pycroscope/test_annotations.py
+++ b/pycroscope/test_annotations.py
@@ -1,15 +1,13 @@
 # static analysis: ignore
 
-import ast
 import sys
 
 from .annotations import _DefaultContext, has_invalid_paramspec_usage, type_from_runtime
 from .error_code import ErrorCode
 from .signature import OverloadedSignature, Signature, SigParameter
-from .test_name_check_visitor import TestNameCheckVisitorBase, _make_checked_visitor
+from .test_name_check_visitor import TestNameCheckVisitorBase
 from .test_node_visitor import assert_passes, skip_before, skip_if_not_installed
 from .tests import make_simple_sequence
-from .type_params import ActiveTypeParams
 from .value import (
     AliasOwner,
     AnnotatedValue,
@@ -42,23 +40,6 @@ _ABSTRACT_CONTEXT_MANAGER_INT = GenericValue(
         else [TypedValue(int)]
     ),
 )
-
-
-def test_default_context_has_active_type_params() -> None:
-    ctx = _DefaultContext(visitor=None, node=None)
-    assert isinstance(ctx.active_type_params, ActiveTypeParams)
-
-
-@skip_before((3, 12))
-def test_default_context_reuses_visitor_active_type_params() -> None:
-    visitor, tree = _make_checked_visitor("""
-        def f[T](x: T) -> T:
-            return x
-        """)
-    function = tree.body[0]
-    assert isinstance(function, ast.FunctionDef)
-    ctx = _DefaultContext(visitor=visitor, node=function)
-    assert ctx.active_type_params is visitor.active_type_params
 
 
 @skip_before((3, 12))

--- a/pycroscope/test_annotations.py
+++ b/pycroscope/test_annotations.py
@@ -1767,11 +1767,11 @@ class TestCustomCheck(TestNameCheckVisitorBase):
 
             def walk_values(self) -> Iterable[Value]:
                 if isinstance(self.value, TypeVar):
-                    yield TypeVarValue(TypeVarParam(self.value))
+                    yield TypeVarValue(TypeVarParam(self.value, owner=None))
 
             def substitute_typevars(self, typevars: TypeVarMap) -> "GreaterThan":
                 if isinstance(self.value, TypeVar):
-                    value = typevars.get_typevar(TypeVarParam(self.value))
+                    value = typevars.get_typevar(TypeVarParam(self.value, owner=None))
                     if isinstance(value, KnownValue) and isinstance(value.val, int):
                         return GreaterThan(value.val)
                 return self

--- a/pycroscope/test_annotations.py
+++ b/pycroscope/test_annotations.py
@@ -1234,6 +1234,18 @@ class TestCallable(TestNameCheckVisitorBase):
 
 
 class TestTypeVar(TestNameCheckVisitorBase):
+    @assert_passes(allow_import_failures=True)
+    def test_invalid_typevar_constructor_args(self):
+        from typing_extensions import TypeVar
+
+        TypeVar("SingleConstraint", str)  # E: incompatible_call
+        TypeVar(
+            "InferCovariant", infer_variance=True, covariant=True
+        )  # E: incompatible_call
+        TypeVar(
+            "InferContravariant", infer_variance=True, contravariant=True
+        )  # E: incompatible_call
+
     @assert_passes()
     def test_bound(self):
         from typing import TypeVar

--- a/pycroscope/test_arg_spec.py
+++ b/pycroscope/test_arg_spec.py
@@ -1,7 +1,7 @@
 # static analysis: ignore
 import functools
 from dataclasses import dataclass
-from typing import Generic, List, NewType
+from typing import List, NewType
 
 import pytest
 from typing_extensions import ParamSpec, Self, TypeVar, TypeVarTuple
@@ -69,16 +69,6 @@ def test_get_type_parameters_ignores_non_iterable_runtime_type_params() -> None:
         __type_params__ = property(lambda self: ())
 
     assert checker.arg_spec_cache.get_type_parameters(Weird) == []
-
-
-def test_runtime_class_type_params_get_class_owner() -> None:
-    checker = Checker()
-
-    class Box(Generic[T]):
-        pass
-
-    (type_param,) = checker.arg_spec_cache.get_type_parameters(Box)
-    assert type_param.owner is Box
 
 
 @skip_before((3, 12))

--- a/pycroscope/test_arg_spec.py
+++ b/pycroscope/test_arg_spec.py
@@ -53,13 +53,19 @@ def test_type_param_str_is_concise() -> None:
     p = ParamSpec("P")
     ts = TypeVarTuple("Ts")
 
-    assert str(TypeVarParam(bounded, bound=TypedValue(int))) == "~S"
+    assert str(TypeVarParam(bounded, owner=None, bound=TypedValue(int))) == "~S"
     assert (
-        str(TypeVarParam(constrained, constraints=(TypedValue(str), TypedValue(bytes))))
+        str(
+            TypeVarParam(
+                constrained,
+                owner=None,
+                constraints=(TypedValue(str), TypedValue(bytes)),
+            )
+        )
         == "~T"
     )
-    assert str(ParamSpecParam(p)) == "**P"
-    assert str(TypeVarTupleParam(ts)) == "*Ts"
+    assert str(ParamSpecParam(p, owner=None)) == "**P"
+    assert str(TypeVarTupleParam(ts, owner=None)) == "*Ts"
 
 
 def test_get_type_parameters_ignores_non_iterable_runtime_type_params() -> None:
@@ -99,9 +105,11 @@ class Box[T]:
 def test_match_typevar_arguments_preserves_suffix_after_default_before_typevartuple() -> (
     None
 ):
-    default_t = TypeVarParam(TypeVar("DefaultT", default=int), default=TypedValue(int))
-    ts = TypeVarTupleParam(TypeVarTuple("Ts"))
-    u = TypeVarParam(TypeVar("U"))
+    default_t = TypeVarParam(
+        TypeVar("DefaultT", default=int), owner=None, default=TypedValue(int)
+    )
+    ts = TypeVarTupleParam(TypeVarTuple("Ts"), owner=None)
+    u = TypeVarParam(TypeVar("U"), owner=None)
 
     assert match_typevar_arguments([default_t, ts, u], [TypedValue(str)]) == [
         (default_t, TypedValue(int)),
@@ -118,9 +126,9 @@ def test_specialize_generic_type_params_preserves_suffix_with_default_prefix() -
 
     assert checker.arg_spec_cache._specialize_generic_type_params(
         [
-            TypeVarParam(default_t, default=TypedValue(int)),
-            TypeVarTupleParam(ts),
-            TypeVarParam(u),
+            TypeVarParam(default_t, owner=None, default=TypedValue(int)),
+            TypeVarTupleParam(ts, owner=None),
+            TypeVarParam(u, owner=None),
         ],
         [TypedValue(str)],
     ) == [TypedValue(int), SequenceValue(tuple, []), TypedValue(str)]

--- a/pycroscope/test_arg_spec.py
+++ b/pycroscope/test_arg_spec.py
@@ -1,7 +1,7 @@
 # static analysis: ignore
 import functools
 from dataclasses import dataclass
-from typing import List, NewType
+from typing import Generic, List, NewType
 
 import pytest
 from typing_extensions import ParamSpec, Self, TypeVar, TypeVarTuple
@@ -14,10 +14,11 @@ from .test_name_check_visitor import (
     ConfiguredNameCheckVisitor,
     TestNameCheckVisitorBase,
 )
-from .test_node_visitor import assert_passes
+from .test_node_visitor import assert_passes, skip_before
 from .value import (
     AnySource,
     AnyValue,
+    FunctionOwner,
     GenericValue,
     KnownValue,
     NewTypeValue,
@@ -68,6 +69,41 @@ def test_get_type_parameters_ignores_non_iterable_runtime_type_params() -> None:
         __type_params__ = property(lambda self: ())
 
     assert checker.arg_spec_cache.get_type_parameters(Weird) == []
+
+
+def test_runtime_class_type_params_get_class_owner() -> None:
+    checker = Checker()
+
+    class Box(Generic[T]):
+        pass
+
+    (type_param,) = checker.arg_spec_cache.get_type_parameters(Box)
+    assert type_param.owner is Box
+
+
+@skip_before((3, 12))
+def test_runtime_generic_method_annotations_use_scoped_type_param_owners() -> None:
+    checker = Checker()
+    ns: dict[str, object] = {}
+    exec(
+        """
+class Box[T]:
+    def f[U](self, x: T, y: U) -> tuple[T, U]:
+        raise NotImplementedError
+""",
+        ns,
+        ns,
+    )
+    Box = ns["Box"]
+    sig = checker.arg_spec_cache.get_argspec(Box.f)
+    assert isinstance(sig, Signature)
+    x_annotation = sig.parameters["x"].annotation
+    y_annotation = sig.parameters["y"].annotation
+    assert isinstance(x_annotation, TypeVarValue)
+    assert x_annotation.typevar_param.owner is Box
+    assert isinstance(y_annotation, TypeVarValue)
+    assert isinstance(y_annotation.typevar_param.owner, FunctionOwner)
+    assert y_annotation.typevar_param.owner.identity is Box.f
 
 
 def test_match_typevar_arguments_preserves_suffix_after_default_before_typevartuple() -> (

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -30,7 +30,6 @@ from .value import (
     NO_RETURN_VALUE,
     UNINITIALIZED_VALUE,
     UNRESOLVED_VALUE,
-    AliasOwner,
     AnnotatedValue,
     AnySource,
     AnyValue,
@@ -48,7 +47,6 @@ from .value import (
     SequenceValue,
     SubclassValue,
     SyntheticClassObjectValue,
-    TypeAliasValue,
     TypedDictEntry,
     TypedDictValue,
     TypedValue,
@@ -328,40 +326,6 @@ def test_legacy_function_type_params_get_function_owner() -> None:
         x_param = next(param for param in info.params if param.param.name == "x")
         assert isinstance(x_param.param.annotation, TypeVarValue)
         assert x_param.param.annotation.typevar_param.owner == owner
-
-
-@skip_before((3, 12))
-def test_pep695_class_type_params_get_class_owner() -> None:
-    visitor, _ = _make_checked_visitor("""
-        class Box[T]:
-            pass
-        """)
-    (type_param,) = visitor.checker.make_type_object(
-        visitor.module.Box
-    ).get_declared_type_params()
-    assert type_param.owner is visitor.module.Box
-
-
-def test_legacy_type_alias_type_params_get_alias_owner() -> None:
-    visitor, tree = _make_checked_visitor("""
-        from typing import TypeVar
-
-        T = TypeVar("T")
-        Alias = list[T]
-        """)
-    alias_node = next(
-        stmt
-        for stmt in tree.body
-        if isinstance(stmt, ast.Assign)
-        and len(stmt.targets) == 1
-        and isinstance(stmt.targets[0], ast.Name)
-        and stmt.targets[0].id == "Alias"
-    )
-    alias_value = visitor.scopes.module_scope().get_declared_type("Alias")
-    assert isinstance(alias_value, TypeAliasValue)
-    (type_param,) = alias_value.alias.get_type_params()
-    assert isinstance(type_param.owner, AliasOwner)
-    assert str(type_param.owner).endswith(".Alias")
 
 
 def test_direct_type_parameter_constructors_stay_deferred_until_bound() -> None:

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -30,21 +30,25 @@ from .value import (
     NO_RETURN_VALUE,
     UNINITIALIZED_VALUE,
     UNRESOLVED_VALUE,
+    AliasOwner,
     AnnotatedValue,
     AnySource,
     AnyValue,
     AsyncTaskIncompleteValue,
     CallableValue,
     DictIncompleteValue,
+    FunctionOwner,
     GenericValue,
     KnownValue,
     KVPair,
     MultiValuedValue,
     NewTypeValue,
+    PartialCallValue,
     ReferencingValue,
     SequenceValue,
     SubclassValue,
     SyntheticClassObjectValue,
+    TypeAliasValue,
     TypedDictEntry,
     TypedDictValue,
     TypedValue,
@@ -244,6 +248,24 @@ def _make_module(code_str: str) -> types.ModuleType:
     return make_module(code_str, extra_scope)
 
 
+def _make_checked_visitor(
+    code_str: str,
+) -> tuple[ConfiguredNameCheckVisitor, ast.Module]:
+    code_str = textwrap.dedent(code_str)
+    tree = ast.parse(code_str)
+    module = _make_module(code_str)
+    settings = {code: code not in DISABLED_IN_TESTS for code in ErrorCode}
+    kwargs = ConfiguredNameCheckVisitor.prepare_constructor_kwargs(
+        {"settings": settings}
+    )
+    visitor = ConfiguredNameCheckVisitor(
+        module.__name__, code_str, tree, module=module, verbosity=0, **kwargs
+    )
+    assert visitor.check_for_test() == []
+    assert visitor.perform_final_checks(kwargs) == []
+    return visitor, tree
+
+
 # ===================================================
 # Tests for specific functionality.
 # ===================================================
@@ -256,6 +278,126 @@ def test_annotation():
         "<test input>", "int()", tree, module=ast, annotate=True, checker=checker
     ).check()
     assert TypedValue(int) == tree.inferred_value
+
+
+@skip_before((3, 12))
+def test_pep695_function_type_params_get_function_owner() -> None:
+    visitor, tree = _make_checked_visitor("""
+        def f[T](x: T) -> T:
+            return x
+        """)
+    function_node = next(
+        stmt
+        for stmt in tree.body
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+    )
+    runtime_function = visitor.module.f
+    with visitor.compute_function_info(
+        function_node, potential_function=runtime_function
+    ) as info:
+        assert len(info.type_params) == 1
+        owner = info.type_params[0].owner
+        assert isinstance(owner, FunctionOwner)
+        assert owner.identity is runtime_function
+        assert str(owner).endswith(".f")
+
+
+def test_legacy_function_type_params_get_function_owner() -> None:
+    visitor, tree = _make_checked_visitor("""
+        from typing import TypeVar
+
+        T = TypeVar("T")
+
+        def f(x: T) -> T:
+            return x
+        """)
+    function_node = next(
+        stmt
+        for stmt in tree.body
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+    )
+    runtime_function = visitor.module.f
+    with visitor.compute_function_info(
+        function_node, potential_function=runtime_function
+    ) as info:
+        assert len(info.type_params) == 1
+        owner = info.type_params[0].owner
+        assert isinstance(owner, FunctionOwner)
+        assert owner.identity is runtime_function
+        assert str(owner).endswith(".f")
+        x_param = next(param for param in info.params if param.param.name == "x")
+        assert isinstance(x_param.param.annotation, TypeVarValue)
+        assert x_param.param.annotation.typevar_param.owner == owner
+
+
+@skip_before((3, 12))
+def test_pep695_class_type_params_get_class_owner() -> None:
+    visitor, _ = _make_checked_visitor("""
+        class Box[T]:
+            pass
+        """)
+    (type_param,) = visitor.checker.make_type_object(
+        visitor.module.Box
+    ).get_declared_type_params()
+    assert type_param.owner is visitor.module.Box
+
+
+def test_legacy_type_alias_type_params_get_alias_owner() -> None:
+    visitor, tree = _make_checked_visitor("""
+        from typing import TypeVar
+
+        T = TypeVar("T")
+        Alias = list[T]
+        """)
+    alias_node = next(
+        stmt
+        for stmt in tree.body
+        if isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+        and stmt.targets[0].id == "Alias"
+    )
+    alias_value = visitor.scopes.module_scope().get_declared_type("Alias")
+    assert isinstance(alias_value, TypeAliasValue)
+    (type_param,) = alias_value.alias.get_type_params()
+    assert isinstance(type_param.owner, AliasOwner)
+    assert str(type_param.owner).endswith(".Alias")
+
+
+def test_direct_type_parameter_constructors_stay_deferred_until_bound() -> None:
+    visitor, tree = _make_checked_visitor("""
+        from typing_extensions import ParamSpec, TypeVar, TypeVarTuple
+
+        T = TypeVar("T")
+        P = ParamSpec("P")
+        Ts = TypeVarTuple("Ts")
+        """)
+    for name in ("T", "P", "Ts"):
+        node = ast.Name(name, ast.Load())
+        value, _ = visitor.resolve_name(node)
+        assert isinstance(value, PartialCallValue)
+
+
+def test_legacy_class_type_param_defaults_rebind_nested_owners() -> None:
+    visitor, _ = _make_checked_visitor("""
+        from typing import Generic
+        from typing_extensions import TypeVar
+
+        T = TypeVar("T")
+        U = TypeVar("U", default=list[T])
+
+        class Box(Generic[T, U]):
+            pass
+        """)
+    t_param, u_param = visitor.checker.make_type_object(
+        visitor.module.Box
+    ).get_declared_type_params()
+    assert t_param.owner is visitor.module.Box
+    assert u_param.owner is visitor.module.Box
+    assert isinstance(u_param.default, GenericValue)
+    (default_arg,) = u_param.default.args
+    assert isinstance(default_arg, TypeVarValue)
+    assert default_arg.typevar_param.owner is visitor.module.Box
 
 
 class TestImportFailureHandling(TestNameCheckVisitorBase):

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -36,13 +36,11 @@ from .value import (
     AsyncTaskIncompleteValue,
     CallableValue,
     DictIncompleteValue,
-    FunctionOwner,
     GenericValue,
     KnownValue,
     KVPair,
     MultiValuedValue,
     NewTypeValue,
-    PartialCallValue,
     ReferencingValue,
     SequenceValue,
     SubclassValue,
@@ -276,92 +274,6 @@ def test_annotation():
         "<test input>", "int()", tree, module=ast, annotate=True, checker=checker
     ).check()
     assert TypedValue(int) == tree.inferred_value
-
-
-@skip_before((3, 12))
-def test_pep695_function_type_params_get_function_owner() -> None:
-    visitor, tree = _make_checked_visitor("""
-        def f[T](x: T) -> T:
-            return x
-        """)
-    function_node = next(
-        stmt
-        for stmt in tree.body
-        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
-    )
-    runtime_function = visitor.module.f
-    with visitor.compute_function_info(
-        function_node, potential_function=runtime_function
-    ) as info:
-        assert len(info.type_params) == 1
-        owner = info.type_params[0].owner
-        assert isinstance(owner, FunctionOwner)
-        assert owner.identity is runtime_function
-        assert str(owner).endswith(".f")
-
-
-def test_legacy_function_type_params_get_function_owner() -> None:
-    visitor, tree = _make_checked_visitor("""
-        from typing import TypeVar
-
-        T = TypeVar("T")
-
-        def f(x: T) -> T:
-            return x
-        """)
-    function_node = next(
-        stmt
-        for stmt in tree.body
-        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
-    )
-    runtime_function = visitor.module.f
-    with visitor.compute_function_info(
-        function_node, potential_function=runtime_function
-    ) as info:
-        assert len(info.type_params) == 1
-        owner = info.type_params[0].owner
-        assert isinstance(owner, FunctionOwner)
-        assert owner.identity is runtime_function
-        assert str(owner).endswith(".f")
-        x_param = next(param for param in info.params if param.param.name == "x")
-        assert isinstance(x_param.param.annotation, TypeVarValue)
-        assert x_param.param.annotation.typevar_param.owner == owner
-
-
-def test_direct_type_parameter_constructors_stay_deferred_until_bound() -> None:
-    visitor, tree = _make_checked_visitor("""
-        from typing_extensions import ParamSpec, TypeVar, TypeVarTuple
-
-        T = TypeVar("T")
-        P = ParamSpec("P")
-        Ts = TypeVarTuple("Ts")
-        """)
-    for name in ("T", "P", "Ts"):
-        node = ast.Name(name, ast.Load())
-        value, _ = visitor.resolve_name(node)
-        assert isinstance(value, PartialCallValue)
-
-
-def test_legacy_class_type_param_defaults_rebind_nested_owners() -> None:
-    visitor, _ = _make_checked_visitor("""
-        from typing import Generic
-        from typing_extensions import TypeVar
-
-        T = TypeVar("T")
-        U = TypeVar("U", default=list[T])
-
-        class Box(Generic[T, U]):
-            pass
-        """)
-    t_param, u_param = visitor.checker.make_type_object(
-        visitor.module.Box
-    ).get_declared_type_params()
-    assert t_param.owner is visitor.module.Box
-    assert u_param.owner is visitor.module.Box
-    assert isinstance(u_param.default, GenericValue)
-    (default_arg,) = u_param.default.args
-    assert isinstance(default_arg, TypeVarValue)
-    assert default_arg.typevar_param.owner is visitor.module.Box
 
 
 class TestImportFailureHandling(TestNameCheckVisitorBase):

--- a/pycroscope/test_predicates.py
+++ b/pycroscope/test_predicates.py
@@ -12,7 +12,7 @@ from .value import (
 
 
 def test_is_universally_assignable_intersection() -> None:
-    typevar = TypeVarValue(TypeVarParam(TypeVar("T_pred")))
+    typevar = TypeVarValue(TypeVarParam(TypeVar("T_pred"), owner=None))
     value = IntersectionValue((typevar, AnyValue(AnySource.unannotated)))
     assert is_universally_assignable(value, TypedValue(int))
 

--- a/pycroscope/test_signature.py
+++ b/pycroscope/test_signature.py
@@ -233,7 +233,7 @@ class TestCanAssign:
                     P("x", annotation=TypedValue(int), kind=K.POSITIONAL_ONLY),
                     P(
                         "__Q",
-                        annotation=InputSigValue(ParamSpecParam(q)),
+                        annotation=InputSigValue(ParamSpecParam(q, owner=None)),
                         kind=K.PARAM_SPEC,
                     ),
                 ],

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -37,7 +37,6 @@ from .value import (
     TypedValue,
     TypeVarParam,
     TypeVarTupleBindingValue,
-    TypeVarTupleParam,
     TypeVarTupleValue,
     TypeVarValue,
     UnboundMethodValue,
@@ -570,16 +569,17 @@ class Array(Generic[*Shape]):
     assert len(mro_value.args) == 1
     assert isinstance(mro_value.args[0], TypeVarTupleValue)
     assert mro_value.args[0].typevar is Shape
+    (shape_param,) = array_object.get_declared_type_params()
     substitutions = array_object.get_substitutions_for_base(
         Array, [TypedValue(int), TypedValue(str)]
     )
-    assert substitutions.get_typevartuple(TypeVarTupleParam(Shape)) == (
+    assert substitutions.get_typevartuple(shape_param) == (
         (False, TypedValue(int)),
         (False, TypedValue(str)),
     )
-    assert substitutions.get_value(
-        TypeVarTupleParam(Shape)
-    ) == TypeVarTupleBindingValue(((False, TypedValue(int)), (False, TypedValue(str))))
+    assert substitutions.get_value(shape_param) == TypeVarTupleBindingValue(
+        ((False, TypedValue(int)), (False, TypedValue(str)))
+    )
 
 
 def test_variadic_runtime_type_object_preserves_packed_base_substitutions() -> None:
@@ -608,17 +608,18 @@ class Child(Base[*Shape], Generic[*Shape]):
 
     checker = Checker()
     child_object = checker.make_type_object(Child)
+    (shape_param,) = checker.make_type_object(Base).get_declared_type_params()
 
     substitutions = child_object.get_substitutions_for_base(
         Base, [TypedValue(int), TypedValue(str)]
     )
-    assert substitutions.get_typevartuple(TypeVarTupleParam(Shape)) == (
+    assert substitutions.get_typevartuple(shape_param) == (
         (False, TypedValue(int)),
         (False, TypedValue(str)),
     )
-    assert substitutions.get_value(
-        TypeVarTupleParam(Shape)
-    ) == TypeVarTupleBindingValue(((False, TypedValue(int)), (False, TypedValue(str))))
+    assert substitutions.get_value(shape_param) == TypeVarTupleBindingValue(
+        ((False, TypedValue(int)), (False, TypedValue(str)))
+    )
 
 
 def test_synthetic_type_object_tracks_declared_type_params_and_specialized_mro() -> (

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -527,7 +527,7 @@ def test_runtime_type_object_tracks_declared_type_params_and_specialized_mro() -
         checker.get_type_parameters(Base)
     )
     assert [entry.get_mro_value() for entry in base_object.get_mro()] == [
-        GenericValue(Base, [TypeVarValue(TypeVarParam(T))]),
+        GenericValue(Base, [TypeVarValue(TypeVarParam(T, owner=None))]),
         TypedValue(Generic),
         TypedValue(object),
     ]
@@ -629,7 +629,7 @@ def test_synthetic_type_object_tracks_declared_type_params_and_specialized_mro()
     base = class_owner_from_key("test.Base")
     child = class_owner_from_key("test.Child")
     grandchild = class_owner_from_key("test.GrandChild")
-    type_param = TypeVarParam(T)
+    type_param = TypeVarParam(T, owner=None)
     checker.register_synthetic_type_bases(base, [], declared_type_params=[type_param])
     checker.register_synthetic_type_bases(
         child,
@@ -666,7 +666,7 @@ def test_synthetic_type_object_infers_declared_type_params_from_bases() -> None:
     checker = Checker()
     base = class_owner_from_key("test.Base")
     child = class_owner_from_key("test.Child")
-    type_param = TypeVarParam(T)
+    type_param = TypeVarParam(T, owner=None)
     checker.register_synthetic_type_bases(base, [], declared_type_params=[type_param])
     checker.register_synthetic_type_bases(
         child, [GenericValue(base, [TypeVarValue(type_param)])]

--- a/pycroscope/test_typeshed.py
+++ b/pycroscope/test_typeshed.py
@@ -57,7 +57,7 @@ from .value import (
 )
 
 T = TypeVar("T")
-TParam = TypeVarParam(T)
+TParam = TypeVarParam(T, owner=None)
 NT = NewType("NT", int)
 
 

--- a/pycroscope/test_value.py
+++ b/pycroscope/test_value.py
@@ -273,7 +273,7 @@ def test_typed_value() -> None:
 
 def test_typevarmap_preserves_fixed_typevartuple_bindings() -> None:
     Ts = TypeVarTuple("Ts")
-    param = TypeVarTupleParam(Ts)
+    param = TypeVarTupleParam(Ts, owner=None)
     tv_map = TypeVarMap().with_typevartuple(
         param, ((False, TypedValue(str)), (False, TypedValue(int)))
     )
@@ -289,7 +289,7 @@ def test_typevarmap_preserves_fixed_typevartuple_bindings() -> None:
 
 def test_typevarmap_preserves_open_typevartuple_bindings() -> None:
     Ts = TypeVarTuple("Ts")
-    param = TypeVarTupleParam(Ts)
+    param = TypeVarTupleParam(Ts, owner=None)
     tv_map = TypeVarMap().with_typevartuple(param, ((True, TypedValue(str)),))
 
     assert tv_map.get_typevartuple(param) == ((True, TypedValue(str)),)
@@ -1120,7 +1120,7 @@ def test_typeform_intersection_simplification() -> None:
 
 
 def test_typevar_intersection_preserves_typevar() -> None:
-    typevar_value = TypeVarValue(TypeVarParam(typing.TypeVar("T")))
+    typevar_value = TypeVarValue(TypeVarParam(typing.TypeVar("T"), owner=None))
     narrowed_int = intersect_values(typevar_value, TypedValue(int), CTX)
     narrowed_str = intersect_values(typevar_value, TypedValue(str), CTX)
 
@@ -1131,7 +1131,7 @@ def test_typevar_intersection_preserves_typevar() -> None:
 
 
 def test_typevar_intersection_distributes_over_union() -> None:
-    typevar_value = TypeVarValue(TypeVarParam(typing.TypeVar("T")))
+    typevar_value = TypeVarValue(TypeVarParam(typing.TypeVar("T"), owner=None))
     assert intersect_values(typevar_value, TypedValue(int) | TypedValue(str), CTX) == (
         value.IntersectionValue((typevar_value, TypedValue(int)))
         | value.IntersectionValue((typevar_value, TypedValue(str)))
@@ -1142,6 +1142,7 @@ def test_constrained_typevar_intersection_simplifies() -> None:
     anystr_value = TypeVarValue(
         TypeVarParam(
             typing.TypeVar("AnyStr", str, bytes),
+            owner=None,
             constraints=(TypedValue(str), TypedValue(bytes)),
         )
     )

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -377,7 +377,10 @@ MroValue = TypedValue | AnyValue
 
 
 def direct_bases_from_values(
-    base_values: Sequence[Value], checker: "pycroscope.checker.Checker"
+    base_values: Sequence[Value],
+    checker: "pycroscope.checker.Checker",
+    *,
+    owner: ClassKey | None = None,
 ) -> tuple[MroValue, ...]:
     import pycroscope.type_object_builder as type_object_builder
 
@@ -385,8 +388,9 @@ def direct_bases_from_values(
         converted
         for base in base_values
         for converted in type_object_builder._iter_base_type_values(
-            base, checker.arg_spec_cache
+            base, checker.arg_spec_cache, owner=owner
         )
+        if owner is None or _class_key_from_value(converted) != owner
     ]
     return tuple(_replace_invalid_bases(direct_bases or [TypedValue(object)]))
 
@@ -3139,13 +3143,21 @@ def _apply_descriptor_protocol_to_method(
         and _is_method_like(initializer)
         and receiver_class.get_type() is not None
     ):
-        bound_value = UnboundMethodValue(
-            attr_name=merged_attribute.name,
-            composite=(
+        method_composite = (
+            Composite(policy.self_value)
+            if policy.on_class
+            and policy.self_value is not None
+            and merged_attribute.name.startswith("__")
+            and merged_attribute.name.endswith("__")
+            else (
                 policy.receiver_composite
                 if policy.receiver_composite is not None
                 else Composite(receiver_class if policy.on_class else receiver_instance)
-            ),
+            )
+        )
+        bound_value = UnboundMethodValue(
+            attr_name=merged_attribute.name,
+            composite=method_composite,
             typevars=(
                 initializer.typevars
                 if isinstance(initializer, KnownValueWithTypeVars)

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -3149,16 +3149,9 @@ def _apply_descriptor_protocol_to_method(
         and receiver_class.get_type() is not None
     ):
         method_composite = (
-            Composite(policy.self_value)
-            if policy.on_class
-            and policy.self_value is not None
-            and merged_attribute.name.startswith("__")
-            and merged_attribute.name.endswith("__")
-            else (
-                policy.receiver_composite
-                if policy.receiver_composite is not None
-                else Composite(receiver_class if policy.on_class else receiver_instance)
-            )
+            policy.receiver_composite
+            if policy.receiver_composite is not None
+            else Composite(receiver_class if policy.on_class else receiver_instance)
         )
         bound_value = UnboundMethodValue(
             attr_name=merged_attribute.name,

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -31,7 +31,13 @@ import pycroscope
 if TYPE_CHECKING:
     from .relations import Relation
 
-from .annotations import make_type_param, type_from_runtime, type_from_value
+from .annotations import (
+    RuntimeAnnotationsContext,
+    add_runtime_type_param_scope,
+    make_type_param,
+    type_from_runtime,
+    type_from_value,
+)
 from .input_sig import AnySig, FullSignature, InputSigValue
 from .options import PyObjectSequenceOption
 from .relations import (
@@ -2768,21 +2774,44 @@ def _bind_attribute_signature(
     ctx: CanAssignContext,
     self_annotation_value: Value | None = None,
 ) -> Value:
+    def _disable_runtime_call(
+        signature: Signature | OverloadedSignature,
+    ) -> Signature | OverloadedSignature:
+        if isinstance(signature, Signature):
+            if not signature.allow_call:
+                return signature
+            return replace(signature, allow_call=False)
+        return OverloadedSignature(
+            [
+                replace(sig, allow_call=False) if sig.allow_call else sig
+                for sig in signature.signatures
+            ]
+        )
+
     if self_annotation_value is None:
         self_annotation_value = receiver_value
     signature = ctx.signature_from_value(value)
     if isinstance(signature, BoundMethodSignature):
+        shielded_signature, restore_typevars = _shield_nested_self_in_signature(
+            signature.signature
+        )
+        signature = replace(signature, signature=shielded_signature)
         bound = signature.get_signature(
             ctx=ctx, self_annotation_value=self_annotation_value, preserve_impl=True
         )
         if bound is None and self_annotation_value == receiver_value:
             bound = signature.get_signature(ctx=ctx, preserve_impl=True)
         if bound is not None:
-            return CallableValue(bound)
+            bound = _disable_runtime_call(bound)
+            result: Value = CallableValue(bound)
+            if restore_typevars:
+                result = result.substitute_typevars(restore_typevars)
+            return result
         return value
     if isinstance(signature, (Signature, OverloadedSignature)):
         if self_annotation_value is None:
             self_annotation_value = receiver_value
+        signature, restore_typevars = _shield_nested_self_in_signature(signature)
         bound = signature.bind_self(
             self_value=receiver_value,
             self_annotation_value=self_annotation_value,
@@ -2794,8 +2823,46 @@ def _bind_attribute_signature(
                 self_value=receiver_value, preserve_impl=True, ctx=ctx
             )
         if bound is not None:
-            return CallableValue(bound)
+            bound = _disable_runtime_call(bound)
+            result = CallableValue(bound)
+            if restore_typevars:
+                result = result.substitute_typevars(restore_typevars)
+            return result
     return value
+
+
+def _shield_nested_self_in_signature(
+    signature: Signature | OverloadedSignature,
+) -> tuple[Signature | OverloadedSignature, TypeVarMap]:
+    if isinstance(signature, OverloadedSignature):
+        restore_typevars = TypeVarMap()
+        shielded_signatures = []
+        for inner_sig in signature.signatures:
+            shielded_sig, inner_restore = _shield_nested_self_in_signature(inner_sig)
+            assert isinstance(shielded_sig, Signature)
+            shielded_signatures.append(shielded_sig)
+            restore_typevars = restore_typevars.merge(inner_restore)
+        return OverloadedSignature(shielded_signatures), restore_typevars
+
+    restore_typevars = TypeVarMap()
+    parameters: dict[str, SigParameter] = {}
+    for name, param in signature.parameters.items():
+        annotated_type = param.annotation
+        if (
+            isinstance(annotated_type, TypeVarValue)
+            and annotated_type.typevar_param.is_self
+        ):
+            replacement = type_param_to_value(
+                replace(annotated_type.typevar_param, typevar=object(), is_self=False)
+            )
+            assert isinstance(replacement, TypeVarValue)
+            restore_typevars = restore_typevars.with_typevar(
+                replacement.typevar_param, annotated_type
+            )
+            parameters[name] = replace(param, annotation=replacement)
+        else:
+            parameters[name] = param
+    return replace(signature, parameters=parameters), restore_typevars
 
 
 def _is_informative_runtime_attribute(attribute: SpecializedAttribute) -> bool:
@@ -4150,15 +4217,13 @@ def _compute_type_params_from_runtime(
         runtime_type_params_iter = iter(runtime_type_params)
     except TypeError:
         return []
+    ctx = pycroscope.arg_spec.AnnotationsContext(self_key=typ)
+    add_runtime_type_param_scope(ctx, typ, typ)
     type_params: list[TypeParam] = []
     for type_param in runtime_type_params_iter:
         try:
             assert checker._arg_spec_cache is not None
-            type_params.append(
-                make_type_param(
-                    type_param, ctx=pycroscope.arg_spec.AnnotationsContext(self_key=typ)
-                )
-            )
+            type_params.append(make_type_param(type_param, ctx=ctx))
         except TypeError:
             continue
     return type_params
@@ -4185,10 +4250,9 @@ def _extract_runtime_direct_bases(
             raw_bases = iter(typ.__bases__)
         except Exception:
             return []
-    bases = [
-        type_from_runtime(base, visitor=checker, suppress_errors=True)
-        for base in raw_bases
-    ]
+    ctx = RuntimeAnnotationsContext(owner=typ, self_key=typ, new_type_param_owner=typ)
+    with ctx.suppress_errors():
+        bases = [type_from_runtime(base, ctx=ctx) for base in raw_bases]
     if is_namedtuple_class(typ):
         bases = [_replace_tuple(base, typ, checker) for base in bases]
     return _replace_invalid_bases(bases)

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -31,13 +31,7 @@ import pycroscope
 if TYPE_CHECKING:
     from .relations import Relation
 
-from .annotations import (
-    RuntimeAnnotationsContext,
-    add_runtime_type_param_scope,
-    make_type_param,
-    type_from_runtime,
-    type_from_value,
-)
+from .annotations import RuntimeAnnotationsContext, type_from_runtime, type_from_value
 from .input_sig import AnySig, FullSignature, InputSigValue
 from .options import PyObjectSequenceOption
 from .relations import (
@@ -4149,23 +4143,7 @@ def _extract_type_param(value: Value) -> TypeParam | None:
 def _compute_type_params_from_runtime(
     typ: type, checker: "pycroscope.checker.Checker"
 ) -> list[TypeParam]:
-    runtime_type_params = safe_getattr(typ, "__type_params__", ())
-    if not runtime_type_params:
-        runtime_type_params = safe_getattr(typ, "__parameters__", ())
-    try:
-        runtime_type_params_iter = iter(runtime_type_params)
-    except TypeError:
-        return []
-    ctx = pycroscope.arg_spec.AnnotationsContext(self_key=typ)
-    add_runtime_type_param_scope(ctx, typ, typ)
-    type_params: list[TypeParam] = []
-    for type_param in runtime_type_params_iter:
-        try:
-            assert checker._arg_spec_cache is not None
-            type_params.append(make_type_param(type_param, ctx=ctx))
-        except TypeError:
-            continue
-    return type_params
+    return checker.arg_spec_cache.get_type_parameters(typ)
 
 
 def _replace_invalid_bases(bases: Sequence[Value]) -> Iterable[MroValue]:

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -2774,44 +2774,21 @@ def _bind_attribute_signature(
     ctx: CanAssignContext,
     self_annotation_value: Value | None = None,
 ) -> Value:
-    def _disable_runtime_call(
-        signature: Signature | OverloadedSignature,
-    ) -> Signature | OverloadedSignature:
-        if isinstance(signature, Signature):
-            if not signature.allow_call:
-                return signature
-            return replace(signature, allow_call=False)
-        return OverloadedSignature(
-            [
-                replace(sig, allow_call=False) if sig.allow_call else sig
-                for sig in signature.signatures
-            ]
-        )
-
     if self_annotation_value is None:
         self_annotation_value = receiver_value
     signature = ctx.signature_from_value(value)
     if isinstance(signature, BoundMethodSignature):
-        shielded_signature, restore_typevars = _shield_nested_self_in_signature(
-            signature.signature
-        )
-        signature = replace(signature, signature=shielded_signature)
         bound = signature.get_signature(
             ctx=ctx, self_annotation_value=self_annotation_value, preserve_impl=True
         )
         if bound is None and self_annotation_value == receiver_value:
             bound = signature.get_signature(ctx=ctx, preserve_impl=True)
         if bound is not None:
-            bound = _disable_runtime_call(bound)
-            result: Value = CallableValue(bound)
-            if restore_typevars:
-                result = result.substitute_typevars(restore_typevars)
-            return result
+            return CallableValue(bound)
         return value
     if isinstance(signature, (Signature, OverloadedSignature)):
         if self_annotation_value is None:
             self_annotation_value = receiver_value
-        signature, restore_typevars = _shield_nested_self_in_signature(signature)
         bound = signature.bind_self(
             self_value=receiver_value,
             self_annotation_value=self_annotation_value,
@@ -2823,46 +2800,8 @@ def _bind_attribute_signature(
                 self_value=receiver_value, preserve_impl=True, ctx=ctx
             )
         if bound is not None:
-            bound = _disable_runtime_call(bound)
-            result = CallableValue(bound)
-            if restore_typevars:
-                result = result.substitute_typevars(restore_typevars)
-            return result
+            return CallableValue(bound)
     return value
-
-
-def _shield_nested_self_in_signature(
-    signature: Signature | OverloadedSignature,
-) -> tuple[Signature | OverloadedSignature, TypeVarMap]:
-    if isinstance(signature, OverloadedSignature):
-        restore_typevars = TypeVarMap()
-        shielded_signatures = []
-        for inner_sig in signature.signatures:
-            shielded_sig, inner_restore = _shield_nested_self_in_signature(inner_sig)
-            assert isinstance(shielded_sig, Signature)
-            shielded_signatures.append(shielded_sig)
-            restore_typevars = restore_typevars.merge(inner_restore)
-        return OverloadedSignature(shielded_signatures), restore_typevars
-
-    restore_typevars = TypeVarMap()
-    parameters: dict[str, SigParameter] = {}
-    for name, param in signature.parameters.items():
-        annotated_type = param.annotation
-        if (
-            isinstance(annotated_type, TypeVarValue)
-            and annotated_type.typevar_param.is_self
-        ):
-            replacement = type_param_to_value(
-                replace(annotated_type.typevar_param, typevar=object(), is_self=False)
-            )
-            assert isinstance(replacement, TypeVarValue)
-            restore_typevars = restore_typevars.with_typevar(
-                replacement.typevar_param, annotated_type
-            )
-            parameters[name] = replace(param, annotation=replacement)
-        else:
-            parameters[name] = param
-    return replace(signature, parameters=parameters), restore_typevars
 
 
 def _is_informative_runtime_attribute(attribute: SpecializedAttribute) -> bool:

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -31,7 +31,12 @@ import pycroscope
 if TYPE_CHECKING:
     from .relations import Relation
 
-from .annotations import RuntimeAnnotationsContext, type_from_runtime, type_from_value
+from .annotations import (
+    RuntimeAnnotationsContext,
+    make_type_param,
+    type_from_runtime,
+    type_from_value,
+)
 from .input_sig import AnySig, FullSignature, InputSigValue
 from .options import PyObjectSequenceOption
 from .relations import (
@@ -4155,7 +4160,26 @@ def _extract_type_param(value: Value) -> TypeParam | None:
 def _compute_type_params_from_runtime(
     typ: type, checker: "pycroscope.checker.Checker"
 ) -> list[TypeParam]:
-    return checker.arg_spec_cache.get_type_parameters(typ)
+    runtime_type_params = safe_getattr(typ, "__type_params__", ())
+    if not runtime_type_params:
+        runtime_type_params = safe_getattr(typ, "__parameters__", ())
+    try:
+        runtime_type_params_iter = iter(runtime_type_params)
+    except TypeError:
+        return []
+    type_params: list[TypeParam] = []
+    for type_param in runtime_type_params_iter:
+        try:
+            assert checker._arg_spec_cache is not None
+            type_params.append(
+                make_type_param(
+                    type_param, ctx=pycroscope.arg_spec.AnnotationsContext(self_key=typ)
+                )
+            )
+        except TypeError:
+            continue
+    return type_params
+    # return checker.arg_spec_cache.get_type_parameters(typ)
 
 
 def _replace_invalid_bases(bases: Sequence[Value]) -> Iterable[MroValue]:

--- a/pycroscope/type_object_builder.py
+++ b/pycroscope/type_object_builder.py
@@ -197,6 +197,7 @@ def _runtime_dataclass_field_info(field: object) -> DataclassFieldInfo:
 def _iter_base_type_values(
     value: Value,
     arg_spec_cache: ArgSpecCache,
+    owner: ClassKey | None = None,
     seen_known_bases: frozenset[int] = frozenset(),
 ) -> Iterator[TypedValue | AnyValue]:
     if isinstance(value, PartialValue):
@@ -206,11 +207,11 @@ def _iter_base_type_values(
         if isinstance(root, SyntheticClassObjectValue):
             root = root.class_type
         elif isinstance(root, KnownValue):
-            root = arg_spec_cache._type_from_base(root.val, object)
+            root = arg_spec_cache._type_from_base(root.val, owner or object)
         root = replace_fallback(root)
         members = tuple(
             (
-                arg_spec_cache._type_from_base(member.val, object)
+                arg_spec_cache._type_from_base(member.val, owner or object)
                 if arg_spec_cache is not None and isinstance(member, KnownValue)
                 else member
             )
@@ -231,33 +232,43 @@ def _iter_base_type_values(
     value = replace_fallback(value)
     if isinstance(value, MultiValuedValue):
         for subval in value.vals:
-            yield from _iter_base_type_values(subval, arg_spec_cache, seen_known_bases)
+            yield from _iter_base_type_values(
+                subval, arg_spec_cache, owner=owner, seen_known_bases=seen_known_bases
+            )
         return
     if isinstance(value, IntersectionValue):
         for subval in value.vals:
-            yield from _iter_base_type_values(subval, arg_spec_cache, seen_known_bases)
+            yield from _iter_base_type_values(
+                subval, arg_spec_cache, owner=owner, seen_known_bases=seen_known_bases
+            )
         return
     yield from _iter_base_type_values_from_simple(
-        value, arg_spec_cache, seen_known_bases
+        value, arg_spec_cache, owner, seen_known_bases
     )
 
 
 def _iter_base_type_values_from_simple(
-    value: SimpleType, arg_spec_cache: ArgSpecCache, seen_known_bases: frozenset[int]
+    value: SimpleType,
+    arg_spec_cache: ArgSpecCache,
+    owner: ClassKey | None,
+    seen_known_bases: frozenset[int],
 ) -> Iterator[TypedValue | AnyValue]:
     if isinstance(value, KnownValue):
         base_id = id(value.val)
         if base_id in seen_known_bases:
             return
         yield from _iter_base_type_values(
-            # TODO: owner is wrong, but this probably doesn't matter
-            arg_spec_cache._type_from_base(value.val, object),
+            arg_spec_cache._type_from_base(value.val, owner or object),
             arg_spec_cache,
-            seen_known_bases | {base_id},
+            owner=owner,
+            seen_known_bases=seen_known_bases | {base_id},
         )
     elif isinstance(value, SyntheticClassObjectValue):
         yield from _iter_base_type_values(
-            value.class_type, arg_spec_cache, seen_known_bases
+            value.class_type,
+            arg_spec_cache,
+            owner=owner,
+            seen_known_bases=seen_known_bases,
         )
     elif isinstance(value, SequenceValue) and value.typ is tuple:
         yield value

--- a/pycroscope/type_object_builder.py
+++ b/pycroscope/type_object_builder.py
@@ -219,6 +219,12 @@ def _iter_base_type_values(
         if isinstance(root, SequenceValue) and root.typ is tuple:
             yield SequenceValue(tuple, [(False, member) for member in members])
             return
+        if isinstance(root, (TypedValue, GenericValue)) and root.typ is tuple:
+            if len(members) == 2 and members[1] == KnownValue(Ellipsis):
+                yield GenericValue(tuple, [members[0]])
+            else:
+                yield SequenceValue(tuple, [(False, member) for member in members])
+            return
         if isinstance(root, (TypedValue, GenericValue)):
             yield GenericValue(root.typ, members)
         return

--- a/pycroscope/type_object_builder.py
+++ b/pycroscope/type_object_builder.py
@@ -418,7 +418,9 @@ def _runtime_member_value(raw_value: object, owner: type) -> Value:
     if not isinstance(runtime_params, tuple) or not runtime_params:
         return value
 
-    ctx = RuntimeAnnotationsContext(owner=owner, self_key=owner)
+    ctx = RuntimeAnnotationsContext(
+        owner=owner, self_key=owner, new_type_param_owner=owner
+    )
     with ctx.suppress_errors():
         type_params = tuple(make_type_param(param, ctx) for param in runtime_params)
         type_arguments = tuple(type_from_runtime(arg, ctx=ctx) for arg in args)

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -1,24 +1,28 @@
 import ast
 import contextlib
+import sys
 from collections.abc import Generator, Iterable, Sequence
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from typing import Protocol
 
 from .analysis_lib import override
 from .error_code import Error, ErrorCode
-from .safe import safe_getattr
-from .value import TypeParam, TypeVarParam, Value
+from .value import TypeParam, TypeParamOwner, TypeVarLike, TypeVarParam, Value
 
-_TYPE_PARAM_AST_NODE_TYPES = tuple(
-    typ
-    for typ in (
-        safe_getattr(ast, "TypeVar", None),
-        safe_getattr(ast, "ParamSpec", None),
-        safe_getattr(ast, "TypeVarTuple", None),
-    )
-    if isinstance(typ, type)
-)
+if sys.version_info >= (3, 12):
+    _TYPE_PARAM_AST_NODE_TYPES = (ast.TypeVar, ast.ParamSpec, ast.TypeVarTuple)
+else:
+    _TYPE_PARAM_AST_NODE_TYPES = ()
+
+TypeParamIdentity = TypeVarLike | ast.AST
+
+
+@dataclass
+class TypeParamScope:
+    owner: TypeParamOwner
+    scope: dict[TypeParamIdentity, TypeParam]
+    is_collecting: bool = False
 
 
 class TypeParamVisitor(Protocol):
@@ -109,6 +113,16 @@ class ActiveTypeParams:
         self._variance_is_suspended = 0
         self._variance_outside_annotations = 0
         self._subscript_arg_polarities: list[tuple[tuple[int, bool], ...]] = []
+        self._scopes: list[TypeParamScope] = []
+
+    @contextmanager
+    def add_scope(self, owner: TypeParamOwner) -> Generator[None]:
+        scope = TypeParamScope(owner, {})
+        self._scopes.append(scope)
+        try:
+            yield
+        finally:
+            self._scopes.pop()
 
     def current_annotation_identities(self) -> set[object]:
         identities: set[object] = set()

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -1,0 +1,489 @@
+import ast
+import contextlib
+from collections.abc import Generator, Iterable, Sequence
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Protocol
+
+from .analysis_lib import override
+from .error_code import Error, ErrorCode
+from .safe import safe_getattr
+from .value import TypeParam, TypeVarParam, Value
+
+_TYPE_PARAM_AST_NODE_TYPES = tuple(
+    typ
+    for typ in (
+        safe_getattr(ast, "TypeVar", None),
+        safe_getattr(ast, "ParamSpec", None),
+        safe_getattr(ast, "TypeVarTuple", None),
+    )
+    if isinstance(typ, type)
+)
+
+
+class TypeParamVisitor(Protocol):
+    in_annotation: bool
+    in_type_alias_definition: bool
+
+    def _is_collecting(self) -> bool: ...
+
+    def show_error(
+        self,
+        node: ast.AST,
+        e: str | None = None,
+        error_code: Error | None = ErrorCode.invalid_annotation,
+    ) -> object | None: ...
+
+    def _show_error_if_checking(
+        self,
+        node: ast.AST,
+        msg: str | None = None,
+        error_code: Error | None = ErrorCode.invalid_annotation,
+    ) -> object | None: ...
+
+    def resolve_name(
+        self,
+        node: ast.Name,
+        error_node: ast.AST | None = None,
+        suppress_errors: bool = False,
+    ) -> tuple[Value, object]: ...
+
+    def _merge_type_param_polarities(
+        self,
+        target: dict[object, set[int]],
+        local_polarities: dict[object, set[int]],
+        *,
+        polarity: int,
+    ) -> None: ...
+
+    def get_type_param_from_value(self, value: Value) -> TypeParam | None: ...
+
+
+@dataclass
+class _LegacyTypeParamPolicy:
+    allowed_identities: set[object]
+    message: str
+    error_code: Error = ErrorCode.invalid_annotation
+    report_in_collecting: bool = True
+    triggered: bool = False
+
+
+@dataclass
+class _VarianceCollectionContext:
+    type_param_polarities: dict[object, set[int]]
+    polarity: int
+
+
+def _compose_observed_variance_polarity(polarity: int, modifier: int) -> int:
+    if polarity == 0 or modifier == 0:
+        return 0
+    return polarity * modifier
+
+
+def _record_variance_polarity(used_polarities: set[int], polarity: int) -> None:
+    if polarity == 0:
+        used_polarities.update({-1, 1})
+    else:
+        used_polarities.add(polarity)
+
+
+def _is_type_param_declaration_node(node: ast.AST) -> bool:
+    return bool(_TYPE_PARAM_AST_NODE_TYPES) and isinstance(
+        node, _TYPE_PARAM_AST_NODE_TYPES
+    )
+
+
+class ActiveTypeParams:
+    def __init__(self, visitor: TypeParamVisitor | None = None) -> None:
+        self.visitor = visitor
+        self._annotation_allowed_identities: list[set[object]] = []
+        self._active_pep695_identities: list[set[object]] = []
+        self._active_pep695_type_params: list[dict[object, TypeParam]] = []
+        self._current_class_type_params: Sequence[TypeParam] | None = None
+        self._disallowed_identities: list[set[object]] = []
+        self._legacy_policies: list[_LegacyTypeParamPolicy] = []
+        self._variance_collections: list[_VarianceCollectionContext] = []
+        self._current_class_type_param_polarities: dict[object, set[int]] | None = None
+        self._current_is_protocol_class: bool = False
+        self._variance_polarity_stack: list[int] = []
+        self._variance_is_suspended = 0
+        self._variance_outside_annotations = 0
+        self._subscript_arg_polarities: list[tuple[tuple[int, bool], ...]] = []
+
+    def current_annotation_identities(self) -> set[object]:
+        identities: set[object] = set()
+        for allowed in self._annotation_allowed_identities:
+            identities.update(allowed)
+        for allowed in self._active_pep695_identities:
+            identities.update(allowed)
+        return identities
+
+    def current_pep695_identities(self) -> set[object]:
+        identities: set[object] = set()
+        for allowed in self._active_pep695_identities:
+            identities.update(allowed)
+        return identities
+
+    def current_pep695_type_params(self) -> dict[object, TypeParam]:
+        type_params: dict[object, TypeParam] = {}
+        for scope in self._active_pep695_type_params:
+            type_params.update(scope)
+        return type_params
+
+    def get_type_param(self, identity: object) -> TypeParam | None:
+        for scope in reversed(self._active_pep695_type_params):
+            type_param = scope.get(identity)
+            if type_param is not None:
+                return type_param
+        return None
+
+    def add_pep695_scope(
+        self,
+        type_params: Sequence[TypeParam],
+        *,
+        additional_identities: Sequence[Iterable[object]] | None = None,
+    ) -> None:
+        if additional_identities is None:
+            additional_identities = [()] * len(type_params)
+        scope: dict[object, TypeParam] = {}
+        identities: set[object] = set()
+        for type_param, extra_identities in zip(type_params, additional_identities):
+            all_identities = {type_param.typevar, *extra_identities}
+            for identity in all_identities:
+                scope[identity] = type_param
+            identities.update(all_identities)
+        if not identities:
+            return
+        self._active_pep695_identities.append(identities)
+        self._active_pep695_type_params.append(scope)
+
+    def current_class_type_params(self) -> Sequence[TypeParam] | None:
+        return self._current_class_type_params
+
+    @contextlib.contextmanager
+    def allow_in_annotations(self, identities: Iterable[object]) -> Generator[None]:
+        identities = set(identities)
+        if not identities:
+            yield
+            return
+        self._annotation_allowed_identities.append(identities)
+        try:
+            yield
+        finally:
+            self._annotation_allowed_identities.pop()
+
+    @contextlib.contextmanager
+    def push_pep695_scope(
+        self,
+        type_params: Sequence[TypeParam],
+        *,
+        additional_identities: Sequence[Iterable[object]] | None = None,
+    ) -> Generator[None]:
+        before = len(self._active_pep695_type_params)
+        self.add_pep695_scope(type_params, additional_identities=additional_identities)
+        if len(self._active_pep695_type_params) == before:
+            yield
+            return
+        try:
+            yield
+        finally:
+            self._active_pep695_type_params.pop()
+            self._active_pep695_identities.pop()
+
+    @contextlib.contextmanager
+    def push_class_type_params(
+        self, type_params: Sequence[TypeParam] | None
+    ) -> Generator[None]:
+        with override(self, "_current_class_type_params", type_params):
+            yield
+
+    @contextlib.contextmanager
+    def disallow(self, identities: Iterable[object]) -> Generator[None]:
+        identities = set(identities)
+        if not identities:
+            yield
+            return
+        self._disallowed_identities.append(identities)
+        try:
+            yield
+        finally:
+            self._disallowed_identities.pop()
+
+    @contextlib.contextmanager
+    def reject_legacy_type_params(
+        self,
+        message: str,
+        *,
+        error_code: Error = ErrorCode.invalid_annotation,
+        include_active_pep695: bool = True,
+        report_in_collecting: bool = True,
+    ) -> Generator[set[object]]:
+        allowed_identities = (
+            self.current_pep695_identities() if include_active_pep695 else set()
+        )
+        policy = _LegacyTypeParamPolicy(
+            allowed_identities,
+            message,
+            error_code=error_code,
+            report_in_collecting=report_in_collecting,
+        )
+        self._legacy_policies.append(policy)
+        try:
+            yield allowed_identities
+        finally:
+            self._legacy_policies.pop()
+
+    @contextlib.contextmanager
+    def collect_variance(
+        self, type_param_polarities: dict[object, set[int]], *, polarity: int
+    ) -> Generator[None]:
+        self._variance_collections.append(
+            _VarianceCollectionContext(type_param_polarities, polarity)
+        )
+        try:
+            yield
+        finally:
+            self._variance_collections.pop()
+
+    @contextlib.contextmanager
+    def compose_variance(self, polarity: int) -> Generator[None]:
+        self._variance_polarity_stack.append(polarity)
+        try:
+            yield
+        finally:
+            self._variance_polarity_stack.pop()
+
+    @contextlib.contextmanager
+    def suspend_variance(self) -> Generator[None]:
+        self._variance_is_suspended += 1
+        try:
+            yield
+        finally:
+            self._variance_is_suspended -= 1
+
+    @contextlib.contextmanager
+    def allow_variance_outside_annotations(self) -> Generator[None]:
+        self._variance_outside_annotations += 1
+        try:
+            yield
+        finally:
+            self._variance_outside_annotations -= 1
+
+    def has_variance_collection(self) -> bool:
+        return bool(self._variance_collections) and not self._variance_is_suspended
+
+    def current_class_type_param_polarities(self) -> dict[object, set[int]] | None:
+        return self._current_class_type_param_polarities
+
+    def current_variance_polarity(self, base_polarity: int) -> int:
+        polarity = base_polarity
+        for modifier in self._variance_polarity_stack:
+            polarity = _compose_observed_variance_polarity(polarity, modifier)
+        return polarity
+
+    @contextlib.contextmanager
+    def push_class_type_param_variance_collection(
+        self,
+        type_param_polarities: dict[object, set[int]] | None,
+        *,
+        is_protocol_class: bool,
+    ) -> Generator[None]:
+        with (
+            override(
+                self, "_current_class_type_param_polarities", type_param_polarities
+            ),
+            override(self, "_current_is_protocol_class", is_protocol_class),
+        ):
+            yield
+
+    @contextlib.contextmanager
+    def suspend_class_type_param_variance_collection(self) -> Generator[None]:
+        if self._current_class_type_param_polarities is None:
+            yield
+            return
+        with override(self, "_current_class_type_param_polarities", None):
+            yield
+
+    def function_param_type_param_variance_context(
+        self, *, parameter_index: int, is_staticmethod: bool
+    ) -> AbstractContextManager[None]:
+        if self._current_class_type_param_polarities is None:
+            return contextlib.nullcontext()
+        if (
+            self._current_is_protocol_class
+            and parameter_index == 0
+            and not is_staticmethod
+        ):
+            return self.suspend_variance()
+        return self.local_class_type_param_variance_context(polarity=-1)
+
+    def function_return_type_param_variance_context(
+        self,
+    ) -> AbstractContextManager[None]:
+        if self._current_class_type_param_polarities is None:
+            return contextlib.nullcontext()
+        return self.local_class_type_param_variance_context(polarity=1)
+
+    @contextlib.contextmanager
+    def local_class_type_param_variance_context(
+        self, *, polarity: int
+    ) -> Generator[None]:
+        target = self._current_class_type_param_polarities
+        if target is None:
+            yield
+            return
+        visitor = self._require_visitor()
+        local_polarities: dict[object, set[int]] = {}
+        with (
+            self.collect_variance(local_polarities, polarity=1),
+            self.compose_variance(polarity),
+        ):
+            yield
+        visitor._merge_type_param_polarities(target, local_polarities, polarity=1)
+
+    @contextlib.contextmanager
+    def push_subscript_arg_polarities(
+        self, polarities: Sequence[tuple[int, bool]]
+    ) -> Generator[None]:
+        self._subscript_arg_polarities.append(tuple(polarities))
+        try:
+            yield
+        finally:
+            self._subscript_arg_polarities.pop()
+
+    @contextlib.contextmanager
+    def consume_subscript_arg_polarities(
+        self, arity: int
+    ) -> Generator[tuple[tuple[int, bool], ...] | None]:
+        polarities = (
+            self._subscript_arg_polarities.pop()
+            if self._subscript_arg_polarities
+            and len(self._subscript_arg_polarities[-1]) == arity
+            else None
+        )
+        try:
+            yield polarities
+        finally:
+            if polarities is not None:
+                self._subscript_arg_polarities.append(polarities)
+
+    def observe_value(self, node: ast.AST, value: Value) -> None:
+        visitor = self.visitor
+        if visitor is None:
+            return
+        if not (
+            self._legacy_policies
+            or self._disallowed_identities
+            or visitor.in_annotation
+            or self._variance_collections
+        ):
+            return
+        if self._variance_is_suspended and not (
+            self._legacy_policies or self._disallowed_identities
+        ):
+            return
+        if _is_type_param_declaration_node(node):
+            return
+
+        type_param = visitor.get_type_param_from_value(value)
+        if type_param is not None:
+            self._check_direct_type_param_usage(node, type_param)
+            if (
+                isinstance(type_param, TypeVarParam)
+                and self._variance_collections
+                and not self._variance_is_suspended
+                and (visitor.in_annotation or self._variance_outside_annotations > 0)
+            ):
+                for context in self._variance_collections:
+                    used_polarities = context.type_param_polarities.get(
+                        type_param.typevar
+                    )
+                    if used_polarities is None:
+                        used_polarities = context.type_param_polarities.setdefault(
+                            type_param.typevar, set()
+                        )
+                    _record_variance_polarity(
+                        used_polarities,
+                        self.current_variance_polarity(context.polarity),
+                    )
+
+    def _require_visitor(self) -> TypeParamVisitor:
+        if self.visitor is None:
+            raise AssertionError(
+                "ActiveTypeParams requires a visitor for this operation"
+            )
+        return self.visitor
+
+    def _show_error(
+        self,
+        node: ast.AST,
+        message: str,
+        *,
+        error_code: Error,
+        report_in_collecting: bool,
+    ) -> None:
+        visitor = self._require_visitor()
+        if report_in_collecting and visitor._is_collecting():
+            visitor.show_error(node, message, error_code=error_code)
+        else:
+            visitor._show_error_if_checking(node, message, error_code=error_code)
+
+    def _check_direct_type_param_usage(
+        self, error_node: ast.AST, type_param: TypeParam
+    ) -> None:
+        visitor = self._require_visitor()
+        identity = type_param.typevar
+        narrowed_error_node = self._narrow_type_param_error_node(error_node, identity)
+        if narrowed_error_node is not error_node:
+            return
+        for policy in self._legacy_policies:
+            if policy.triggered:
+                continue
+            if identity in policy.allowed_identities:
+                continue
+            policy.triggered = True
+            self._show_error(
+                narrowed_error_node,
+                policy.message,
+                error_code=policy.error_code,
+                report_in_collecting=policy.report_in_collecting,
+            )
+            break
+
+        if not isinstance(type_param, TypeVarParam) or type_param.is_self:
+            return
+        if any(identity in disallowed for disallowed in self._disallowed_identities):
+            visitor._show_error_if_checking(
+                narrowed_error_node,
+                "Type parameter is not valid in this annotation context",
+                error_code=ErrorCode.invalid_annotation,
+            )
+            return
+        if visitor.in_type_alias_definition or not visitor.in_annotation:
+            return
+        if identity in self.current_annotation_identities():
+            return
+        visitor._show_error_if_checking(
+            narrowed_error_node,
+            "Type parameter is not valid in this annotation context",
+            error_code=ErrorCode.invalid_annotation,
+        )
+
+    # TODO: this is silly, find a better solution to prevent duplicate errors
+    def _narrow_type_param_error_node(self, node: ast.AST, identity: object) -> ast.AST:
+        visitor = self._require_visitor()
+        if isinstance(node, ast.Name):
+            return node
+        for subnode in ast.walk(node):
+            if not isinstance(subnode, ast.Name):
+                continue
+            resolved, _ = visitor.resolve_name(
+                subnode, error_node=subnode, suppress_errors=True
+            )
+            resolved_type_param = visitor.get_type_param_from_value(resolved)
+            if (
+                resolved_type_param is not None
+                and resolved_type_param.typevar is identity
+            ):
+                return subnode
+        return node

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -1,14 +1,36 @@
 import ast
 import contextlib
 import sys
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
 from contextlib import AbstractContextManager, contextmanager
-from dataclasses import dataclass
-from typing import Protocol
+from dataclasses import dataclass, replace
+from typing import Protocol, TypeGuard
 
 from .analysis_lib import override
 from .error_code import Error, ErrorCode
-from .value import TypeParam, TypeParamOwner, TypeVarLike, TypeVarParam, Value
+from .safe import is_instance_of_typing_name
+from .value import (
+    AnnotatedValue,
+    GenericValue,
+    IntersectionValue,
+    MultiValuedValue,
+    ParamSpecParam,
+    PartialValue,
+    SequenceValue,
+    SubclassValue,
+    TypeParam,
+    TypeParamOwner,
+    TypeVarLike,
+    TypeVarMap,
+    TypeVarParam,
+    TypeVarTupleParam,
+    TypeVarTupleValue,
+    TypeVarValue,
+    Value,
+    get_single_typevartuple_param,
+    type_param_to_value,
+    with_type_param_owner,
+)
 
 if sys.version_info >= (3, 12):
     _TYPE_PARAM_AST_NODE_TYPES = (ast.TypeVar, ast.ParamSpec, ast.TypeVarTuple)
@@ -20,9 +42,23 @@ TypeParamIdentity = TypeVarLike | ast.AST
 
 @dataclass
 class TypeParamScope:
-    owner: TypeParamOwner
-    scope: dict[TypeParamIdentity, TypeParam]
-    is_collecting: bool = False
+    """A lexical type-parameter scope.
+
+    `owner` is the definition that binds newly declared parameters in this scope.
+    `bindings` maps runtime or AST identities to canonical, owner-bound params.
+    `disallowed` contains visible identities that are invalid in this context.
+    """
+
+    owner: TypeParamOwner | None
+    bindings: dict[TypeParamIdentity, TypeParam]
+    disallowed: set[TypeParamIdentity]
+
+
+@dataclass(frozen=True)
+class TypeParamBindingResult:
+    type_params: tuple[TypeParam, ...]
+    substitutions: TypeVarMap
+    aliases: tuple[frozenset[TypeParamIdentity], ...]
 
 
 class TypeParamVisitor(Protocol):
@@ -97,14 +133,223 @@ def _is_type_param_declaration_node(node: ast.AST) -> bool:
     )
 
 
+def _is_type_param_identity(identity: object) -> TypeGuard[TypeParamIdentity]:
+    return isinstance(identity, ast.AST) or _is_typevarlike(identity)
+
+
+def _is_typevarlike(identity: object) -> bool:
+    return (
+        is_instance_of_typing_name(identity, "TypeVar")
+        or is_instance_of_typing_name(identity, "ParamSpec")
+        or is_instance_of_typing_name(identity, "TypeVarTuple")
+    )
+
+
+def _typed_identities(identities: Iterable[object]) -> set[TypeParamIdentity]:
+    typed: set[TypeParamIdentity] = set()
+    for identity in identities:
+        if _is_type_param_identity(identity):
+            typed.add(identity)
+    return typed
+
+
+def _identity_aliases(
+    raw_param: TypeParam, bound_param: TypeParam
+) -> frozenset[TypeParamIdentity]:
+    aliases: set[TypeParamIdentity] = set()
+    if (
+        _is_type_param_identity(raw_param.typevar)
+        and raw_param.typevar is not bound_param.typevar
+    ):
+        aliases.add(raw_param.typevar)
+    if _is_type_param_identity(bound_param.typevar):
+        aliases.add(bound_param.typevar)
+    return frozenset(aliases)
+
+
+def _type_param_from_value(value: Value) -> TypeParam | None:
+    if isinstance(value, TypeVarValue):
+        return value.typevar_param
+    if isinstance(value, TypeVarTupleValue):
+        return value.typevar_tuple_param
+    typevartuple_param = get_single_typevartuple_param(value)
+    if typevartuple_param is not None:
+        return typevartuple_param
+    from pycroscope.input_sig import InputSigValue
+
+    if isinstance(value, InputSigValue) and isinstance(value.input_sig, ParamSpecParam):
+        return value.input_sig
+    return None
+
+
+def _normalize_type_param_identities_in_value(
+    value: Value, replacements: Mapping[object, TypeParam]
+) -> Value:
+    type_param = _type_param_from_value(value)
+    if type_param is not None:
+        replacement = replacements.get(type_param.typevar)
+        if replacement is not None:
+            return type_param_to_value(replacement)
+        return value
+    if isinstance(value, AnnotatedValue):
+        normalized = _normalize_type_param_identities_in_value(
+            value.value, replacements
+        )
+        if normalized is value.value:
+            return value
+        return replace(value, value=normalized)
+    if isinstance(value, GenericValue):
+        normalized_args = tuple(
+            _normalize_type_param_identities_in_value(arg, replacements)
+            for arg in value.args
+        )
+        if normalized_args == value.args:
+            return value
+        return GenericValue(value.typ, normalized_args, weak=value.weak)
+    if isinstance(value, SequenceValue):
+        normalized_members = tuple(
+            (is_many, _normalize_type_param_identities_in_value(member, replacements))
+            for is_many, member in value.members
+        )
+        if normalized_members == value.members:
+            return value
+        return replace(value, members=normalized_members)
+    if isinstance(value, PartialValue):
+        normalized_root = _normalize_type_param_identities_in_value(
+            value.root, replacements
+        )
+        normalized_members = tuple(
+            _normalize_type_param_identities_in_value(member, replacements)
+            for member in value.members
+        )
+        normalized_runtime_value = _normalize_type_param_identities_in_value(
+            value.runtime_value, replacements
+        )
+        if (
+            normalized_root is value.root
+            and normalized_members == value.members
+            and normalized_runtime_value is value.runtime_value
+        ):
+            return value
+        return replace(
+            value,
+            root=normalized_root,
+            members=normalized_members,
+            runtime_value=normalized_runtime_value,
+        )
+    if isinstance(value, SubclassValue):
+        normalized_typ = _normalize_type_param_identities_in_value(
+            value.typ, replacements
+        )
+        if normalized_typ is value.typ:
+            return value
+        return replace(value, typ=normalized_typ)
+    if isinstance(value, MultiValuedValue):
+        normalized_vals = tuple(
+            _normalize_type_param_identities_in_value(subval, replacements)
+            for subval in value.vals
+        )
+        if normalized_vals == value.vals:
+            return value
+        return MultiValuedValue(normalized_vals)
+    if isinstance(value, IntersectionValue):
+        normalized_vals = tuple(
+            _normalize_type_param_identities_in_value(subval, replacements)
+            for subval in value.vals
+        )
+        if normalized_vals == value.vals:
+            return value
+        return IntersectionValue(normalized_vals)
+    return value
+
+
+def _substitute_typevars_in_type_param(
+    type_param: TypeParam, substitutions: TypeVarMap
+) -> TypeParam:
+    if isinstance(type_param, TypeVarParam):
+        return replace(
+            type_param,
+            bound=(
+                None
+                if type_param.bound is None
+                else type_param.bound.substitute_typevars(substitutions)
+            ),
+            default=(
+                None
+                if type_param.default is None
+                else type_param.default.substitute_typevars(substitutions)
+            ),
+            constraints=tuple(
+                constraint.substitute_typevars(substitutions)
+                for constraint in type_param.constraints
+            ),
+        )
+    if isinstance(type_param, TypeVarTupleParam):
+        return replace(
+            type_param,
+            default=(
+                None
+                if type_param.default is None
+                else type_param.default.substitute_typevars(substitutions)
+            ),
+        )
+    return replace(
+        type_param,
+        default=(
+            None
+            if type_param.default is None
+            else type_param.default.substitute_typevars(substitutions)
+        ),
+    )
+
+
+def _normalize_type_param_identities_in_type_param(
+    type_param: TypeParam,
+    replacements: Mapping[object, TypeParam],
+    normalize_value: Callable[[Value, Mapping[object, TypeParam]], Value],
+) -> TypeParam:
+    if isinstance(type_param, TypeVarParam):
+        return replace(
+            type_param,
+            bound=(
+                None
+                if type_param.bound is None
+                else normalize_value(type_param.bound, replacements)
+            ),
+            default=(
+                None
+                if type_param.default is None
+                else normalize_value(type_param.default, replacements)
+            ),
+            constraints=tuple(
+                normalize_value(constraint, replacements)
+                for constraint in type_param.constraints
+            ),
+        )
+    if isinstance(type_param, TypeVarTupleParam):
+        return replace(
+            type_param,
+            default=(
+                None
+                if type_param.default is None
+                else normalize_value(type_param.default, replacements)
+            ),
+        )
+    return replace(
+        type_param,
+        default=(
+            None
+            if type_param.default is None
+            else normalize_value(type_param.default, replacements)
+        ),
+    )
+
+
 class ActiveTypeParams:
     def __init__(self, visitor: TypeParamVisitor | None = None) -> None:
         self.visitor = visitor
         self._annotation_allowed_identities: list[set[object]] = []
-        self._active_pep695_identities: list[set[object]] = []
-        self._active_pep695_type_params: list[dict[object, TypeParam]] = []
         self._current_class_type_params: Sequence[TypeParam] | None = None
-        self._disallowed_identities: list[set[object]] = []
         self._legacy_policies: list[_LegacyTypeParamPolicy] = []
         self._variance_collections: list[_VarianceCollectionContext] = []
         self._current_class_type_param_polarities: dict[object, set[int]] | None = None
@@ -116,60 +361,80 @@ class ActiveTypeParams:
         self._scopes: list[TypeParamScope] = []
 
     @contextmanager
-    def add_scope(self, owner: TypeParamOwner) -> Generator[None]:
-        scope = TypeParamScope(owner, {})
+    def push_scope(self, owner: TypeParamOwner | None = None) -> Generator[None]:
+        scope = TypeParamScope(owner, {}, set())
         self._scopes.append(scope)
         try:
             yield
         finally:
             self._scopes.pop()
 
-    def current_annotation_identities(self) -> set[object]:
-        identities: set[object] = set()
+    def current_owner(self) -> TypeParamOwner:
+        for scope in reversed(self._scopes):
+            if scope.owner is not None:
+                return scope.owner
+        raise AssertionError("no active type parameter owner")
+
+    def current_annotation_identities(self) -> set[TypeParamIdentity]:
+        identities: set[TypeParamIdentity] = set()
         for allowed in self._annotation_allowed_identities:
-            identities.update(allowed)
-        for allowed in self._active_pep695_identities:
-            identities.update(allowed)
+            identities.update(_typed_identities(allowed))
+        identities.update(self.current_pep695_identities())
         return identities
 
-    def current_pep695_identities(self) -> set[object]:
-        identities: set[object] = set()
-        for allowed in self._active_pep695_identities:
-            identities.update(allowed)
-        return identities
+    def current_pep695_identities(self) -> set[TypeParamIdentity]:
+        return set(self.current_pep695_type_params())
 
-    def current_pep695_type_params(self) -> dict[object, TypeParam]:
-        type_params: dict[object, TypeParam] = {}
-        for scope in self._active_pep695_type_params:
-            type_params.update(scope)
+    def current_pep695_type_params(self) -> dict[TypeParamIdentity, TypeParam]:
+        type_params: dict[TypeParamIdentity, TypeParam] = {}
+        for scope in self._scopes:
+            type_params.update(scope.bindings)
         return type_params
 
     def get_type_param(self, identity: object) -> TypeParam | None:
-        for scope in reversed(self._active_pep695_type_params):
-            type_param = scope.get(identity)
+        if not _is_type_param_identity(identity):
+            return None
+        for scope in reversed(self._scopes):
+            type_param = scope.bindings.get(identity)
             if type_param is not None:
                 return type_param
         return None
+
+    def declare(
+        self,
+        type_param: TypeParam,
+        *,
+        aliases: Iterable[object] = (),
+        owner: TypeParamOwner | None = None,
+    ) -> TypeParam:
+        if owner is None:
+            owner = self._scopes[-1].owner if self._scopes else None
+        canonical = with_type_param_owner(type_param, owner)
+        if not self._scopes:
+            self._scopes.append(TypeParamScope(None, {}, set()))
+        for identity in (canonical.typevar, *_typed_identities(aliases)):
+            self._scopes[-1].bindings[identity] = canonical
+        return canonical
 
     def add_pep695_scope(
         self,
         type_params: Sequence[TypeParam],
         *,
-        additional_identities: Sequence[Iterable[object]] | None = None,
+        aliases: Sequence[Iterable[object]] | None = None,
+        owner: TypeParamOwner | None = None,
     ) -> None:
-        if additional_identities is None:
-            additional_identities = [()] * len(type_params)
-        scope: dict[object, TypeParam] = {}
-        identities: set[object] = set()
-        for type_param, extra_identities in zip(type_params, additional_identities):
-            all_identities = {type_param.typevar, *extra_identities}
-            for identity in all_identities:
-                scope[identity] = type_param
-            identities.update(all_identities)
-        if not identities:
+        if aliases is None:
+            aliases = [()] * len(type_params)
+        if len(aliases) != len(type_params):
+            raise ValueError("type parameter aliases must match type parameters")
+        if not type_params:
             return
-        self._active_pep695_identities.append(identities)
-        self._active_pep695_type_params.append(scope)
+        if not self._scopes:
+            self._scopes.append(TypeParamScope(owner, {}, set()))
+        elif owner is not None and self._scopes[-1].owner is None:
+            self._scopes[-1].owner = owner
+        for type_param, param_aliases in zip(type_params, aliases):
+            self.declare(type_param, aliases=param_aliases, owner=owner)
 
     def current_class_type_params(self) -> Sequence[TypeParam] | None:
         return self._current_class_type_params
@@ -191,18 +456,15 @@ class ActiveTypeParams:
         self,
         type_params: Sequence[TypeParam],
         *,
-        additional_identities: Sequence[Iterable[object]] | None = None,
+        aliases: Sequence[Iterable[object]] | None = None,
+        owner: TypeParamOwner | None = None,
     ) -> Generator[None]:
-        before = len(self._active_pep695_type_params)
-        self.add_pep695_scope(type_params, additional_identities=additional_identities)
-        if len(self._active_pep695_type_params) == before:
+        if not type_params:
             yield
             return
-        try:
+        with self.push_scope(owner):
+            self.add_pep695_scope(type_params, aliases=aliases)
             yield
-        finally:
-            self._active_pep695_type_params.pop()
-            self._active_pep695_identities.pop()
 
     @contextlib.contextmanager
     def push_class_type_params(
@@ -213,15 +475,61 @@ class ActiveTypeParams:
 
     @contextlib.contextmanager
     def disallow(self, identities: Iterable[object]) -> Generator[None]:
-        identities = set(identities)
-        if not identities:
+        disallowed = _typed_identities(identities)
+        if not disallowed:
             yield
             return
-        self._disallowed_identities.append(identities)
-        try:
+        with self.push_scope():
+            self._scopes[-1].disallowed.update(disallowed)
             yield
-        finally:
-            self._disallowed_identities.pop()
+
+    def bind_all(
+        self,
+        type_params: Sequence[TypeParam],
+        owner: TypeParamOwner,
+        *,
+        aliases: Sequence[Iterable[object]] | None = None,
+        normalize_value: (
+            Callable[[Value, Mapping[object, TypeParam]], Value] | None
+        ) = None,
+    ) -> TypeParamBindingResult:
+        if aliases is None:
+            aliases = [()] * len(type_params)
+        if len(aliases) != len(type_params):
+            raise ValueError("type parameter aliases must match type parameters")
+        owner_bound = tuple(
+            with_type_param_owner(param, owner) for param in type_params
+        )
+        substitutions = TypeVarMap()
+        replacements: dict[object, TypeParam] = {}
+        all_aliases: list[frozenset[TypeParamIdentity]] = []
+        for raw_param, bound_param, extra_aliases in zip(
+            type_params, owner_bound, aliases
+        ):
+            substitutions = substitutions.with_value(
+                raw_param, type_param_to_value(bound_param)
+            )
+            replacements[raw_param.typevar] = bound_param
+            replacements[bound_param.typevar] = bound_param
+            param_aliases = set(_identity_aliases(raw_param, bound_param))
+            param_aliases.update(_typed_identities(extra_aliases))
+            for alias in param_aliases:
+                replacements[alias] = bound_param
+            all_aliases.append(frozenset(param_aliases))
+        if normalize_value is None:
+            normalize_value = _normalize_type_param_identities_in_value
+        return TypeParamBindingResult(
+            tuple(
+                _normalize_type_param_identities_in_type_param(
+                    _substitute_typevars_in_type_param(param, substitutions),
+                    replacements,
+                    normalize_value,
+                )
+                for param in owner_bound
+            ),
+            substitutions,
+            tuple(all_aliases),
+        )
 
     @contextlib.contextmanager
     def reject_legacy_type_params(
@@ -232,9 +540,10 @@ class ActiveTypeParams:
         include_active_pep695: bool = True,
         report_in_collecting: bool = True,
     ) -> Generator[set[object]]:
-        allowed_identities = (
-            self.current_pep695_identities() if include_active_pep695 else set()
-        )
+        allowed_identities: set[object] = set()
+        if include_active_pep695:
+            for identity in self.current_pep695_identities():
+                allowed_identities.add(identity)
         policy = _LegacyTypeParamPolicy(
             allowed_identities,
             message,
@@ -387,13 +696,13 @@ class ActiveTypeParams:
             return
         if not (
             self._legacy_policies
-            or self._disallowed_identities
+            or self._has_disallowed_identities()
             or visitor.in_annotation
             or self._variance_collections
         ):
             return
         if self._variance_is_suspended and not (
-            self._legacy_policies or self._disallowed_identities
+            self._legacy_policies or self._has_disallowed_identities()
         ):
             return
         if _is_type_param_declaration_node(node):
@@ -466,7 +775,7 @@ class ActiveTypeParams:
 
         if not isinstance(type_param, TypeVarParam) or type_param.is_self:
             return
-        if any(identity in disallowed for disallowed in self._disallowed_identities):
+        if self._is_disallowed(identity):
             visitor._show_error_if_checking(
                 narrowed_error_node,
                 "Type parameter is not valid in this annotation context",
@@ -481,6 +790,27 @@ class ActiveTypeParams:
             narrowed_error_node,
             "Type parameter is not valid in this annotation context",
             error_code=ErrorCode.invalid_annotation,
+        )
+
+    def _has_disallowed_identities(self) -> bool:
+        return any(scope.disallowed for scope in self._scopes)
+
+    def _is_disallowed(self, identity: object) -> bool:
+        return any(identity in scope.disallowed for scope in self._scopes)
+
+    def normalize_type_param_identities(
+        self,
+        type_param: TypeParam,
+        replacements: Mapping[object, TypeParam],
+        *,
+        normalize_value: (
+            Callable[[Value, Mapping[object, TypeParam]], Value] | None
+        ) = None,
+    ) -> TypeParam:
+        if normalize_value is None:
+            normalize_value = _normalize_type_param_identities_in_value
+        return _normalize_type_param_identities_in_type_param(
+            type_param, replacements, normalize_value
         )
 
     # TODO: this is silly, find a better solution to prevent duplicate errors

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -369,11 +369,13 @@ class ActiveTypeParams:
         finally:
             self._scopes.pop()
 
-    def current_owner(self) -> TypeParamOwner:
-        for scope in reversed(self._scopes):
-            if scope.owner is not None:
-                return scope.owner
-        raise AssertionError("no active type parameter owner")
+    if sys.version_info >= (3, 12):
+
+        def current_owner(self) -> TypeParamOwner:
+            for scope in reversed(self._scopes):
+                if scope.owner is not None:
+                    return scope.owner
+            raise AssertionError("no active type parameter owner")
 
     def current_annotation_identities(self) -> set[TypeParamIdentity]:
         identities: set[TypeParamIdentity] = set()

--- a/pycroscope/typeshed.py
+++ b/pycroscope/typeshed.py
@@ -438,7 +438,9 @@ class TypeshedFinder:
                 # too confusing, just hardcode it.
                 if typ is AbstractSet:
                     return [
-                        GenericValue(Collection, (TypeVarValue(TypeVarParam(T_co)),))
+                        GenericValue(
+                            Collection, (TypeVarValue(TypeVarParam(T_co, owner=None)),)
+                        )
                     ]
                 if typ is collections.abc.Callable:
                     return None
@@ -452,7 +454,9 @@ class TypeshedFinder:
                 fq_name = str(val.typ)
                 if fq_name == "collections.abc.Set":
                     return [
-                        GenericValue(Collection, (TypeVarValue(TypeVarParam(T_co)),))
+                        GenericValue(
+                            Collection, (TypeVarValue(TypeVarParam(T_co, owner=None)),)
+                        )
                     ]
                 elif fq_name in (
                     "typing.Callable",

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -42,7 +42,7 @@ from collections.abc import (
     Sequence,
 )
 from contextlib import AbstractContextManager
-from dataclasses import InitVar, dataclass, field
+from dataclasses import InitVar, dataclass, field, replace
 from itertools import chain
 from types import FunctionType, ModuleType
 from typing import Any, Optional, TypeGuard, TypeVar, Union
@@ -1029,6 +1029,11 @@ class PartialCallValue(Value):
     runtime_value: Value
     node: ast.AST = field(compare=False, hash=False)
 
+    def __hash__(self) -> int:
+        return hash(
+            (self.callee, tuple(sorted(self.arguments.items())), self.runtime_value)
+        )
+
     def __str__(self) -> str:
         return f"{self.runtime_value} (call with arguments {self.arguments})"
 
@@ -1259,6 +1264,14 @@ class ParamSpecParam:
     def __str__(self) -> str:
         return _type_param_to_string("**", self.param_spec.__name__, self.owner)
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ParamSpecParam):
+            return NotImplemented
+        return self.param_spec == other.param_spec
+
+    def __hash__(self) -> int:
+        return hash(self.param_spec)
+
 
 @dataclass(frozen=True)
 class TypeVarTupleParam:
@@ -1274,8 +1287,28 @@ class TypeVarTupleParam:
     def __str__(self) -> str:
         return _type_param_to_string("*", self.typevar_tuple.__name__, self.owner)
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TypeVarTupleParam):
+            return NotImplemented
+        return self.typevar_tuple == other.typevar_tuple
+
+    def __hash__(self) -> int:
+        return hash(self.typevar_tuple)
+
 
 TypeParam = TypeVarParam | ParamSpecParam | TypeVarTupleParam
+
+
+def with_type_param_owner(
+    type_param: TypeParam, owner: TypeParamOwner | None
+) -> TypeParam:
+    if owner is None or type_param.owner is not None:
+        return type_param
+    if isinstance(type_param, TypeVarParam):
+        return replace(type_param, owner=owner)
+    if isinstance(type_param, ParamSpecParam):
+        return replace(type_param, owner=owner)
+    return replace(type_param, owner=owner)
 
 
 def _value_from_runtime_type_param_component(component: object) -> Value:

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -1029,11 +1029,6 @@ class PartialCallValue(Value):
     runtime_value: Value
     node: ast.AST = field(compare=False, hash=False)
 
-    def __hash__(self) -> int:
-        return hash(
-            (self.callee, tuple(sorted(self.arguments.items())), self.runtime_value)
-        )
-
     def __str__(self) -> str:
         return f"{self.runtime_value} (call with arguments {self.arguments})"
 

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -1259,14 +1259,6 @@ class ParamSpecParam:
     def __str__(self) -> str:
         return _type_param_to_string("**", self.param_spec.__name__, self.owner)
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ParamSpecParam):
-            return NotImplemented
-        return self.param_spec == other.param_spec
-
-    def __hash__(self) -> int:
-        return hash(self.param_spec)
-
 
 @dataclass(frozen=True)
 class TypeVarTupleParam:

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -1157,7 +1157,7 @@ def _type_param_to_string(prefix: str, name: str, owner: TypeParamOwner | None) 
 @dataclass(frozen=True)
 class TypeVarParam:
     typevar: TypeVarType
-    owner: TypeParamOwner | None = None  # TODO: make required
+    owner: TypeParamOwner | None
     bound: Value | None = None
     default: Value | None = None
     constraints: Sequence[Value] = ()
@@ -1236,7 +1236,7 @@ class TypeVarParam:
 @dataclass(frozen=True)
 class ParamSpecParam:
     param_spec: ParamSpecLike
-    owner: TypeParamOwner | None = None  # TODO: make required
+    owner: TypeParamOwner | None
     default: Value | None = None
     variance: Variance = Variance.INVARIANT
 
@@ -1263,7 +1263,7 @@ class ParamSpecParam:
 @dataclass(frozen=True)
 class TypeVarTupleParam:
     typevar_tuple: TypeVarTupleLike
-    owner: TypeParamOwner | None = None  # TODO: make required
+    owner: TypeParamOwner | None
     default: Value | None = None
     variance: Variance = Variance.INVARIANT
 
@@ -1302,13 +1302,13 @@ def _value_from_runtime_type_param_component(component: object) -> Value:
     if isinstance(component, Value):
         return component
     if is_instance_of_typing_name(component, "TypeVar"):
-        return TypeVarValue(TypeVarParam(component))
+        return TypeVarValue(TypeVarParam(component, owner=None))
     if is_instance_of_typing_name(component, "TypeVarTuple"):
         return TypeVarTupleValue(component)
     if is_instance_of_typing_name(component, "ParamSpec"):
         from pycroscope.input_sig import InputSigValue
 
-        return InputSigValue(ParamSpecParam(component))
+        return InputSigValue(ParamSpecParam(component, owner=None))
     if isinstance(component, tuple):
         return SequenceValue(
             tuple,
@@ -4331,10 +4331,17 @@ class CustomMapping(Protocol[K, V_co]):
 
 NominalMappingValue = GenericValue(
     collections.abc.Mapping,
-    [TypeVarValue(TypeVarParam(K)), TypeVarValue(TypeVarParam(V))],
+    [
+        TypeVarValue(TypeVarParam(K, owner=None)),
+        TypeVarValue(TypeVarParam(V, owner=None)),
+    ],
 )
 ProtocolMappingValue = GenericValue(
-    CustomMapping, [TypeVarValue(TypeVarParam(K)), TypeVarValue(TypeVarParam(V_co))]
+    CustomMapping,
+    [
+        TypeVarValue(TypeVarParam(K, owner=None)),
+        TypeVarValue(TypeVarParam(V_co, owner=None)),
+    ],
 )
 
 
@@ -4391,12 +4398,12 @@ def kv_pairs_from_mapping(
             if isinstance(can_assign, CanAssignError):
                 return can_assign
         key_type = can_assign.get_typevar(
-            TypeVarParam(K), AnyValue(AnySource.generic_argument)
+            TypeVarParam(K, owner=None), AnyValue(AnySource.generic_argument)
         )
         value_type = can_assign.get_typevar(
-            TypeVarParam(V),
+            TypeVarParam(V, owner=None),
             can_assign.get_typevar(
-                TypeVarParam(V_co), AnyValue(AnySource.generic_argument)
+                TypeVarParam(V_co, owner=None), AnyValue(AnySource.generic_argument)
             ),
         )
         return [KVPair(key_type, value_type, is_many=True)]


### PR DESCRIPTION
## Summary

This teaches annotation/type-parameter handling to carry active type parameter scopes so TypeVar-like parameters can be associated with the class, function, or type alias that introduced them. Direct TypeVar, ParamSpec, and TypeVarTuple constructor calls remain deferred until they are bound into a valid owner scope.

It also moves ActiveTypeParams into type_params.py and threads runtime PEP 695 scopes through annotations, argspecs, type objects, aliases, and related call handling.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.12 --extra tests pytest -q -x`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.12 --extra tests --extra full pytest pycroscope/test_self.py::test_all -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.12 --extra tests python tools/conformance_ci.py --typing-repo ~/py/typing`
