### PR TITLE
[codex] Support dict.fromkeys inference

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve precise dictionary entries for `dict.fromkeys()`, so known literal keys with a shared value can satisfy broader `dict[...]` return annotations.
 - Fix overload-only callable protocol methods so protocol compatibility checks use the declared overload set instead of the runtime overload placeholder.
 - Fix callable signature compatibility for syntactic `*args: Any, **kwargs: Any` tails and `ParamSpec[...]`, so callable protocols interoperate with fixed signatures more consistently.
 - Drop restrictions against redefined and function-local `type` statements.

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -1158,6 +1158,34 @@ def _dict_setitem_impl(ctx: CallContext) -> ImplReturn:
     return _add_pairs_to_dict(ctx.vars["self"], [pair], ctx, varname)
 
 
+def _dict_fromkeys_impl(ctx: CallContext) -> ImplReturn:
+    value = ctx.vars["value"]
+
+    def inner(iterable: Value) -> Value:
+        keys = concrete_values_from_iterable(iterable, ctx.visitor)
+        if isinstance(keys, CanAssignError):
+            ctx.show_error(
+                f"{iterable} is not iterable",
+                ErrorCode.unsupported_operation,
+                arg="iterable",
+                detail=str(keys),
+            )
+            return AnyValue(AnySource.error)
+        if isinstance(keys, Value):
+            if not _check_dict_key_hashability(keys, ctx, "iterable"):
+                return AnyValue(AnySource.error)
+            return DictIncompleteValue(dict, [KVPair(keys, value, is_many=True)])
+
+        pairs = []
+        for key in keys:
+            if not _check_dict_key_hashability(key, ctx, "iterable"):
+                return AnyValue(AnySource.error)
+            pairs.append(KVPair(key, value))
+        return DictIncompleteValue(dict, pairs)
+
+    return flatten_unions(inner, ctx.vars["iterable"])
+
+
 def _dict_getitem_impl(ctx: CallContext) -> ImplReturn:
     def inner(key: Value) -> Value:
         self_value = replace_fallback(ctx.vars["self"])
@@ -3279,6 +3307,63 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
             callable=dict.__setitem__,
             impl=_dict_setitem_impl,
             return_annotation=KnownValue(None),
+        ),
+        OverloadedSignature(
+            [
+                Signature.make(
+                    [
+                        SigParameter(
+                            "iterable",
+                            _POS_ONLY,
+                            annotation=GenericValue(
+                                collections.abc.Iterable,
+                                [TypeVarValue(TypeVarParam(K, owner=None))],
+                            ),
+                        ),
+                        SigParameter(
+                            "value",
+                            _POS_ONLY,
+                            annotation=KnownValue(None),
+                            default=KnownValue(None),
+                        ),
+                    ],
+                    callable=dict.fromkeys,
+                    impl=_dict_fromkeys_impl,
+                    return_annotation=GenericValue(
+                        dict,
+                        [
+                            TypeVarValue(TypeVarParam(K, owner=None)),
+                            AnyValue(AnySource.explicit) | KnownValue(None),
+                        ],
+                    ),
+                ),
+                Signature.make(
+                    [
+                        SigParameter(
+                            "iterable",
+                            _POS_ONLY,
+                            annotation=GenericValue(
+                                collections.abc.Iterable,
+                                [TypeVarValue(TypeVarParam(K, owner=None))],
+                            ),
+                        ),
+                        SigParameter(
+                            "value",
+                            _POS_ONLY,
+                            annotation=TypeVarValue(TypeVarParam(V, owner=None)),
+                        ),
+                    ],
+                    callable=dict.fromkeys,
+                    impl=_dict_fromkeys_impl,
+                    return_annotation=GenericValue(
+                        dict,
+                        [
+                            TypeVarValue(TypeVarParam(K, owner=None)),
+                            TypeVarValue(TypeVarParam(V, owner=None)),
+                        ],
+                    ),
+                ),
+            ]
         ),
         Signature.make(
             [

--- a/pycroscope/test_implementation.py
+++ b/pycroscope/test_implementation.py
@@ -1069,6 +1069,49 @@ class TestGenericMutators(TestNameCheckVisitorBase):
             )
 
     @assert_passes()
+    def test_dict_fromkeys(self):
+        from typing_extensions import Literal
+
+        FIELDS = ("section", "reference_type", "authors")
+
+        def capybara() -> dict[str, str]:
+            row = dict.fromkeys(FIELDS, "")
+            assert_is_value(
+                row,
+                DictIncompleteValue(
+                    dict,
+                    [
+                        KVPair(KnownValue("section"), KnownValue("")),
+                        KVPair(KnownValue("reference_type"), KnownValue("")),
+                        KVPair(KnownValue("authors"), KnownValue("")),
+                    ],
+                ),
+            )
+            row["other_key"] = "some_value"
+            assert_is_value(
+                row,
+                DictIncompleteValue(
+                    dict,
+                    [
+                        KVPair(KnownValue("section"), KnownValue("")),
+                        KVPair(KnownValue("reference_type"), KnownValue("")),
+                        KVPair(KnownValue("authors"), KnownValue("")),
+                        KVPair(KnownValue("other_key"), KnownValue("some_value")),
+                    ],
+                ),
+            )
+            return row
+
+        def explicit_none(i: int) -> None:
+            assert_is_value(
+                dict.fromkeys([i], None),
+                DictIncompleteValue(dict, [KVPair(TypedValue(int), KnownValue(None))]),
+            )
+
+        def from_iterable(keys: tuple[Literal["x"], ...]) -> dict[str, int]:
+            return dict.fromkeys(keys, 1)
+
+    @assert_passes()
     def test_dict_clear(self):
         from typing import Dict
 

--- a/pycroscope/test_typeshed.py
+++ b/pycroscope/test_typeshed.py
@@ -240,17 +240,6 @@ class TestTypeshedClient(TestNameCheckVisitorBase):
         assert tsf._get_fq_name(ExplodesOnQualname()) is None
 
     @assert_passes()
-    def test_dict_fromkeys(self):
-        def capybara(i: int) -> None:
-            assert_is_value(
-                dict.fromkeys([i]),
-                GenericValue(
-                    dict,
-                    [TypedValue(int), AnyValue(AnySource.explicit) | KnownValue(None)],
-                ),
-            )
-
-    @assert_passes()
     def test_datetime(self):
         from datetime import datetime
 


### PR DESCRIPTION
## Summary

- add a `dict.fromkeys` impl that returns a `DictIncompleteValue`
- preserve precise known keys for concrete iterables while still supporting arbitrary later dictionary mutations
- move coverage from the typeshed test surface into implementation tests

## Root cause

`dict.fromkeys()` previously relied on its typeshed return type, which collapses concrete literal keys into a generic `dict[...]`. Because `dict` is invariant, a return like `dict[Literal["section", ...], Literal[""]]` could fail against a broader annotation such as `dict[str, str]`.

## Validation

- `uv run --python 3.12 --extra tests python -m pytest pycroscope/test_implementation.py pycroscope/test_typeshed.py`
- `uv run --python 3.12 --extra tests --extra full python -m pytest pycroscope/test_self.py::test_all`
- `uvx prek run --files pycroscope/implementation.py pycroscope/test_implementation.py pycroscope/test_typeshed.py docs/changelog.md`
