### PR TITLE
Improve third-party CI local workflow

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Install pycroscope
         run: pip install .
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 .venv
 node_modules/
 tmp/
+tools/third_party_ci_local.toml
 .DS_Store
 .coverage
 coverage.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,3 +46,18 @@ We run tests on all supported Python versions on GitHub Actions,
 but usually I don't bother when testing locally. If necessary, you
 can install all supported versions with a tool like
 [pyenv](https://github.com/pyenv/pyenv).
+
+## Third-party CI
+
+`tools/third_party_ci.py` runs pycroscope against configured third-party
+repositories. It automatically reads the gitignored local config file
+`tools/third_party_ci_local.toml` if it exists, so you can keep local checkout
+paths there:
+
+```toml
+[local]
+taxonomy = "/path/to/taxonomy"
+```
+
+Command-line `--local NAME:PATH` values override the config file. Dependency
+installation output is hidden by default; pass `-v` or `--verbose` to show it.

--- a/tools/run_third_party.py
+++ b/tools/run_third_party.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import os
 import re
 import subprocess
 import sys
 import tempfile
-from collections.abc import Iterator, Sequence
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -47,21 +46,36 @@ def _resolve_workdir_relative_path(workdir: Path, value: str) -> Path:
     return path.resolve()
 
 
-def install_editable_package(package_dir: Path) -> None:
-    if importlib.util.find_spec("pip") is not None:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-e", str(package_dir)], check=True
-        )
+def _editable_install_command(package_dir: Path) -> list[str]:
+    return ["uv", "pip", "install", "--python", sys.executable, "-e", str(package_dir)]
+
+
+def install_editable_package(package_dir: Path, *, verbose: bool = False) -> None:
+    command = _editable_install_command(package_dir)
+    if verbose:
+        subprocess.run(command, check=True)
         return
 
-    subprocess.run(
-        ["uv", "pip", "install", "--python", sys.executable, "-e", str(package_dir)],
-        check=True,
-    )
+    try:
+        subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        if exc.stdout:
+            print(
+                exc.stdout,
+                end="" if exc.stdout.endswith("\n") else "\n",
+                file=sys.stderr,
+            )
+        raise
 
 
 @contextmanager
-def clone_repo(repo_url: str, ref: str | None = None) -> Iterator[Path]:
+def clone_repo(repo_url: str, ref: str | None = None) -> Generator[Path, None, None]:
     repo_name = _sanitize_repo_name(repo_url)
     with tempfile.TemporaryDirectory(prefix=f"{repo_name}-") as temp_dir:
         clone_dir = Path(temp_dir) / repo_name
@@ -76,7 +90,9 @@ def clone_repo(repo_url: str, ref: str | None = None) -> Iterator[Path]:
 
 
 @contextmanager
-def repo_context(repo_ref: str, ref: str | None = None) -> Iterator[tuple[Path, bool]]:
+def repo_context(
+    repo_ref: str, ref: str | None = None
+) -> Generator[tuple[Path, bool], None, None]:
     if Path(repo_ref).expanduser().exists():
         yield _resolve_local_repo(repo_ref), False
         return
@@ -206,6 +222,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             "For values starting with '-', use --pycroscope-arg=VALUE."
         ),
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show dependency installation output.",
+    )
     install_group = parser.add_mutually_exclusive_group()
     install_group.add_argument(
         "--install",
@@ -235,7 +257,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             should_install = args.install or (cloned and not args.skip_install)
             if should_install:
                 print(f"Installing editable package from: {install_dir}")
-                install_editable_package(install_dir)
+                install_editable_package(install_dir, verbose=args.verbose)
             return run_pycroscope(
                 repo_root,
                 workdir=workdir,

--- a/tools/test_third_party_ci.py
+++ b/tools/test_third_party_ci.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tools import run_third_party, third_party_ci
+
+
+def test_read_local_config(tmp_path: Path) -> None:
+    config = tmp_path / "third_party_ci_local.toml"
+    config.write_text(
+        textwrap.dedent("""
+            [local]
+            taxonomy = "/path/to/taxonomy"
+        """),
+        encoding="utf-8",
+    )
+
+    assert third_party_ci.read_local_config(config, {"taxonomy"}) == {
+        "taxonomy": "/path/to/taxonomy"
+    }
+
+
+def test_read_local_config_rejects_unknown_check(tmp_path: Path) -> None:
+    config = tmp_path / "third_party_ci_local.toml"
+    config.write_text(
+        textwrap.dedent("""
+            [local]
+            unknown = "/tmp/unknown"
+        """),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unknown third-party check"):
+        third_party_ci.read_local_config(config, {"taxonomy"})
+
+
+def test_build_run_third_party_argv_uses_local_override() -> None:
+    check = third_party_ci.ThirdPartyCheck(
+        name="taxonomy",
+        repo_url="https://example.com/taxonomy.git",
+        targets=("taxonomy/",),
+    )
+    argv = third_party_ci.build_run_third_party_argv(
+        check, {"taxonomy": "/path/to/taxonomy"}, verbose=True
+    )
+
+    assert argv[0] == "/path/to/taxonomy"
+    assert "--verbose" in argv
+
+
+def test_main_reads_local_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / "third_party_ci_local.toml"
+    config.write_text(
+        textwrap.dedent("""
+            [local]
+            taxonomy = "/path/to/taxonomy"
+        """),
+        encoding="utf-8",
+    )
+    seen_overrides: dict[str, str] = {}
+
+    def fake_run_check(
+        check: third_party_ci.ThirdPartyCheck,
+        local_overrides: dict[str, str],
+        *,
+        verbose: bool = False,
+    ) -> int:
+        nonlocal seen_overrides
+        seen_overrides = local_overrides
+        assert not verbose
+        return 0
+
+    monkeypatch.setattr(third_party_ci, "LOCAL_CONFIG_PATH", config)
+    monkeypatch.setattr(third_party_ci, "run_check", fake_run_check)
+
+    assert third_party_ci.main(["taxonomy"]) == 0
+    assert seen_overrides == {"taxonomy": "/path/to/taxonomy"}
+
+
+def test_main_command_line_local_overrides_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / "third_party_ci_local.toml"
+    config.write_text(
+        textwrap.dedent("""
+            [local]
+            taxonomy = "/path/to/taxonomy"
+        """),
+        encoding="utf-8",
+    )
+    seen_overrides: dict[str, str] = {}
+    seen_verbose = False
+
+    def fake_run_check(
+        check: third_party_ci.ThirdPartyCheck,
+        local_overrides: dict[str, str],
+        *,
+        verbose: bool = False,
+    ) -> int:
+        nonlocal seen_overrides, seen_verbose
+        seen_overrides = local_overrides
+        seen_verbose = verbose
+        return 0
+
+    monkeypatch.setattr(third_party_ci, "LOCAL_CONFIG_PATH", config)
+    monkeypatch.setattr(third_party_ci, "run_check", fake_run_check)
+
+    assert (
+        third_party_ci.main(["taxonomy", "--local", "taxonomy:/cli/taxonomy", "-v"])
+        == 0
+    )
+    assert seen_overrides == {"taxonomy": "/cli/taxonomy"}
+    assert seen_verbose is True
+
+
+def test_install_editable_package_hides_success_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen_command: list[str] = []
+    seen_kwargs: dict[str, object] = {}
+
+    def fake_run(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal seen_command, seen_kwargs
+        seen_command = command
+        seen_kwargs = kwargs
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(run_third_party.subprocess, "run", fake_run)
+
+    run_third_party.install_editable_package(tmp_path)
+
+    assert seen_command == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        run_third_party.sys.executable,
+        "-e",
+        str(tmp_path),
+    ]
+    assert seen_kwargs["stdout"] is subprocess.PIPE
+    assert seen_kwargs["stderr"] is subprocess.STDOUT
+    assert seen_kwargs["text"] is True
+
+
+def test_install_editable_package_verbose_streams_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen_kwargs: dict[str, object] = {}
+
+    def fake_run(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal seen_kwargs
+        seen_kwargs = kwargs
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(run_third_party.subprocess, "run", fake_run)
+
+    run_third_party.install_editable_package(tmp_path, verbose=True)
+
+    assert "stdout" not in seen_kwargs
+    assert "stderr" not in seen_kwargs

--- a/tools/third_party_ci.py
+++ b/tools/third_party_ci.py
@@ -11,6 +11,11 @@ if __package__ in (None, ""):
 
 from tools import run_third_party
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # static analysis: ignore[import_failed]
+
 
 @dataclass(frozen=True)
 class ThirdPartyCheck:
@@ -39,6 +44,8 @@ THIRD_PARTY_CHECKS: Final[tuple[ThirdPartyCheck, ...]] = (
         targets=("taxonomy/",),
     ),
 )
+
+LOCAL_CONFIG_PATH: Final = Path(__file__).with_name("third_party_ci_local.toml")
 
 
 def _checks_by_name() -> dict[str, ThirdPartyCheck]:
@@ -85,8 +92,34 @@ def parse_local_overrides(values: list[str], known_checks: set[str]) -> dict[str
     return overrides
 
 
+def read_local_config(
+    path: Path | None = None, known_checks: set[str] | None = None
+) -> dict[str, str]:
+    if path is None:
+        path = LOCAL_CONFIG_PATH
+    if not path.exists():
+        return {}
+
+    known_checks = known_checks or {check.name for check in THIRD_PARTY_CHECKS}
+    with path.open("rb") as config_file:
+        data = tomllib.load(config_file)
+
+    local = data.get("local", {})
+    if not isinstance(local, dict):
+        raise ValueError(f"{path}: [local] must be a table.")
+
+    overrides: dict[str, str] = {}
+    for name, value in local.items():
+        if name not in known_checks:
+            raise ValueError(f"{path}: unknown third-party check in [local]: {name}")
+        if not isinstance(value, str):
+            raise ValueError(f"{path}: [local].{name} must be a string path.")
+        overrides[name] = value
+    return overrides
+
+
 def build_run_third_party_argv(
-    check: ThirdPartyCheck, local_overrides: dict[str, str]
+    check: ThirdPartyCheck, local_overrides: dict[str, str], *, verbose: bool = False
 ) -> list[str]:
     repo_ref = local_overrides.get(check.name, check.repo_url)
     argv = [repo_ref, *check.targets, "--config-file", check.config_file]
@@ -102,12 +135,18 @@ def build_run_third_party_argv(
         argv.append(f"--pycroscope-arg={arg}")
     if check.install:
         argv.append("--install")
+    if verbose:
+        argv.append("--verbose")
     return argv
 
 
-def run_check(check: ThirdPartyCheck, local_overrides: dict[str, str]) -> int:
+def run_check(
+    check: ThirdPartyCheck, local_overrides: dict[str, str], *, verbose: bool = False
+) -> int:
     print(f"Running pycroscope on {check.name}...")
-    exit_code = run_third_party.main(build_run_third_party_argv(check, local_overrides))
+    exit_code = run_third_party.main(
+        build_run_third_party_argv(check, local_overrides, verbose=verbose)
+    )
     if exit_code == 0:
         if check.expected_to_fail:
             print(f"{check.name}: unexpectedly clean")
@@ -148,13 +187,21 @@ def main(argv: list[str] | None = None) -> int:
             "May be repeated."
         ),
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show dependency installation output from each third-party check.",
+    )
     args = parser.parse_args(argv)
 
     try:
         selected_checks = select_checks(args.checks)
-        local_overrides = parse_local_overrides(
-            args.local, {check.name for check in THIRD_PARTY_CHECKS}
-        )
+        known_checks = {check.name for check in THIRD_PARTY_CHECKS}
+        local_overrides = {
+            **read_local_config(known_checks=known_checks),
+            **parse_local_overrides(args.local, known_checks),
+        }
     except ValueError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -166,7 +213,7 @@ def main(argv: list[str] | None = None) -> int:
 
     failures: list[str] = []
     for check in selected_checks:
-        if run_check(check, local_overrides) != 0:
+        if run_check(check, local_overrides, verbose=args.verbose) != 0:
             failures.append(check.name)
 
     if failures:


### PR DESCRIPTION
## Summary

- hide editable-install output in third-party CI unless `-v/--verbose` is passed
- add a gitignored `tools/third_party_ci_local.toml` for local checkout paths
- make third-party editable installs consistently use `uv pip install`
- install uv in the third-party CI workflow
- add focused tests for the local config and install-output behavior

## Validation

- `uv run --extra tests pytest tools/test_third_party_ci.py`
- `uvx prek run ruff --files tools/run_third_party.py tools/third_party_ci.py tools/test_third_party_ci.py`
- `uvx prek run black --files tools/run_third_party.py tools/third_party_ci.py tools/test_third_party_ci.py`
- `uvx prek run end-of-file-fixer --files tools/run_third_party.py tools/third_party_ci.py tools/test_third_party_ci.py .gitignore CONTRIBUTING.md`
- `uvx prek run trailing-whitespace --files tools/run_third_party.py tools/third_party_ci.py tools/test_third_party_ci.py .gitignore CONTRIBUTING.md`
- `uv run python -m pycroscope --config-file pyproject.toml tools/third_party_ci.py tools/run_third_party.py tools/test_third_party_ci.py`
- `uv run python tools/third_party_ci.py --list`
