### PR TITLE
[codex] Fix dataclass staticmethod overlay lookup

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserve precise dictionary entries for `dict.fromkeys()`, so known literal keys with a shared value can satisfy broader `dict[...]` return annotations.
+- Fix false positive `undefined_attribute` errors for `@staticmethod` methods accessed through dataclass instances.
 - Fix overload-only callable protocol methods so protocol compatibility checks use the declared overload set instead of the runtime overload placeholder.
 - Fix callable signature compatibility for syntactic `*args: Any, **kwargs: Any` tails and `ParamSpec[...]`, so callable protocols interoperate with fixed signatures more consistently.
 - Drop restrictions against redefined and function-local `type` statements.

--- a/pycroscope/dataclass.py
+++ b/pycroscope/dataclass.py
@@ -26,6 +26,22 @@ from .value import (
     get_self_param,
 )
 
+DATACLASS_MANAGED_METHODS = frozenset(
+    {
+        "__delattr__",
+        "__eq__",
+        "__ge__",
+        "__gt__",
+        "__hash__",
+        "__init__",
+        "__le__",
+        "__lt__",
+        "__post_init__",
+        "__repr__",
+        "__setattr__",
+    }
+)
+
 
 def synthesize_dataclass_hash_attribute(
     semantics: DataclassInfo | None,

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -2615,12 +2615,31 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             ),
         )
 
+    def _should_add_class_body_method_to_synthetic_overlay(
+        self,
+        synthetic_type: TypeObject,
+        method_name: str,
+        dataclass_semantics: DataclassInfo | None,
+    ) -> bool:
+        if not isinstance(synthetic_type.typ, type):
+            return True
+        if dataclass_semantics is None:
+            return True
+        return method_name in dataclass_helpers.DATACLASS_MANAGED_METHODS
+
     def _apply_synthetic_method_symbol_flags(
-        self, synthetic_type: TypeObject, node: ast.ClassDef
+        self,
+        synthetic_type: TypeObject,
+        node: ast.ClassDef,
+        dataclass_semantics: DataclassInfo | None = None,
     ) -> None:
         for method_name, (
             function_decorators
         ) in self._get_synthetic_method_symbol_flags(node).items():
+            if not self._should_add_class_body_method_to_synthetic_overlay(
+                synthetic_type, method_name, dataclass_semantics
+            ):
+                continue
             existing = synthetic_type.get_declared_symbol(method_name)
             if existing is not None and existing.is_property:
                 continue
@@ -2659,7 +2678,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             self._set_synthetic_member_on_type_object(
                 synthetic_type, synthetic_name, initializer=attr_value
             )
-        self._apply_synthetic_method_symbol_flags(synthetic_type, node)
+        self._apply_synthetic_method_symbol_flags(
+            synthetic_type, node, dataclass_semantics
+        )
         dataclass_helpers.apply_synthetic_attributes(
             dataclass_semantics,
             type_object=synthetic_type,
@@ -2897,6 +2918,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return
         synthetic_type = self._current_synthetic_overlay_type_object()
         if synthetic_type is None:
+            return
+        if not self._should_add_class_body_method_to_synthetic_overlay(
+            synthetic_type, node.name, self.current_dataclass_info
+        ):
             return
 
         deprecation_message = self._deprecation_message_from_value(
@@ -3669,7 +3694,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 tobj.set_is_direct_namedtuple(is_direct_namedtuple)
                 tobj.set_dataclass_info(dataclass_semantics)
                 tobj.set_dataclass_transform_info(dataclass_transform_info)
-                self._apply_synthetic_method_symbol_flags(tobj, node)
+                self._apply_synthetic_method_symbol_flags(
+                    tobj, node, dataclass_semantics
+                )
                 dataclass_metadata_class = synthetic_class
                 if self._is_checking():
                     # Bind the class name while checking its body so references

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -598,6 +598,20 @@ class TestAttributes(TestNameCheckVisitorBase):
             def read_staticmethod(self) -> None:
                 assert_type(super().label(), int)
 
+    @assert_passes(run_in_both_module_modes=True)
+    def test_dataclass_staticmethod_access_through_instance(self):
+        from dataclasses import dataclass
+
+        @dataclass
+        class Visitor:
+            @staticmethod
+            def is_literal(node: object) -> bool:
+                return True
+
+            def visit(self, node: object) -> None:
+                if self.is_literal(node):
+                    pass
+
     @assert_passes()
     def test_super_new_attribute(self):
         class Base:


### PR DESCRIPTION
## Summary

- limit runtime dataclass synthetic overlays to dataclass-managed class-body methods
- preserve ordinary runtime method symbols such as `@staticmethod` descriptors on dataclass classes
- add a regression test for accessing a dataclass staticmethod through `self`

## Root Cause

Runtime dataclass analysis was copying ordinary class-body methods into the synthetic overlay. For `@staticmethod`, the copied runtime value came from descriptor access and was already unwrapped to the inner function, while the runtime symbol table still had the real `staticmethod` object. That made instance lookup lose the descriptor shape and report a false `undefined_attribute`.

## Validation

- `uv run --python 3.12 --extra tests pytest pycroscope/test_dataclass.py`
- `uv run --python 3.12 --extra tests pytest pycroscope/test_attributes.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.12 --extra tests python tools/third_party_ci.py stubdefaulter`
