### PR TITLE
Avoid eager PEP 649 annotation evaluation in _safe_get_signature

### DIFF
--- a/pycroscope/arg_spec.py
+++ b/pycroscope/arg_spec.py
@@ -21,6 +21,9 @@ from unittest import mock
 import typing_extensions
 from typing_extensions import NoDefault, is_typeddict
 
+if sys.version_info >= (3, 14):
+    from annotationlib import Format
+
 import pycroscope
 
 from . import implementation
@@ -1378,7 +1381,17 @@ class ArgSpecCache:
         try:
             # follow_wrapped=True leads to problems with decorators that
             # mess with the arguments, such as mock.patch.
-            return inspect.signature(obj, follow_wrapped=False)
+            #
+            # On Python 3.14+ request FORWARDREF-format annotations so PEP 649
+            # lazy annotations are not eagerly resolved. Eager resolution would
+            # raise NameError for any annotation referencing a name imported
+            # only under `if TYPE_CHECKING:`.
+            if sys.version_info >= (3, 14):
+                return inspect.signature(
+                    obj, follow_wrapped=False, annotation_format=Format.FORWARDREF
+                )
+            else:
+                return inspect.signature(obj, follow_wrapped=False)  # pragma: no cover
         except (TypeError, ValueError, AttributeError):
             # TypeError if signature() does not support the object, ValueError
             # if it cannot provide a signature, and AttributeError if we're on

--- a/pycroscope/test_arg_spec.py
+++ b/pycroscope/test_arg_spec.py
@@ -638,3 +638,39 @@ class TestPytestRaises(TestNameCheckVisitorBase):
                 pass
 
             pytest.raises()  # E: incompatible_call
+
+
+@skip_before((3, 14))
+def test_safe_get_signature_handles_type_checking_annotations() -> None:
+    """On Python 3.14+, a function whose unquoted annotation references a name
+    imported only under ``if TYPE_CHECKING:`` must remain introspectable.
+
+    PEP 649 makes annotations lazy, so the unquoted ``Iterator[int]`` return
+    annotation below becomes a deferred ``__annotate__`` expression that
+    raises ``NameError`` if anything forces eager evaluation.
+    """
+    checker = Checker()
+    ns: dict[str, object] = {}
+    exec(
+        """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def f(x: int) -> Iterator[int]:
+    raise NotImplementedError
+""",
+        ns,
+        ns,
+    )
+    f = ns["f"]
+    # Sanity check that this setup really does exercise the bug: reading
+    # __annotations__ at runtime must raise NameError, because `Iterator`
+    # only exists in the TYPE_CHECKING namespace.
+    with pytest.raises(NameError):
+        _ = f.__annotations__
+    sig = checker.arg_spec_cache.get_argspec(f)
+    assert isinstance(sig, Signature)
+    assert "x" in sig.parameters


### PR DESCRIPTION
Fixes #499.

## What was happening

On Python 3.14, `_safe_get_signature` called `inspect.signature(obj)` without telling it how to handle annotations. The default behavior is to evaluate them, which fails for any function whose annotation references a name imported only under `if TYPE_CHECKING:`; the name does not exist at runtime, so evaluation raises `NameError`.

`_safe_get_signature` only catches `TypeError`, `ValueError`, and `AttributeError`, so the `NameError` propagated up and got reported as an `internal_error` finding.

## The fix

Pass `annotation_format=Format.FORWARDREF` to `inspect.signature` on Python 3.14+. With that flag, names that cannot be resolved are returned as `ForwardRef` objects instead of triggering evaluation, so the call succeeds even when the annotation references a `TYPE_CHECKING`-only import.

This matches what `type_object_builder.py` already does for `inspect.get_annotations`.

## Test

Added a regression test in `test_arg_spec.py`. It defines a function whose unquoted return annotation refers to a `TYPE_CHECKING`-only import, sanity-checks that reading `__annotations__` at runtime really does raise `NameError` (so the test isn't a no-op), and then asserts that `get_argspec` returns a usable `Signature`.

Verified on Python 3.14.5:

- The new test passes with the fix and fails without it.
- Full `pytest pycroscope/` suite: 2177 passed, 13 skipped.
- `test_self.py` passes.
