### PR TITLE
Recognize conditional Enum members gated by static `if` checks

### DIFF
--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -4334,8 +4334,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if runtime_bases is None:
             return None
 
+        statements = self._flatten_static_if_class_body(node.body)
+        if statements is None:
+            return None
+
         members: dict[str, object] = {}
-        for statement in node.body:
+        for statement in statements:
             if isinstance(statement, ast.Expr):
                 if isinstance(statement.value, ast.Constant) and isinstance(
                     statement.value.value, str
@@ -4393,6 +4397,49 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         except Exception:
             self.log(logging.INFO, "unable to synthesize enum runtime class", node.name)
             return None
+
+    def _statically_active_if_branch(
+        self, statement: ast.If
+    ) -> Sequence[ast.stmt] | None:
+        # If ``statement.test`` is statically known to be true, return the body;
+        # if statically false, return the else-branch; if the value cannot be
+        # determined statically, return None.
+        #
+        # The typical case we care about is ``sys.version_info >= (3, 12)``,
+        # which the comparison visitor folds to a known boolean.
+        with self.catch_errors() as errors:
+            val, _ = self.constraint_from_condition(
+                statement.test, check_boolability=False
+            )
+        if errors:
+            return None
+        definite_value = _extract_definite_value(val)
+        if definite_value is True:
+            return statement.body
+        if definite_value is False:
+            return statement.orelse
+        return None
+
+    def _flatten_static_if_class_body(
+        self, statements: Sequence[ast.stmt]
+    ) -> list[ast.stmt] | None:
+        # Return ``statements`` with each ``ast.If`` replaced by the active
+        # branch's body (recursing into nested ifs). Returns None if any
+        # ``ast.If`` has a test that we cannot statically resolve, since in
+        # that case we cannot tell which members would exist at runtime.
+        out: list[ast.stmt] = []
+        for statement in statements:
+            if isinstance(statement, ast.If):
+                branch = self._statically_active_if_branch(statement)
+                if branch is None:
+                    return None
+                inner = self._flatten_static_if_class_body(branch)
+                if inner is None:
+                    return None
+                out.extend(inner)
+            else:
+                out.append(statement)
+        return out
 
     def _runtime_base_from_value(
         self, base_value: Value, *, allow_synthetic_class_base: bool
@@ -4453,7 +4500,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 synthetic_type, name, initializer=value, is_method=False
             )
 
-        for member_name, statement in _iter_enum_assignment_candidates(node):
+        for member_name, statement in _iter_enum_assignment_candidates(
+            node, visitor=self
+        ):
             stmt_forced_member, stmt_forced_nonmember = (
                 _enum_statement_member_decorators(statement)
             )
@@ -4562,7 +4611,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 _set_enum_declared_symbol(member_name, initializer)
             except Exception:
                 continue
-        for member_name, statement in _iter_enum_assignment_candidates(node):
+        for member_name, statement in _iter_enum_assignment_candidates(
+            node, visitor=self
+        ):
             if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
                 continue
             if not isinstance(statement.value, ast.Name):
@@ -16014,9 +16065,19 @@ def _enum_ignore_names(value: Value | None) -> set[str]:
 
 
 def _iter_enum_assignment_candidates(
-    node: ast.ClassDef,
+    node: ast.ClassDef, *, visitor: "NameCheckVisitor | None" = None
 ) -> Iterable[tuple[str, ast.AST]]:
-    for statement in node.body:
+    # Yields ``(name, statement)`` pairs for every member-like statement in the
+    # class body. Pass ``visitor`` to also descend into ``if`` blocks whose test
+    # the visitor can fold to a known boolean (typically ``sys.version_info``
+    # comparisons); without it, only top-level statements are emitted.
+    yield from _iter_enum_assignment_candidates_in(node.body, visitor)
+
+
+def _iter_enum_assignment_candidates_in(
+    statements: Sequence[ast.stmt], visitor: "NameCheckVisitor | None"
+) -> Iterable[tuple[str, ast.AST]]:
+    for statement in statements:
         if isinstance(statement, ast.Assign):
             for target in statement.targets:
                 if isinstance(target, ast.Name):
@@ -16028,6 +16089,13 @@ def _iter_enum_assignment_candidates(
             statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
         ):
             yield statement.name, statement
+        elif isinstance(statement, ast.If) and visitor is not None:
+            # When the test is not statically known, skip the branch entirely
+            # rather than yielding from one side; we cannot tell which members
+            # would exist at runtime.
+            branch = visitor._statically_active_if_branch(statement)
+            if branch is not None:
+                yield from _iter_enum_assignment_candidates_in(branch, visitor)
 
 
 def _enum_member_wrapper_flags(node: ast.AST) -> tuple[bool, bool]:

--- a/pycroscope/test_enum.py
+++ b/pycroscope/test_enum.py
@@ -242,6 +242,52 @@ class TestEnum(TestNameCheckVisitorBase):
         )
 
     @assert_passes(run_in_both_module_modes=True)
+    def test_conditional_enum_members(self):
+        # Per the typing spec, Enum members may be declared inside `if` blocks
+        # whose test is statically known (such as `sys.version_info` checks):
+        # the active branch's members exist, the inactive branch's do not.
+        import sys
+        from enum import Enum
+
+        from typing_extensions import Literal, assert_type
+
+        class Color(Enum):
+            RED = 1
+            if sys.version_info >= (3, 0):
+                GREEN = 2
+            if sys.version_info >= (4, 0):
+                BLUE = 3
+
+        def capybara():
+            assert_type(Color.RED, Literal[Color.RED])
+            assert_type(Color.GREEN, Literal[Color.GREEN])
+            Color.BLUE  # E: undefined_attribute
+
+    def test_conditional_enum_members_after_import_failure(self):
+        # When the module cannot be imported at analysis time we fall back to
+        # synthesizing the Enum class from the AST. That fallback also needs
+        # to honour statically-known `if` blocks so conditional members are
+        # recognized as proper Enum members rather than plain attributes.
+        self.assert_passes(
+            """
+            import sys
+            from enum import Enum
+
+            from typing_extensions import Literal, assert_type
+
+            class Color(Enum):
+                RED = 1
+                if sys.version_info >= (3, 0):
+                    GREEN = 2
+
+            assert_type(Color.RED, Literal[Color.RED])
+            assert_type(Color.GREEN, Literal[Color.GREEN])
+            """,
+            allow_import_failures=True,
+            force_runtime_module_load_failure=True,
+        )
+
+    @assert_passes(run_in_both_module_modes=True)
     def test_enum_declared_value_type_checks_member_assignments(self):
         from enum import Enum
 


### PR DESCRIPTION
Fixes #502

Pycroscope now descends into `if` blocks inside an Enum class body when the test is statically known (for example `sys.version_info >= (3, 12)`). Members in the active branch are treated as real Enum members; members in the inactive branch are ignored.

This unbreaks the `enums_definition` case in the typing conformance suite, which started failing after [python/typing#2263](https://github.com/python/typing/pull/2263).

Two small helpers are added on `NameCheckVisitor`:

* `_statically_active_if_branch`: returns the branch to keep, or `None` if the test cannot be resolved statically.
* `_flatten_static_if_class_body`: pre-flattens a class body using the helper above, recursing into nested `if`s.

`_make_enum_related_fallback_class` runs the flatten pass before its existing extraction loop. `_iter_enum_assignment_candidates` gains an optional `visitor` so `_apply_synthetic_enum_semantics` sees conditional members too.

When an `if` test cannot be statically resolved, behavior is unchanged: the fallback synthesis bails out and the iterator skips the block.

I also added new unit tests in `pycroscope/test_enum.py` covering both the normal and `force_runtime_module_load_failure=True` modes.