### PR TITLE
Sync uv.lock with pyproject.toml 0.4.0 bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "pycroscope"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
The 0.4.0 release commit ([8c7d986](https://github.com/JelleZijlstra/pycroscope/commit/8c7d986)) bumped `pyproject.toml` from `0.3.0` to `0.4.0` but left `uv.lock` recording the project at `0.3.0`. As a result, every contributor who runs `uv sync` gets a dirty working tree.

This commit just records the regenerated lockfile so the version inside `uv.lock` matches `pyproject.toml`. No dependency changes.
