### PR TITLE
[codex] Recognize warnings.deprecated decorators

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Recognize `warnings.deprecated` as a deprecation decorator in static fallback analysis, fixing missed deprecated diagnostics with newer `typing_extensions` backports.
 - Fix false positive `unsafe_comparison` errors when comparing a value narrowed by a length predicate against its original type.
 - Preserve precise dictionary entries for `dict.fromkeys()`, so known literal keys with a shared value can satisfy broader `dict[...]` return annotations.
 - Fix false positive `undefined_attribute` errors for `@staticmethod` methods accessed through dataclass instances.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -85,6 +85,7 @@ from .find_unused import used
 from .functions import FunctionDefNode
 from .node_visitor import ErrorContext
 from .safe import (
+    is_deprecated_decorator,
     is_instance_of_typing_name,
     is_sentinel,
     is_typing_name,
@@ -3447,7 +3448,7 @@ class _Visitor(ast.NodeVisitor):
             )
             make_type_param_from_value(partial, ctx=self.ctx)
             return partial
-        elif is_typing_name(func.val, "deprecated") or func.val is deprecated:
+        elif is_deprecated_decorator(func.val):
             if node.keywords:
                 self.ctx.show_error(
                     "deprecated() does not accept keyword arguments", node=node

--- a/pycroscope/functions.py
+++ b/pycroscope/functions.py
@@ -19,13 +19,12 @@ from typing_extensions import ReadOnly, Sentinel
 
 from .analysis_lib import is_positional_only_arg_name
 from .error_code import ErrorCode
-from .extensions import deprecated as deprecated_decorator
 from .input_sig import InputSigValue
 from .maybe_asynq import asynq
 from .node_visitor import Error, ErrorContext
 from .options import Options, PyObjectSequenceOption
 from .relations import Relation, get_tv_map, has_relation
-from .safe import is_instance_of_typing_name, is_typing_name
+from .safe import is_deprecated_decorator, is_instance_of_typing_name, is_typing_name
 from .signature import (
     ParameterKind,
     Signature,
@@ -870,11 +869,7 @@ def _deprecated_message_from_decorator(
     unapplied: Value, node: ast.expr, ctx: Context
 ) -> str | None:
     if not (
-        isinstance(unapplied, KnownValue)
-        and (
-            is_typing_name(unapplied.val, "deprecated")
-            or unapplied.val is deprecated_decorator
-        )
+        isinstance(unapplied, KnownValue) and is_deprecated_decorator(unapplied.val)
     ):
         return None
     if not isinstance(node, ast.Call) or not node.args:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -155,6 +155,7 @@ from .relations import (
 from .safe import (
     hasattr_static,
     is_dataclass_type,
+    is_deprecated_decorator,
     is_hashable,
     is_namedtuple_class,
     is_typing_name,
@@ -3025,7 +3026,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         for unapplied, _, node in decorators:
             if not (
                 isinstance(unapplied, KnownValue)
-                and is_typing_name(unapplied.val, "deprecated")
+                and is_deprecated_decorator(unapplied.val)
                 and isinstance(node, ast.Call)
                 and node.args
                 and isinstance(node.args[0], ast.Constant)

--- a/pycroscope/safe.py
+++ b/pycroscope/safe.py
@@ -8,6 +8,7 @@ import inspect
 import sys
 import types
 import typing
+import warnings
 from collections.abc import Container, Sequence
 from typing import Any, NewType, TypeVar
 
@@ -170,6 +171,18 @@ def is_typing_name(obj: object, name: str) -> bool:
         if obj is typing_obj:
             return True
     return safe_in(obj, names)
+
+
+def is_deprecated_decorator(obj: object) -> bool:
+    from .extensions import deprecated as deprecated_decorator
+
+    if obj is deprecated_decorator or is_typing_name(obj, "deprecated"):
+        return True
+    return obj is _WARNINGS_DEPRECATED
+
+
+_MISSING = object()
+_WARNINGS_DEPRECATED = getattr(warnings, "deprecated", _MISSING)
 
 
 try:

--- a/pycroscope/typeshed.py
+++ b/pycroscope/typeshed.py
@@ -31,7 +31,6 @@ from .annotations import (
     value_from_ast,
 )
 from .error_code import Error, ErrorCode
-from .extensions import deprecated as deprecated_decorator
 from .extensions import evaluated, overload, real_overload
 from .functions import IMPLICIT_CLASSMETHODS, translate_vararg_type
 from .options import (
@@ -40,7 +39,13 @@ from .options import (
     Options,
     PathSequenceOption,
 )
-from .safe import hasattr_static, is_typing_name, safe_getattr, safe_isinstance
+from .safe import (
+    hasattr_static,
+    is_deprecated_decorator,
+    is_typing_name,
+    safe_getattr,
+    safe_isinstance,
+)
 from .shared_options import ImportPaths
 from .signature import (
     ConcreteSignature,
@@ -1315,9 +1320,8 @@ class TypeshedFinder:
             elif decorator == KnownValue(evaluated):
                 is_evaluated = True
                 continue
-            elif (
-                isinstance(decorator, DecoratorValue)
-                and decorator.decorator is deprecated_decorator
+            elif isinstance(decorator, DecoratorValue) and is_deprecated_decorator(
+                decorator.decorator
             ):
                 arg = decorator.args[0]
                 if isinstance(arg, KnownValue) and isinstance(arg.val, str):
@@ -1547,9 +1551,8 @@ class TypeshedFinder:
     def _extract_extension_from_decorator(
         self, decorator_val: Value
     ) -> Extension | None:
-        if (
-            isinstance(decorator_val, DecoratorValue)
-            and decorator_val.decorator is deprecated_decorator
+        if isinstance(decorator_val, DecoratorValue) and is_deprecated_decorator(
+            decorator_val.decorator
         ):
             arg = decorator_val.args[0]
             if isinstance(arg, KnownValue) and isinstance(arg.val, str):


### PR DESCRIPTION
## Summary

- Add a shared `is_deprecated_decorator()` helper for deprecation-decorator identity checks.
- Treat `warnings.deprecated` as a deprecated decorator when it exists, alongside `typing_extensions.deprecated` and `pycroscope.extensions.deprecated`.
- Use the helper across function parsing, annotation parsing, class/member metadata, and typeshed extraction.

## Root Cause

In static fallback mode, typeshed can resolve `typing_extensions.deprecated` to `warnings.deprecated`, while newer `typing_extensions` backports may expose a distinct runtime `typing_extensions.deprecated` object on affected Python patch versions. Existing checks only recognized the typing/pycroscope identities, so deprecation metadata could be missed.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.13 --extra tests pytest pycroscope/test_deprecated.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.14 --extra tests --with-editable /Users/jelle/py/typing_extensions pytest pycroscope/test_deprecated.py::TestRuntime::test_unimportable_module_deprecations -q`
- `UV_CACHE_DIR=/tmp/uv-cache uvx ruff check pycroscope/safe.py pycroscope/functions.py pycroscope/annotations.py pycroscope/name_check_visitor.py pycroscope/typeshed.py pycroscope/test_deprecated.py`