### PR TITLE
[codex] Fix predicate intersection overlap checks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix false positive `unsafe_comparison` errors when comparing a value narrowed by a length predicate against its original type.
 - Preserve precise dictionary entries for `dict.fromkeys()`, so known literal keys with a shared value can satisfy broader `dict[...]` return annotations.
 - Fix overload-only callable protocol methods so protocol compatibility checks use the declared overload set instead of the runtime overload placeholder.
 - Fix callable signature compatibility for syntactic `*args: Any, **kwargs: Any` tails and `ParamSpec[...]`, so callable protocols interoperate with fixed signatures more consistently.

--- a/pycroscope/test_unsafe_comparison.py
+++ b/pycroscope/test_unsafe_comparison.py
@@ -64,6 +64,13 @@ class TestUnsafeOverlap(TestNameCheckVisitorBase):
             assert 1 == z  # E: unsafe_comparison
 
     @assert_passes()
+    def test_len_predicate_intersection(self):
+        def capybara(title: str):
+            title_without_brackets = title.strip()
+            if len(title_without_brackets) >= 20 and title_without_brackets != title:
+                pass
+
+    @assert_passes()
     def test_subclass_value(self):
         from typing import Type
 

--- a/pycroscope/test_value.py
+++ b/pycroscope/test_value.py
@@ -14,7 +14,7 @@ from typing_extensions import Protocol, TypeVarTuple, runtime_checkable
 from . import tests, value
 from .checker import Checker
 from .name_check_visitor import NameCheckVisitor
-from .predicates import MinLen
+from .predicates import MaxLen, MinLen
 from .relations import _extract_type_form, intersect_values, is_subtype
 from .signature import ELLIPSIS_PARAM, Signature
 from .stacked_scopes import Composite
@@ -1317,3 +1317,25 @@ def test_can_overlap() -> None:
         TypedValue(str).can_overlap(KnownValue(None), CTX, OverlapMode.EQ),
         CanAssignError,
     )
+
+
+def test_intersection_can_overlap() -> None:
+    min_len_20 = value.PredicateValue(MinLen(20))
+    str_and_min_len = IntersectionValue((TypedValue(str), min_len_20))
+
+    assert str_and_min_len.can_overlap(TypedValue(str), CTX, OverlapMode.EQ) is None
+    assert TypedValue(str).can_overlap(str_and_min_len, CTX, OverlapMode.EQ) is None
+    assert value.is_overlapping(str_and_min_len, TypedValue(str), CTX)
+    assert not value.is_overlapping(
+        TypedValue(str) & TypedValue(int), TypedValue(str), CTX
+    )
+
+
+def test_predicate_can_overlap_uses_intersection() -> None:
+    min_len_20 = value.PredicateValue(MinLen(20))
+    max_len_10 = value.PredicateValue(MaxLen(10))
+
+    assert isinstance(
+        min_len_20.can_overlap(max_len_10, CTX, OverlapMode.EQ), CanAssignError
+    )
+    assert not value.is_overlapping(min_len_20, max_len_10, CTX)

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -556,6 +556,17 @@ class Value:
                     return None
                 errors.append(maybe_error)
             return CanAssignError("cannot overlap with union", errors)
+        if isinstance(other, IntersectionValue):
+            errors = []
+            for val in other.vals:
+                maybe_error = self.can_overlap(val, ctx, mode)
+                if maybe_error is not None:
+                    errors.append(maybe_error)
+            if errors:
+                return CanAssignError("cannot overlap with intersection", errors)
+            return None
+        if isinstance(other, PredicateValue):
+            return other.can_overlap(self, ctx, mode)
         if isinstance(other, AnnotatedValue):
             return self.can_overlap(other.value, ctx, mode)
         if isinstance(other, TypeVarValue):
@@ -2948,6 +2959,18 @@ class IntersectionValue(Value):
             [val.get_type_value(ctx) for val in self.vals], ctx
         )
 
+    def can_overlap(
+        self, other: Value, ctx: CanAssignContext, mode: OverlapMode
+    ) -> CanAssignError | None:
+        errors: list[CanAssignError] = []
+        for val in self.vals:
+            maybe_error = val.can_overlap(other, ctx, mode)
+            if maybe_error is not None:
+                errors.append(maybe_error)
+        if errors:
+            return CanAssignError("cannot overlap with intersection", errors)
+        return None
+
     def __str__(self) -> str:
         return " & ".join(str(val) for val in self.vals)
 
@@ -3941,6 +3964,26 @@ class PredicateValue(Value):
         # `object`, not an exact class object.
         return SubclassValue(TypedValue(object))
 
+    def can_overlap(
+        self, other: Value, ctx: CanAssignContext, mode: OverlapMode
+    ) -> CanAssignError | None:
+        if isinstance(
+            other,
+            (
+                VariableNameValue,
+                MultiValuedValue,
+                IntersectionValue,
+                AnnotatedValue,
+                TypeVarValue,
+                TypeAliasValue,
+            ),
+        ):
+            return super().can_overlap(other, ctx, mode)
+        inters = self.predicate.intersect_with(gradualize(other), ctx)
+        if inters is NO_RETURN_VALUE:
+            return CanAssignError(f"{self} and {other} cannot overlap")
+        return None
+
     def walk_values(self) -> Iterable[Value]:
         yield self
         yield from self.predicate.walk_values()
@@ -4731,14 +4774,24 @@ def is_overlapping(left: Value, right: Value, ctx: CanAssignContext) -> bool:
     # Fairly permissive checks for now; possibly this can be tightened up later.
     left = _deliteral(left)
     right = _deliteral(right)
-    # TODO: we should always do this but that leads to some silly behavior
-    # (it starts thinking about dictionary subclasses that are also sequences)
-    if isinstance(left, PredicateValue) or isinstance(right, PredicateValue):
-        inters = pycroscope.relations.intersect_values(left, right, ctx)
+    if isinstance(left, MultiValuedValue):
+        return not left.vals or any(
+            is_overlapping(val, right, ctx) for val in left.vals
+        )
+    if isinstance(right, MultiValuedValue):
+        return not right.vals or any(
+            is_overlapping(left, val, ctx) for val in right.vals
+        )
+    if isinstance(left, IntersectionValue):
+        return all(is_overlapping(val, right, ctx) for val in left.vals)
+    if isinstance(right, IntersectionValue):
+        return all(is_overlapping(left, val, ctx) for val in right.vals)
+    if isinstance(left, PredicateValue):
+        inters = left.predicate.intersect_with(gradualize(right), ctx)
         return inters is not NO_RETURN_VALUE
-    if isinstance(left, (MultiValuedValue, IntersectionValue)) and left.vals:
-        # Swap the operands so we decompose and de-Literal the other union too
-        return any(is_overlapping(right, val, ctx) for val in left.vals)
+    if isinstance(right, PredicateValue):
+        inters = right.predicate.intersect_with(gradualize(left), ctx)
+        return inters is not NO_RETURN_VALUE
     return left.is_assignable(right, ctx) or right.is_assignable(left, ctx)
 
 


### PR DESCRIPTION
## Summary

- Treat intersection overlap checks as requiring every intersection member to overlap with the other type.
- Let predicate overlap checks consult `Predicate.intersect_with()`, so predicates that reduce to `Never` are considered non-overlapping.
- Add regression coverage for the length-predicate comparison case that previously produced a false positive `unsafe_comparison` error.

## Root Cause

`IntersectionValue` did not implement `can_overlap()`, so comparisons involving values like `str & Predicate[len(x) >= 20]` fell through to the generic non-overlap path. The boolean `is_overlapping()` helper also treated intersections like union alternatives instead of requiring all intersection members to be compatible.

## Validation

- `uv run --python 3.12 --extra tests python -m pytest pycroscope/test_value.py pycroscope/test_unsafe_comparison.py`
- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff check pycroscope/value.py pycroscope/test_value.py pycroscope/test_unsafe_comparison.py`