### PR TITLE
[codex] Infer type parameter variance from class API

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Infer and validate class type-parameter variance from the collected class API in both importable and static fallback analysis, including generic bases and callable member annotations.
+
 ## Version 0.4.0 (May 2, 2026)
 
 This release aims to strengthen robustness and quality, fixing many issues

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Infer and validate class type-parameter variance from the collected class API in both importable and static fallback analysis, including generic bases and callable member annotations.
+- Treat plain subclasses of frozen dataclasses as mutable for their own annotated attributes, while keeping inherited frozen dataclass fields read-only.
 
 ## Version 0.4.0 (May 2, 2026)
 

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -171,6 +171,7 @@ from .value import (
     replace_fallback,
     replace_known_sequence_value,
     stringify_object,
+    type_param_to_value,
     typevartuple_binding_to_generic_args,
     unite_values,
 )
@@ -346,6 +347,10 @@ class Context:
         return AnyValue(AnySource.error)
 
     def get_name_from_globals(self, name: str, globals: Mapping[str, Any]) -> Value:
+        if (
+            type_param := self.active_type_params.get_type_param_by_name(name)
+        ) is not None:
+            return type_param_to_value(type_param)
         if name in globals:
             return KnownValue(globals[name])
         elif hasattr(builtins, name):

--- a/pycroscope/functions.py
+++ b/pycroscope/functions.py
@@ -259,11 +259,6 @@ class Context(ErrorContext, CanAssignContext, Protocol):
     def catch_errors(self) -> AbstractContextManager[list[Error]]:
         raise NotImplementedError
 
-    def function_param_type_param_variance_context(
-        self, *, parameter_index: int, is_staticmethod: bool
-    ) -> AbstractContextManager[None]:
-        raise NotImplementedError
-
 
 class AsynqDecorators(PyObjectSequenceOption[object]):
     """Decorators that are equivalent to asynq.asynq."""
@@ -460,10 +455,7 @@ def compute_parameters(
             and not isinstance(node, ast.Lambda)
         )
         if arg.annotation is not None:
-            with ctx.function_param_type_param_variance_context(
-                parameter_index=idx, is_staticmethod=is_staticmethod
-            ):
-                value = ctx.expr_of_annotation(arg.annotation)
+            value = ctx.expr_of_annotation(arg.annotation)
             inner_value, _ = value.maybe_unqualify(
                 set(Qualifier), qualifier_error_code=ErrorCode.invalid_qualifier
             )

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -243,8 +243,7 @@ from .type_object import (
 from .type_params import (
     ActiveTypeParams,
     TypeParamIdentity,
-    compose_observed_variance_polarity,
-    record_variance_polarity,
+    infer_type_param_variances_from_class_api,
 )
 from .typeshed import TypeshedFinder
 from .value import (
@@ -2942,14 +2941,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             for decorator in node.decorator_list
         ):
 
-            if isinstance(function_value, PartialCallValue) and is_equivalent(
-                function_value.callee, KnownValue(property), self
-            ):
-                getter = function_value.arguments.get(
-                    "fget", AnyValue(AnySource.inference)
-                )
-            else:
-                getter = AnyValue(AnySource.inference)
+            getter = self._undecorated_function_value(info)
             fget = info.get_symbol(getter, deprecation_message)
             self._set_complete_synthetic_class_symbol(
                 node.name,
@@ -2971,20 +2963,21 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 setter_target_name = decorator.value.id
                 break
         if setter_target_name is None:
-            function_decorators = self._synthetic_method_symbol_flags(node)
             self._set_complete_synthetic_class_symbol(
                 node.name,
                 initializer=function_value,
                 node=node,
                 is_instance_only=False,
                 is_method=True,
-                function_decorators=function_decorators,
+                function_decorators=info.decorator_kinds,
                 deprecation_message=deprecation_message,
             )
             return
 
         mangled_target = _mangle_class_attribute_name(class_name, setter_target_name)
-        fset = info.get_symbol(function_value, deprecation_message)
+        fset = info.get_symbol(
+            self._undecorated_function_value(info), deprecation_message
+        )
         existing = synthetic_type.get_declared_symbol(mangled_target)
         existing_property_info = (
             existing.property_info if existing is not None else None
@@ -3008,6 +3001,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 fset=fset,
             ),
         )
+
+    def _undecorated_function_value(self, info: FunctionInfo) -> Value:
+        return compute_value_of_function(replace(info, decorators=[]), self)
 
     def _deprecation_message_from_value(self, value: Value) -> str | None:
         value = replace_fallback(value)
@@ -3731,16 +3727,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 class_scope_object if isinstance(class_scope_object, type) else None
             )
             is_protocol_class = self._is_protocol_class(base_values, class_scope_object)
-            class_type_param_polarities: dict[object, set[int]] = {}
-            if not is_protocol_class:
-                for base_variance_info in base_type_param_variance_infos:
-                    if base_variance_info.is_variance_declaration_base:
-                        continue
-                    self._merge_type_param_polarities(
-                        class_type_param_polarities,
-                        base_variance_info.type_param_polarities,
-                        polarity=1,
-                    )
             effective_type_param_values = (
                 type_param_values
                 if type_param_values
@@ -3844,6 +3830,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                     for base in base_values_for_registration
                 ]
+            variance_declaration_base_indexes = frozenset(
+                i
+                for i, base_info in enumerate(base_type_param_variance_infos)
+                if base_info.is_variance_declaration_base
+            )
             if should_register_generic_bases:
                 self.checker.register_synthetic_type_bases(
                     generic_class_key,
@@ -3880,24 +3871,18 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 ),
                 override(self, "current_namedtuple_info", namedtuple_info),
                 self.active_type_params.push_class_type_params(class_scope_type_params),
-                self.active_type_params.push_class_type_param_variance_collection(
-                    class_type_param_polarities, is_protocol_class=is_protocol_class
-                ),
             ):
                 value, class_scope_values = self._visit_class_and_get_value(
                     node, class_scope_object
                 )
             if synthetic_typeddict is None:
                 inferred_registration_type_params: Sequence[TypeParam] | None = None
-                if class_scope_type_params and any(
-                    _type_param_uses_infer_variance(type_param)
-                    for type_param in class_scope_type_params
-                ):
+                if class_scope_type_params:
                     inferred_registration_type_params = (
-                        self._infer_type_param_variances_from_polarities(
-                            class_scope_type_params,
-                            class_type_param_polarities,
-                            is_protocol=False,
+                        infer_type_param_variances_from_class_api(
+                            tobj,
+                            self,
+                            excluded_base_indexes=variance_declaration_base_indexes,
                         )
                     )
 
@@ -3953,11 +3938,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     base_type_param_variance_infos,
                 )
                 self._check_protocol_type_param_variances(
-                    node,
-                    declared_type_params,
-                    base_values,
-                    class_scope_object,
-                    class_type_param_polarities,
+                    node, tobj, excluded_base_indexes=variance_declaration_base_indexes
                 )
             if (
                 runtime_enum_fallback_class is not None
@@ -5383,42 +5364,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def _check_protocol_type_param_variances(
         self,
         node: ast.ClassDef,
-        type_params: Sequence[TypeParam],
-        base_values: Sequence[Value],
-        class_scope_object: ClassKey | None,
-        type_param_polarities: Mapping[object, set[int]],
+        tobj: TypeObject,
+        *,
+        excluded_base_indexes: frozenset[int],
     ) -> None:
         if sys.version_info >= (3, 12) and node.type_params:
             # PEP 695 class type parameters infer variance, so explicit
             # protocol variance checks for legacy TypeVars don't apply.
             return
-        if not self._is_protocol_class(base_values, class_scope_object):
+        if not tobj.is_protocol():
             return
+        type_params = tobj.get_declared_type_params()
         if not type_params:
             return
-        if isinstance(class_scope_object, (type, ClassOwner)):
-            canonical_type_params = tuple(
-                self.checker.get_type_parameters(class_scope_object)
-            )
-            if len(canonical_type_params) == len(type_params):
-                rebound_type_params: list[TypeParam] = []
-                for declared_type_param, canonical_type_param in zip(
-                    type_params, canonical_type_params
-                ):
-                    if isinstance(declared_type_param, TypeVarParam) and isinstance(
-                        canonical_type_param, TypeVarParam
-                    ):
-                        rebound_type_params.append(
-                            replace(
-                                canonical_type_param,
-                                variance=declared_type_param.variance,
-                            )
-                        )
-                    elif type(declared_type_param) is type(canonical_type_param):
-                        rebound_type_params.append(canonical_type_param)
-                    else:
-                        rebound_type_params.append(declared_type_param)
-                type_params = tuple(rebound_type_params)
         checked_type_params = [
             type_param
             for type_param in type_params
@@ -5426,12 +5384,25 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         ]
         if not checked_type_params:
             return
-        inferred_type_params = self._infer_type_param_variances_from_polarities(
-            checked_type_params, type_param_polarities, is_protocol=True
+        inferred_type_params = infer_type_param_variances_from_class_api(
+            tobj,
+            self,
+            excluded_base_indexes=excluded_base_indexes,
+            infer_variance_only=False,
         )
-        for declared_type_param, inferred_type_param in zip(
-            checked_type_params, inferred_type_params
-        ):
+        if inferred_type_params is None:
+            return
+        inferred_type_params_by_identity = {
+            type_param.typevar: type_param
+            for type_param in inferred_type_params
+            if isinstance(type_param, TypeVarParam)
+        }
+        for declared_type_param in checked_type_params:
+            inferred_type_param = inferred_type_params_by_identity.get(
+                declared_type_param.typevar
+            )
+            if inferred_type_param is None:
+                continue
             if declared_type_param.variance is inferred_type_param.variance:
                 continue
             type_param_name = safe_getattr(
@@ -6905,8 +6876,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 if isinstance(node, ast.Lambda) or node.returns is None:
                     return_annotation = None
                 else:
-                    with self.function_return_type_param_variance_context():
-                        return_annotation = self.value_of_annotation(node.returns)
+                    return_annotation = self.value_of_annotation(node.returns)
                     if isinstance(return_annotation, InputSigValue):
                         if isinstance(return_annotation.input_sig, ParamSpecParam):
                             self.show_error(
@@ -7010,16 +6980,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
     def visit_FunctionDef(self, node: FunctionDefNode) -> Value:
         potential_function = self._get_potential_function(node)
-        variance_ctx: AbstractContextManager[None] = contextlib.nullcontext()
-        if (
-            self.active_type_params.current_class_type_param_polarities() is not None
-            and node.name in {"__init__", "__new__"}
-        ):
-            variance_ctx = (
-                self.active_type_params.suspend_class_type_param_variance_collection()
-            )
         with (
-            variance_ctx,
             self.compute_function_info(
                 node,
                 # If we set the current_class in the collecting phase,
@@ -8664,52 +8625,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 )
             self.check_for_missing_generic_params(node, val)
             return val
-
-    def function_param_type_param_variance_context(
-        self, *, parameter_index: int, is_staticmethod: bool
-    ) -> AbstractContextManager[None]:
-        return self.active_type_params.function_param_type_param_variance_context(
-            parameter_index=parameter_index, is_staticmethod=is_staticmethod
-        )
-
-    def function_return_type_param_variance_context(
-        self,
-    ) -> AbstractContextManager[None]:
-        return self.active_type_params.function_return_type_param_variance_context()
-
-    def _merge_type_param_polarities(
-        self,
-        target: dict[object, set[int]],
-        local_polarities: Mapping[object, set[int]],
-        *,
-        polarity: int,
-    ) -> None:
-        for typevar, local_used_polarities in local_polarities.items():
-            target_used_polarities = target.setdefault(typevar, set())
-            for local_used_polarity in local_used_polarities:
-                record_variance_polarity(
-                    target_used_polarities,
-                    compose_observed_variance_polarity(polarity, local_used_polarity),
-                )
-
-    def _infer_type_param_variances_from_polarities(
-        self,
-        type_params: Sequence[TypeParam],
-        type_param_polarities: Mapping[object, set[int]],
-        *,
-        is_protocol: bool,
-    ) -> Sequence[TypeParam]:
-        inferred_type_params = []
-        for type_param in type_params:
-            polarities = type_param_polarities.get(type_param.typevar, set())
-            if polarities == {1} or (is_protocol and not polarities):
-                variance = Variance.COVARIANT
-            elif polarities == {-1}:
-                variance = Variance.CONTRAVARIANT
-            else:
-                variance = Variance.INVARIANT
-            inferred_type_params.append(replace(type_param, variance=variance))
-        return inferred_type_params
 
     def _is_invalid_generic_annotation_node(self, node: ast.AST) -> bool:
         target = node.value if isinstance(node, ast.Subscript) else node
@@ -11697,24 +11612,8 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         explicit_type_alias_assignment_value = None
-        local_type_param_polarities: dict[object, set[int]] | None = None
-        class_type_param_polarities = (
-            self.active_type_params.current_class_type_param_polarities()
-        )
-        should_collect_class_annotation_variance = (
-            class_type_param_polarities is not None
-            and self.scopes.scope_type() is ScopeType.class_scope
-            and self.current_synthetic_typeddict is None
-        )
         if self.current_synthetic_typeddict is None:
-            if should_collect_class_annotation_variance:
-                local_type_param_polarities = {}
-                with self.active_type_params.collect_variance(
-                    local_type_param_polarities, polarity=1
-                ):
-                    annotation = self._visit_annotation(node.annotation)
-            else:
-                annotation = self._visit_annotation(node.annotation)
+            annotation = self._visit_annotation(node.annotation)
             if (
                 self._is_current_class_dataclass()
                 and _is_dataclass_kw_only_marker_value(annotation)
@@ -11770,32 +11669,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 and expected_type is None
             ):
                 expected_type = AnyValue(AnySource.unannotated)
-        if (
-            should_collect_class_annotation_variance
-            and local_type_param_polarities is not None
-            and class_type_param_polarities is not None
-        ):
-            if self.is_in_typeddict_definition():
-                attribute_polarity = 0
-            elif Qualifier.ClassVar in qualifiers:
-                attribute_polarity = None
-            else:
-                attribute_polarity = (
-                    1
-                    if (
-                        self.current_dataclass_info is not None
-                        and self.current_dataclass_info.frozen
-                    )
-                    or Qualifier.Final in qualifiers
-                    or Qualifier.ReadOnly in qualifiers
-                    else 0
-                )
-            if attribute_polarity is not None:
-                self._merge_type_param_polarities(
-                    class_type_param_polarities,
-                    local_type_param_polarities,
-                    polarity=attribute_polarity,
-                )
         if Qualifier.TypeAlias in qualifiers and node.value is not None:
             if isinstance(node.target, ast.Name):
                 if self._is_collecting():
@@ -12967,6 +12840,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     bound=bound,
                     constraints=tuple(constraints) if constraints is not None else (),
                     default=default if default is not None else None,
+                    variance=Variance.INFERRED,
                 )
             )
             self._check_typevar_default_constraints(typevar, node)
@@ -16743,14 +16617,6 @@ def _variance_is_compatible_with_usage(
     if variance is Variance.COVARIANT:
         return -1 not in used_polarities
     return 1 not in used_polarities
-
-
-def _type_param_uses_infer_variance(type_param: TypeParam) -> bool:
-    if not is_instance_of_typing_name(type_param.typevar, "TypeVar"):
-        return False
-    if type_param.variance is Variance.INFERRED:
-        return True
-    return bool(safe_getattr(type_param.typevar, "__infer_variance__", False))
 
 
 def is_typing_object(value: object, typing_name: str) -> bool:

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -3830,11 +3830,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                     for base in base_values_for_registration
                 ]
-            variance_declaration_base_indexes = frozenset(
-                i
-                for i, base_info in enumerate(base_type_param_variance_infos)
-                if base_info.is_variance_declaration_base
-            )
             if should_register_generic_bases:
                 self.checker.register_synthetic_type_bases(
                     generic_class_key,
@@ -3879,11 +3874,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 inferred_registration_type_params: Sequence[TypeParam] | None = None
                 if class_scope_type_params:
                     inferred_registration_type_params = (
-                        infer_type_param_variances_from_class_api(
-                            tobj,
-                            self,
-                            excluded_base_indexes=variance_declaration_base_indexes,
-                        )
+                        infer_type_param_variances_from_class_api(tobj, self)
                     )
 
                 if inferred_registration_type_params is not None:
@@ -3937,9 +3928,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     class_scope_object,
                     base_type_param_variance_infos,
                 )
-                self._check_protocol_type_param_variances(
-                    node, tobj, excluded_base_indexes=variance_declaration_base_indexes
-                )
+                self._check_protocol_type_param_variances(node, tobj)
             if (
                 runtime_enum_fallback_class is not None
                 and class_scope_values is not None
@@ -5362,11 +5351,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         return value
 
     def _check_protocol_type_param_variances(
-        self,
-        node: ast.ClassDef,
-        tobj: TypeObject,
-        *,
-        excluded_base_indexes: frozenset[int],
+        self, node: ast.ClassDef, tobj: TypeObject
     ) -> None:
         if sys.version_info >= (3, 12) and node.type_params:
             # PEP 695 class type parameters infer variance, so explicit
@@ -5385,10 +5370,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if not checked_type_params:
             return
         inferred_type_params = infer_type_param_variances_from_class_api(
-            tobj,
-            self,
-            excluded_base_indexes=excluded_base_indexes,
-            infer_variance_only=False,
+            tobj, self, infer_variance_only=False
         )
         if inferred_type_params is None:
             return
@@ -12045,7 +12027,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 symbol_qualifiers.add(Qualifier.Final)
             if (
                 self.current_tobj is not None
-                and self.current_tobj.is_frozen_dataclass()
+                and self.current_tobj.is_direct_frozen_dataclass()
             ):
                 symbol_qualifiers.add(Qualifier.ReadOnly)
             is_instance_only = False
@@ -14110,8 +14092,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         tobj, on_class = self.checker.get_type_object_for_value(
             root, self.current_class_key
         )
-        is_dataclass, dataclass_frozen = self._get_dataclass_status_for_type(tobj.typ)
-        if is_dataclass and dataclass_frozen:
+        if tobj.is_direct_frozen_dataclass():
             self._show_error_if_checking(
                 node,
                 f"Cannot {wording} attribute {node.attr} of frozen dataclass {tobj.typ}",

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -411,7 +411,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
         class Bad2(Contra_TA[Contra_TA[Contra_TA[T_co]]]):  # E: invalid_base
             ...
 
-    @assert_passes()
+    @assert_passes(run_in_both_module_modes=True)
     def test_protocol_variance_mismatch(self):
         from typing import Protocol, TypeVar
 
@@ -423,7 +423,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
         class TakesT(Protocol[T]):  # E: invalid_protocol
             def put(self, value: T) -> None: ...
 
-    @assert_passes()
+    @assert_passes(run_in_both_module_modes=True)
     def test_protocol_explicit_variance_mismatch(self):
         from typing import Protocol, TypeVar
 
@@ -436,7 +436,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
         class BadContravariant(Protocol[T_contra]):  # E: invalid_protocol
             def get(self) -> T_contra: ...
 
-    @assert_passes()
+    @assert_passes(run_in_both_module_modes=True)
     def test_protocol_unused_typevar_is_covariant(self):
         from typing import Protocol, TypeVar
 
@@ -449,7 +449,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
         class CovariantIsOkay(Protocol[T_co]):
             def __init__(self, value: T_co) -> None: ...
 
-    @assert_passes()
+    @assert_passes(run_in_both_module_modes=True)
     def test_protocol_paramspec_is_ignored_for_variance_check(self):
         from typing import ParamSpec, Protocol, TypeVar
 
@@ -459,7 +459,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
         class Callback(Protocol[P, R]):
             def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
 
-    @assert_passes()
+    @assert_passes(run_in_both_module_modes=True)
     def test_protocol_output_only_covariant_typevar_is_valid(self):
         from typing import Protocol, TypeVar
 
@@ -468,7 +468,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
         class Reader(Protocol[T_co]):
             def get(self) -> T_co: ...
 
-    @assert_passes()
+    @assert_passes(run_in_both_module_modes=True)
     def test_protocol_mapping_value_type_can_be_covariant(self):
         from typing import Iterable, Protocol, TypeVar
 
@@ -495,6 +495,36 @@ class TestTypeVar(TestNameCheckVisitorBase):
         class GoodAliasStaticMethod(Protocol[T_contra]):
             @my_staticmethod
             def put(value: T_contra) -> None: ...
+
+    @assert_passes()
+    def test_protocol_staticmethod_participates_in_variance(self):
+        from typing import Protocol, TypeVar
+
+        T = TypeVar("T")
+        T_contra = TypeVar("T_contra", contravariant=True)
+
+        class BadStaticMethod(Protocol[T]):  # E: invalid_protocol
+            @staticmethod
+            def put(value: T) -> None: ...
+
+        class GoodStaticMethod(Protocol[T_contra]):
+            @staticmethod
+            def put(value: T_contra) -> None: ...
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_protocol_property_participates_in_variance(self):
+        from typing import Protocol, TypeVar
+
+        T = TypeVar("T")
+        T_co = TypeVar("T_co", covariant=True)
+
+        class BadReader(Protocol[T]):  # E: invalid_protocol
+            @property
+            def item(self) -> T: ...
+
+        class GoodReader(Protocol[T_co]):
+            @property
+            def item(self) -> T_co: ...
 
     @assert_passes()
     def test_typeshed(self):
@@ -1534,7 +1564,8 @@ class TestGenericClasses(TestNameCheckVisitorBase):
 
     @skip_before((3, 12))
     def test_infer_variance_from_member_annotations(self):
-        self.assert_passes("""
+        self.assert_passes(
+            """
             from typing import Iterator
 
             class C[T]:
@@ -1543,11 +1574,14 @@ class TestGenericClasses(TestNameCheckVisitorBase):
 
             x: C[float] = C[int]()
             y: C[int] = C[float]()  # E: incompatible_assignment
-        """)
+        """,
+            run_in_both_module_modes=True,
+        )
 
     @skip_before((3, 12))
     def test_infer_variance_from_generic_base(self):
-        self.assert_passes("""
+        self.assert_passes(
+            """
             from typing import Generic, TypeVar
 
             T_co = TypeVar("T_co", covariant=True)
@@ -1569,7 +1603,9 @@ class TestGenericClasses(TestNameCheckVisitorBase):
             b: ChildCo[float] = ChildCo[int]()
             c: ChildContra[int] = ChildContra[float]()
             d: ChildContra[float] = ChildContra[int]()  # E: incompatible_assignment
-        """)
+        """,
+            run_in_both_module_modes=True,
+        )
 
     @skip_before((3, 12))
     def test_infer_variance_from_inferred_variance_base(self):
@@ -1656,6 +1692,27 @@ class TestGenericClasses(TestNameCheckVisitorBase):
             r1: CallableReturnBox[int] = CallableReturnBox[float]()
             r2: CallableReturnBox[float] = CallableReturnBox[int]()  # E: incompatible_assignment
         """)
+
+    @skip_before((3, 12))
+    def test_infer_variance_from_final_callable_attributes(self):
+        self.assert_passes(
+            """
+            from typing import Callable, Final, cast
+
+            class CallbackSource[T]:
+                callback: Final[Callable[[], T]] = cast(Callable[[], T], lambda: None)
+
+            class CallbackSink[T]:
+                callback: Final[Callable[[T], None]] = cast(Callable[[T], None], lambda value: None)
+
+            source_ok: CallbackSource[object] = CallbackSource[int]()
+            source_bad: CallbackSource[int] = CallbackSource[object]()  # E: incompatible_assignment
+
+            sink_bad: CallbackSink[object] = CallbackSink[int]()  # E: incompatible_assignment
+            sink_ok: CallbackSink[int] = CallbackSink[object]()
+        """,
+            run_in_both_module_modes=True,
+        )
 
     @skip_before((3, 12))
     def test_infer_variance_ignores_bad_sequence_annotation_without_crashing(self):

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -1624,6 +1624,29 @@ class TestGenericClasses(TestNameCheckVisitorBase):
         """)
 
     @skip_before((3, 12))
+    def test_infer_variance_from_string_forward_reference_return(self):
+        self.assert_passes(
+            """
+            from typing import Iterator
+
+            class Parent[T]:
+                def __iter__(self) -> Iterator[T]:
+                    raise NotImplementedError
+
+            class Child[T](Parent[T]):
+                pass
+
+            class Factory[T]:
+                def make(self) -> "Child[T]":
+                    raise NotImplementedError
+
+            x: Factory[float] = Factory[int]()
+            y: Factory[int] = Factory[float]()  # E: incompatible_assignment
+        """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 12))
     def test_infer_variance_mixed_input_and_output_is_invariant(self):
         self.assert_passes("""
             class Box[T]:

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -1658,6 +1658,29 @@ class TestGenericClasses(TestNameCheckVisitorBase):
         """)
 
     @skip_before((3, 12))
+    def test_infer_variance_plain_subclass_of_frozen_dataclass_is_not_frozen(self):
+        self.assert_passes(
+            """
+            from dataclasses import dataclass
+
+            @dataclass(frozen=True)
+            class Base[T]:
+                base: T
+
+            class Child[T](Base[T]):
+                child: T
+
+            def mutate(child: Child[int]) -> None:
+                child.child = 1
+                child.base = 1  # E: incompatible_assignment
+
+            x: Child[object] = Child[int](1)  # E: incompatible_assignment
+            y: Child[int] = Child[object](object())  # E: incompatible_assignment
+        """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 12))
     def test_infer_variance_property_setter_makes_type_param_invariant(self):
         self.assert_passes("""
             class PropBox[T]:

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -1296,6 +1296,18 @@ class TypeObject:
         _, frozen = self.get_dataclass_frozen_status()
         return frozen is True
 
+    def is_direct_frozen_dataclass(self) -> bool:
+        if (dataclass_info := self.get_direct_dataclass_info()) is not None:
+            return dataclass_info.frozen is True
+        if not isinstance(self.typ, type):
+            return False
+        try:
+            class_dict = self.typ.__dict__
+        except Exception:
+            return False
+        dataclass_params = class_dict.get("__dataclass_params__")
+        return safe_getattr(dataclass_params, "frozen", None) is True
+
     def get_dataclass_frozen_status(self) -> tuple[bool, bool | None]:
         for entry in self.get_mro():
             if entry.tobj is None:

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -1292,10 +1292,6 @@ class TypeObject:
                     return True
         return False
 
-    def is_frozen_dataclass(self) -> bool:
-        _, frozen = self.get_dataclass_frozen_status()
-        return frozen is True
-
     def is_direct_frozen_dataclass(self) -> bool:
         if (dataclass_info := self.get_direct_dataclass_info()) is not None:
             return dataclass_info.frozen is True

--- a/pycroscope/type_object_builder.py
+++ b/pycroscope/type_object_builder.py
@@ -165,7 +165,10 @@ CUSTOM_SYMBOLS: dict[ClassKey, dict[str, ClassSymbol]] = {
 
 
 def _is_frozen_dataclass(typ: type) -> bool:
-    params = safe_getattr(typ, "__dataclass_params__", None)
+    try:
+        params = typ.__dict__.get("__dataclass_params__")
+    except Exception:
+        return False
     return params is not None and getattr(params, "frozen", False) is True
 
 

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -717,6 +717,17 @@ class ActiveTypeParams:
                 return type_param
         return None
 
+    def get_type_param_by_name(self, name: str) -> TypeParam | None:
+        for scope in reversed(self._scopes):
+            seen_type_params: set[TypeParam] = set()
+            for type_param in scope.bindings.values():
+                if type_param in seen_type_params:
+                    continue
+                seen_type_params.add(type_param)
+                if safe_getattr(type_param.typevar, "__name__", None) == name:
+                    return type_param
+        return None
+
     def declare(
         self,
         type_param: TypeParam,

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -670,7 +670,6 @@ class ActiveTypeParams:
         self._legacy_policies: list[_LegacyTypeParamPolicy] = []
         self._variance_collections: list[_VarianceCollectionContext] = []
         self._variance_polarity_stack: list[int] = []
-        self._variance_is_suspended = 0
         self._variance_outside_annotations = 0
         self._subscript_arg_polarities: list[tuple[tuple[int, bool], ...]] = []
         self._scopes: list[TypeParamScope] = []
@@ -905,14 +904,6 @@ class ActiveTypeParams:
             self._variance_polarity_stack.pop()
 
     @contextlib.contextmanager
-    def suspend_variance(self) -> Generator[None]:
-        self._variance_is_suspended += 1
-        try:
-            yield
-        finally:
-            self._variance_is_suspended -= 1
-
-    @contextlib.contextmanager
     def allow_variance_outside_annotations(self) -> Generator[None]:
         self._variance_outside_annotations += 1
         try:
@@ -921,7 +912,7 @@ class ActiveTypeParams:
             self._variance_outside_annotations -= 1
 
     def has_variance_collection(self) -> bool:
-        return bool(self._variance_collections) and not self._variance_is_suspended
+        return bool(self._variance_collections)
 
     def current_variance_polarity(self, base_polarity: int) -> int:
         polarity = base_polarity
@@ -966,10 +957,6 @@ class ActiveTypeParams:
             or self._variance_collections
         ):
             return
-        if self._variance_is_suspended and not (
-            self._legacy_policies or self._has_disallowed_identities()
-        ):
-            return
         if _is_type_param_declaration_node(node):
             return
 
@@ -979,7 +966,6 @@ class ActiveTypeParams:
             if (
                 isinstance(type_param, TypeVarParam)
                 and self._variance_collections
-                and not self._variance_is_suspended
                 and (visitor.in_annotation or self._variance_outside_annotations > 0)
             ):
                 for context in self._variance_collections:

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -1,36 +1,62 @@
 import ast
 import contextlib
+import enum
 import sys
+import typing
 from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
-from typing import Protocol, TypeGuard
+from typing import TYPE_CHECKING, Protocol, TypeGuard
+
+from typing_extensions import assert_never
 
 from .analysis_lib import override
 from .error_code import Error, ErrorCode
-from .safe import is_instance_of_typing_name
+from .safe import is_instance_of_typing_name, safe_getattr
 from .value import (
     AnnotatedValue,
+    AnyValue,
+    CallableValue,
+    CanAssignContext,
+    ClassKey,
+    ClassSymbol,
     GenericValue,
     IntersectionValue,
+    KnownValue,
     MultiValuedValue,
+    ParamSpecArgsValue,
+    ParamSpecKwargsValue,
     ParamSpecParam,
     PartialValue,
+    PartialValueOperation,
+    PredicateValue,
     SequenceValue,
     SubclassValue,
+    SyntheticClassObjectValue,
+    SyntheticModuleValue,
+    SyntheticTypeFormValue,
+    TypedValue,
+    TypeFormValue,
     TypeParam,
     TypeParamOwner,
     TypeVarLike,
     TypeVarMap,
     TypeVarParam,
+    TypeVarTupleBindingValue,
     TypeVarTupleParam,
     TypeVarTupleValue,
     TypeVarValue,
+    UnboundMethodValue,
     Value,
+    Variance,
     get_single_typevartuple_param,
+    replace_fallback_except,
     type_param_to_value,
     with_type_param_owner,
 )
+
+if TYPE_CHECKING:
+    from .type_object import TypeObject
 
 if sys.version_info >= (3, 12):
     _TYPE_PARAM_AST_NODE_TYPES = (ast.TypeVar, ast.ParamSpec, ast.TypeVarTuple)
@@ -88,14 +114,6 @@ class TypeParamVisitor(Protocol):
         suppress_errors: bool = False,
     ) -> tuple[Value, object]: ...
 
-    def _merge_type_param_polarities(
-        self,
-        target: dict[object, set[int]],
-        local_polarities: dict[object, set[int]],
-        *,
-        polarity: int,
-    ) -> None: ...
-
     def get_type_param_from_value(self, value: Value) -> TypeParam | None: ...
 
 
@@ -125,6 +143,322 @@ def record_variance_polarity(used_polarities: set[int], polarity: int) -> None:
         used_polarities.update({-1, 1})
     else:
         used_polarities.add(polarity)
+
+
+class Polarity(enum.Enum):
+    COVARIANT = 1
+    CONTRAVARIANT = -1
+    INVARIANT = 0
+
+    def compose(self, other: "Polarity") -> "Polarity":
+        if self is Polarity.INVARIANT or other is Polarity.INVARIANT:
+            return Polarity.INVARIANT
+        if self is other:
+            return Polarity.COVARIANT
+        return Polarity.CONTRAVARIANT
+
+    def merge(self, other: "Polarity") -> "Polarity":
+        if self is other:
+            return self
+        return Polarity.INVARIANT
+
+
+def polarity_from_variance(variance: Variance) -> Polarity:
+    if variance is Variance.COVARIANT:
+        return Polarity.COVARIANT
+    if variance is Variance.CONTRAVARIANT:
+        return Polarity.CONTRAVARIANT
+    return Polarity.INVARIANT
+
+
+def variance_from_polarity(polarity: Polarity | None, *, is_protocol: bool) -> Variance:
+    if polarity is Polarity.COVARIANT or (is_protocol and polarity is None):
+        return Variance.COVARIANT
+    if polarity is Polarity.CONTRAVARIANT:
+        return Variance.CONTRAVARIANT
+    return Variance.INVARIANT
+
+
+def get_polarities_from_value(
+    value: Value,
+    type_params: Sequence[TypeParam],
+    *,
+    ctx: CanAssignContext,
+    polarity: Polarity = Polarity.COVARIANT,
+) -> dict[TypeParam, Polarity]:
+    collector = _PolarityCollector(type_params, ctx)
+    collector.collect(value, polarity)
+    return collector.polarities
+
+
+def get_polarities_from_class_symbol(
+    name: str,
+    symbol: ClassSymbol,
+    type_params: Sequence[TypeParam],
+    *,
+    ctx: CanAssignContext,
+    is_frozen_dataclass: bool,
+) -> dict[TypeParam, Polarity]:
+    collector = _PolarityCollector(type_params, ctx)
+    collector.collect_class_symbol(
+        name, symbol, is_frozen_dataclass=is_frozen_dataclass
+    )
+    return collector.polarities
+
+
+def infer_type_param_variances_from_class_api(
+    tobj: "TypeObject",
+    ctx: CanAssignContext,
+    *,
+    excluded_base_indexes: frozenset[int] = frozenset(),
+    infer_variance_only: bool = True,
+) -> Sequence[TypeParam] | None:
+    type_params = tobj.get_declared_type_params()
+    inferable_type_params = tuple(
+        type_param
+        for type_param in type_params
+        if isinstance(type_param, TypeVarParam)
+        and (not infer_variance_only or _type_param_uses_infer_variance(type_param))
+    )
+    if not inferable_type_params:
+        return None
+
+    collector = _PolarityCollector(inferable_type_params, ctx)
+    for index, base_value in enumerate(tobj.get_direct_bases()):
+        if index in excluded_base_indexes:
+            continue
+        collector.collect(base_value, Polarity.COVARIANT)
+    is_frozen_dataclass = tobj.is_frozen_dataclass()
+    for name, symbol in tobj.get_declared_symbols().items():
+        collector.collect_class_symbol(
+            name, symbol, is_frozen_dataclass=is_frozen_dataclass
+        )
+
+    inferable_type_param_set = set(inferable_type_params)
+    return tuple(
+        (
+            replace(
+                type_param,
+                variance=variance_from_polarity(
+                    collector.polarities.get(type_param), is_protocol=tobj.is_protocol()
+                ),
+            )
+            if type_param in inferable_type_param_set
+            else type_param
+        )
+        for type_param in type_params
+    )
+
+
+def _type_param_uses_infer_variance(type_param: TypeParam) -> bool:
+    if not is_instance_of_typing_name(type_param.typevar, "TypeVar"):
+        return False
+    if type_param.variance is Variance.INFERRED:
+        return True
+    return bool(safe_getattr(type_param.typevar, "__infer_variance__", False))
+
+
+def _input_sig_value(value: Value) -> typing.Any | None:
+    from pycroscope.input_sig import InputSigValue
+
+    if isinstance(value, InputSigValue):
+        return value
+    return None
+
+
+class _PolarityCollector:
+    def __init__(self, type_params: Sequence[TypeParam], ctx: CanAssignContext) -> None:
+        self._type_params_by_identity = {
+            type_param.typevar: type_param
+            for type_param in type_params
+            if isinstance(type_param, TypeVarParam)
+        }
+        self._ctx = ctx
+        self.polarities: dict[TypeParam, Polarity] = {}
+
+    def record(self, type_param: TypeVarParam, polarity: Polarity) -> None:
+        target = self._type_params_by_identity.get(type_param.typevar)
+        if target is None:
+            return
+        existing = self.polarities.get(target)
+        self.polarities[target] = (
+            polarity if existing is None else existing.merge(polarity)
+        )
+
+    def collect(self, value: Value, polarity: Polarity) -> None:
+        if isinstance(value, TypeVarValue):
+            self.record(value.typevar_param, polarity)
+            return
+        if isinstance(value, (ParamSpecArgsValue, ParamSpecKwargsValue)):
+            return
+        if isinstance(value, TypeVarTupleBindingValue):
+            for _, member in value.binding:
+                self.collect(member, polarity)
+            return
+        if isinstance(value, TypeVarTupleValue):
+            return
+        if isinstance(value, TypeFormValue):
+            self.collect(value.inner_type, polarity)
+            return
+        if isinstance(value, SyntheticTypeFormValue):
+            self.collect(value.inner_type, polarity)
+            return
+        input_sig_value = _input_sig_value(value)
+        if input_sig_value is not None:
+            for member in input_sig_value.input_sig.walk_values():
+                if member is not input_sig_value:
+                    self.collect(member, polarity)
+            return
+        if (
+            isinstance(value, PartialValue)
+            and value.operation is PartialValueOperation.SUBSCRIPT
+        ):
+            class_key = self._class_key_from_value(value.root)
+            if class_key is not None:
+                self.collect_generic(class_key, value.members, polarity)
+            else:
+                for member in value.members:
+                    self.collect(member, Polarity.INVARIANT)
+            return
+
+        value = replace_fallback_except(
+            value,
+            (
+                CallableValue,
+                TypeVarValue,
+                ParamSpecArgsValue,
+                ParamSpecKwargsValue,
+                TypeVarTupleBindingValue,
+                TypeVarTupleValue,
+                TypeFormValue,
+                SyntheticTypeFormValue,
+            ),
+        )
+
+        match value:
+            case TypeVarValue(typevar_param=typevar_param):
+                self.record(typevar_param, polarity)
+            case ParamSpecArgsValue() | ParamSpecKwargsValue():
+                return
+            case TypeVarTupleBindingValue(binding=binding):
+                for _, member in binding:
+                    self.collect(member, polarity)
+            case TypeVarTupleValue():
+                return
+            case TypeFormValue(inner_type=inner_type):
+                self.collect(inner_type, polarity)
+            case SyntheticTypeFormValue(inner_type=inner_type):
+                self.collect(inner_type, polarity)
+            case MultiValuedValue(vals=vals) | IntersectionValue(vals=vals):
+                for subval in vals:
+                    self.collect(subval, polarity)
+            case CallableValue(signature=signature):
+                self.collect_signature(signature, polarity, skip_first_parameter=False)
+            case GenericValue(typ=typ, args=args):
+                self.collect_generic(typ, args, polarity)
+            case SubclassValue(typ=typ):
+                self.collect(typ, polarity)
+            case (
+                AnyValue()
+                | KnownValue()
+                | SyntheticClassObjectValue()
+                | SyntheticModuleValue()
+                | UnboundMethodValue()
+                | TypedValue()
+                | PredicateValue()
+            ):
+                return
+            case _:
+                assert_never(value)
+
+    def _class_key_from_value(self, value: Value) -> ClassKey | None:
+        value = replace_fallback_except(value, (SyntheticClassObjectValue,))
+        match value:
+            case SyntheticClassObjectValue(class_type=class_type):
+                return class_type.typ
+            case GenericValue(typ=typ) | TypedValue(typ=typ):
+                return typ
+            case KnownValue(val=val):
+                origin = typing.get_origin(val)
+                if isinstance(val, type):
+                    return val
+                if isinstance(origin, type):
+                    return origin
+                return None
+            case _:
+                return None
+
+    def collect_generic(
+        self, typ: ClassKey, args: Sequence[Value], polarity: Polarity
+    ) -> None:
+        declared_type_params = self._ctx.get_type_parameters(typ)
+        for arg, type_param in zip(args, declared_type_params):
+            self.collect(
+                arg, polarity.compose(polarity_from_variance(type_param.variance))
+            )
+
+    def collect_signature(
+        self, signature: object, polarity: Polarity, *, skip_first_parameter: bool
+    ) -> None:
+        from .signature import BoundMethodSignature, OverloadedSignature, Signature
+
+        if isinstance(signature, BoundMethodSignature):
+            signature = signature.signature
+        if isinstance(signature, OverloadedSignature):
+            for overload in signature.signatures:
+                self.collect_signature(
+                    overload, polarity, skip_first_parameter=skip_first_parameter
+                )
+            return
+        if not isinstance(signature, Signature):
+            return
+        for index, param in enumerate(signature.parameters.values()):
+            if skip_first_parameter and index == 0:
+                continue
+            self.collect(param.annotation, polarity.compose(Polarity.CONTRAVARIANT))
+        self.collect(signature.return_value, polarity)
+
+    def collect_class_symbol(
+        self, name: str, symbol: ClassSymbol, *, is_frozen_dataclass: bool
+    ) -> None:
+        if symbol.is_classvar:
+            return
+        if symbol.property_info is not None:
+            if symbol.property_info.fget is not None:
+                self.collect_class_symbol(
+                    name,
+                    symbol.property_info.fget,
+                    is_frozen_dataclass=is_frozen_dataclass,
+                )
+            if symbol.property_info.fset is not None:
+                self.collect_class_symbol(
+                    name,
+                    symbol.property_info.fset,
+                    is_frozen_dataclass=is_frozen_dataclass,
+                )
+            return
+        if symbol.is_method:
+            if name in {"__init__", "__new__"}:
+                return
+            if symbol.initializer is not None:
+                signature = self._ctx.signature_from_value(symbol.initializer)
+                if signature is None:
+                    self.collect(symbol.initializer, Polarity.COVARIANT)
+                else:
+                    self.collect_signature(
+                        signature,
+                        Polarity.COVARIANT,
+                        skip_first_parameter=not symbol.is_staticmethod,
+                    )
+            return
+        if symbol.annotation is None:
+            return
+        attribute_polarity = (
+            Polarity.COVARIANT
+            if is_frozen_dataclass or symbol.is_final or symbol.is_readonly
+            else Polarity.INVARIANT
+        )
+        self.collect(symbol.annotation, attribute_polarity)
 
 
 def _is_type_param_declaration_node(node: ast.AST) -> bool:
@@ -352,8 +686,6 @@ class ActiveTypeParams:
         self._current_class_type_params: Sequence[TypeParam] | None = None
         self._legacy_policies: list[_LegacyTypeParamPolicy] = []
         self._variance_collections: list[_VarianceCollectionContext] = []
-        self._current_class_type_param_polarities: dict[object, set[int]] | None = None
-        self._current_is_protocol_class: bool = False
         self._variance_polarity_stack: list[int] = []
         self._variance_is_suspended = 0
         self._variance_outside_annotations = 0
@@ -597,74 +929,11 @@ class ActiveTypeParams:
     def has_variance_collection(self) -> bool:
         return bool(self._variance_collections) and not self._variance_is_suspended
 
-    def current_class_type_param_polarities(self) -> dict[object, set[int]] | None:
-        return self._current_class_type_param_polarities
-
     def current_variance_polarity(self, base_polarity: int) -> int:
         polarity = base_polarity
         for modifier in self._variance_polarity_stack:
             polarity = compose_observed_variance_polarity(polarity, modifier)
         return polarity
-
-    @contextlib.contextmanager
-    def push_class_type_param_variance_collection(
-        self,
-        type_param_polarities: dict[object, set[int]] | None,
-        *,
-        is_protocol_class: bool,
-    ) -> Generator[None]:
-        with (
-            override(
-                self, "_current_class_type_param_polarities", type_param_polarities
-            ),
-            override(self, "_current_is_protocol_class", is_protocol_class),
-        ):
-            yield
-
-    @contextlib.contextmanager
-    def suspend_class_type_param_variance_collection(self) -> Generator[None]:
-        if self._current_class_type_param_polarities is None:
-            yield
-            return
-        with override(self, "_current_class_type_param_polarities", None):
-            yield
-
-    def function_param_type_param_variance_context(
-        self, *, parameter_index: int, is_staticmethod: bool
-    ) -> AbstractContextManager[None]:
-        if self._current_class_type_param_polarities is None:
-            return contextlib.nullcontext()
-        if (
-            self._current_is_protocol_class
-            and parameter_index == 0
-            and not is_staticmethod
-        ):
-            return self.suspend_variance()
-        return self.local_class_type_param_variance_context(polarity=-1)
-
-    def function_return_type_param_variance_context(
-        self,
-    ) -> AbstractContextManager[None]:
-        if self._current_class_type_param_polarities is None:
-            return contextlib.nullcontext()
-        return self.local_class_type_param_variance_context(polarity=1)
-
-    @contextlib.contextmanager
-    def local_class_type_param_variance_context(
-        self, *, polarity: int
-    ) -> Generator[None]:
-        target = self._current_class_type_param_polarities
-        if target is None:
-            yield
-            return
-        visitor = self._require_visitor()
-        local_polarities: dict[object, set[int]] = {}
-        with (
-            self.collect_variance(local_polarities, polarity=1),
-            self.compose_variance(polarity),
-        ):
-            yield
-        visitor._merge_type_param_polarities(target, local_polarities, polarity=1)
 
     @contextlib.contextmanager
     def push_subscript_arg_polarities(

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -12,7 +12,7 @@ from typing_extensions import assert_never
 
 from .analysis_lib import override
 from .error_code import Error, ErrorCode
-from .safe import is_instance_of_typing_name, safe_getattr
+from .safe import is_instance_of_typing_name, is_typing_name, safe_getattr
 from .value import (
     AnnotatedValue,
     AnyValue,
@@ -145,73 +145,44 @@ def record_variance_polarity(used_polarities: set[int], polarity: int) -> None:
         used_polarities.add(polarity)
 
 
-class Polarity(enum.Enum):
+class _Polarity(enum.Enum):
     COVARIANT = 1
     CONTRAVARIANT = -1
     INVARIANT = 0
 
-    def compose(self, other: "Polarity") -> "Polarity":
-        if self is Polarity.INVARIANT or other is Polarity.INVARIANT:
-            return Polarity.INVARIANT
+    def compose(self, other: "_Polarity") -> "_Polarity":
+        if self is _Polarity.INVARIANT or other is _Polarity.INVARIANT:
+            return _Polarity.INVARIANT
         if self is other:
-            return Polarity.COVARIANT
-        return Polarity.CONTRAVARIANT
+            return _Polarity.COVARIANT
+        return _Polarity.CONTRAVARIANT
 
-    def merge(self, other: "Polarity") -> "Polarity":
+    def merge(self, other: "_Polarity") -> "_Polarity":
         if self is other:
             return self
-        return Polarity.INVARIANT
+        return _Polarity.INVARIANT
 
 
-def polarity_from_variance(variance: Variance) -> Polarity:
+def _polarity_from_variance(variance: Variance) -> _Polarity:
     if variance is Variance.COVARIANT:
-        return Polarity.COVARIANT
+        return _Polarity.COVARIANT
     if variance is Variance.CONTRAVARIANT:
-        return Polarity.CONTRAVARIANT
-    return Polarity.INVARIANT
+        return _Polarity.CONTRAVARIANT
+    return _Polarity.INVARIANT
 
 
-def variance_from_polarity(polarity: Polarity | None, *, is_protocol: bool) -> Variance:
-    if polarity is Polarity.COVARIANT or (is_protocol and polarity is None):
+def _variance_from_polarity(
+    polarity: _Polarity | None, *, is_protocol: bool
+) -> Variance:
+    if polarity is _Polarity.COVARIANT or (is_protocol and polarity is None):
         return Variance.COVARIANT
-    if polarity is Polarity.CONTRAVARIANT:
+    if polarity is _Polarity.CONTRAVARIANT:
         return Variance.CONTRAVARIANT
     return Variance.INVARIANT
 
 
-def get_polarities_from_value(
-    value: Value,
-    type_params: Sequence[TypeParam],
-    *,
-    ctx: CanAssignContext,
-    polarity: Polarity = Polarity.COVARIANT,
-) -> dict[TypeParam, Polarity]:
-    collector = _PolarityCollector(type_params, ctx)
-    collector.collect(value, polarity)
-    return collector.polarities
-
-
-def get_polarities_from_class_symbol(
-    name: str,
-    symbol: ClassSymbol,
-    type_params: Sequence[TypeParam],
-    *,
-    ctx: CanAssignContext,
-    is_frozen_dataclass: bool,
-) -> dict[TypeParam, Polarity]:
-    collector = _PolarityCollector(type_params, ctx)
-    collector.collect_class_symbol(
-        name, symbol, is_frozen_dataclass=is_frozen_dataclass
-    )
-    return collector.polarities
-
-
 def infer_type_param_variances_from_class_api(
-    tobj: "TypeObject",
-    ctx: CanAssignContext,
-    *,
-    excluded_base_indexes: frozenset[int] = frozenset(),
-    infer_variance_only: bool = True,
+    tobj: "TypeObject", ctx: CanAssignContext, *, infer_variance_only: bool = True
 ) -> Sequence[TypeParam] | None:
     type_params = tobj.get_declared_type_params()
     inferable_type_params = tuple(
@@ -224,11 +195,11 @@ def infer_type_param_variances_from_class_api(
         return None
 
     collector = _PolarityCollector(inferable_type_params, ctx)
-    for index, base_value in enumerate(tobj.get_direct_bases()):
-        if index in excluded_base_indexes:
+    for base_value in tobj.get_direct_bases():
+        if _is_type_parameter_declaration_base(base_value):
             continue
-        collector.collect(base_value, Polarity.COVARIANT)
-    is_frozen_dataclass = tobj.is_frozen_dataclass()
+        collector.collect(base_value, _Polarity.COVARIANT)
+    is_frozen_dataclass = tobj.is_direct_frozen_dataclass()
     for name, symbol in tobj.get_declared_symbols().items():
         collector.collect_class_symbol(
             name, symbol, is_frozen_dataclass=is_frozen_dataclass
@@ -239,7 +210,7 @@ def infer_type_param_variances_from_class_api(
         (
             replace(
                 type_param,
-                variance=variance_from_polarity(
+                variance=_variance_from_polarity(
                     collector.polarities.get(type_param), is_protocol=tobj.is_protocol()
                 ),
             )
@@ -266,6 +237,18 @@ def _input_sig_value(value: Value) -> typing.Any | None:
     return None
 
 
+def _is_type_parameter_declaration_base(value: Value) -> bool:
+    if isinstance(value, GenericValue):
+        return is_typing_name(value.typ, "Generic") or is_typing_name(
+            value.typ, "Protocol"
+        )
+    if isinstance(value, TypedValue):
+        return is_typing_name(value.typ, "Generic") or is_typing_name(
+            value.typ, "Protocol"
+        )
+    return False
+
+
 class _PolarityCollector:
     def __init__(self, type_params: Sequence[TypeParam], ctx: CanAssignContext) -> None:
         self._type_params_by_identity = {
@@ -274,9 +257,9 @@ class _PolarityCollector:
             if isinstance(type_param, TypeVarParam)
         }
         self._ctx = ctx
-        self.polarities: dict[TypeParam, Polarity] = {}
+        self.polarities: dict[TypeParam, _Polarity] = {}
 
-    def record(self, type_param: TypeVarParam, polarity: Polarity) -> None:
+    def record(self, type_param: TypeVarParam, polarity: _Polarity) -> None:
         target = self._type_params_by_identity.get(type_param.typevar)
         if target is None:
             return
@@ -285,7 +268,7 @@ class _PolarityCollector:
             polarity if existing is None else existing.merge(polarity)
         )
 
-    def collect(self, value: Value, polarity: Polarity) -> None:
+    def collect(self, value: Value, polarity: _Polarity) -> None:
         if isinstance(value, TypeVarValue):
             self.record(value.typevar_param, polarity)
             return
@@ -318,7 +301,7 @@ class _PolarityCollector:
                 self.collect_generic(class_key, value.members, polarity)
             else:
                 for member in value.members:
-                    self.collect(member, Polarity.INVARIANT)
+                    self.collect(member, _Polarity.INVARIANT)
             return
 
         value = replace_fallback_except(
@@ -389,16 +372,16 @@ class _PolarityCollector:
                 return None
 
     def collect_generic(
-        self, typ: ClassKey, args: Sequence[Value], polarity: Polarity
+        self, typ: ClassKey, args: Sequence[Value], polarity: _Polarity
     ) -> None:
         declared_type_params = self._ctx.get_type_parameters(typ)
         for arg, type_param in zip(args, declared_type_params):
             self.collect(
-                arg, polarity.compose(polarity_from_variance(type_param.variance))
+                arg, polarity.compose(_polarity_from_variance(type_param.variance))
             )
 
     def collect_signature(
-        self, signature: object, polarity: Polarity, *, skip_first_parameter: bool
+        self, signature: object, polarity: _Polarity, *, skip_first_parameter: bool
     ) -> None:
         from .signature import BoundMethodSignature, OverloadedSignature, Signature
 
@@ -415,7 +398,7 @@ class _PolarityCollector:
         for index, param in enumerate(signature.parameters.values()):
             if skip_first_parameter and index == 0:
                 continue
-            self.collect(param.annotation, polarity.compose(Polarity.CONTRAVARIANT))
+            self.collect(param.annotation, polarity.compose(_Polarity.CONTRAVARIANT))
         self.collect(signature.return_value, polarity)
 
     def collect_class_symbol(
@@ -443,20 +426,20 @@ class _PolarityCollector:
             if symbol.initializer is not None:
                 signature = self._ctx.signature_from_value(symbol.initializer)
                 if signature is None:
-                    self.collect(symbol.initializer, Polarity.COVARIANT)
+                    self.collect(symbol.initializer, _Polarity.COVARIANT)
                 else:
                     self.collect_signature(
                         signature,
-                        Polarity.COVARIANT,
+                        _Polarity.COVARIANT,
                         skip_first_parameter=not symbol.is_staticmethod,
                     )
             return
         if symbol.annotation is None:
             return
         attribute_polarity = (
-            Polarity.COVARIANT
+            _Polarity.COVARIANT
             if is_frozen_dataclass or symbol.is_final or symbol.is_readonly
-            else Polarity.INVARIANT
+            else _Polarity.INVARIANT
         )
         self.collect(symbol.annotation, attribute_polarity)
 


### PR DESCRIPTION
## Summary

- Infer PEP 695 and protocol type-parameter variance from the collected `TypeObject` class API instead of visitor-side polarity bookkeeping.
- Move the polarity collection logic into `type_params.py`, including generic bases, callable member annotations, properties, and class symbols.
- Fix direct frozen dataclass handling so plain subclasses keep their own attributes mutable while inherited frozen fields remain read-only.
- Resolve active PEP 695 type parameters in runtime string annotations so forward-referenced generic return types participate in variance inference.

## Impact

This makes importable and static fallback analysis agree on inferred variance, including PEP 695 class parameters, and removes visitor plumbing such as excluded base indexes.

## Validation

- `uvx prek run --files docs/changelog.md pycroscope/functions.py pycroscope/name_check_visitor.py pycroscope/test_typevar.py pycroscope/type_object.py pycroscope/type_object_builder.py pycroscope/type_params.py`
- `uvx prek run --files pycroscope/annotations.py pycroscope/type_params.py pycroscope/test_typevar.py`
- `uv run --python 3.12 --extra tests python -m pytest pycroscope/test_typevar.py pycroscope/test_protocol.py -q`
- `uv run --python 3.12 --extra tests python -m pytest pycroscope/test_dataclass.py pycroscope/test_type_object.py -q`
- `uv run --python 3.12 --extra tests --extra asynq --extra codemod python -m pytest pycroscope/test_self.py -q`
- `uv run --python 3.12 python tools/conformance_ci.py --typing-repo ~/py/typing`