### PR TITLE
[codex] Handle recursive gradual types robustly

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improve recursive gradual type compatibility for aliases, protocols, and TypedDicts, so recursive `Any` tails no longer hide incompatible nested types and mutually recursive TypedDicts no longer produce internal recursion errors.
 - Infer and validate class type-parameter variance from the collected class API in both importable and static fallback analysis, including generic bases and callable member annotations.
 - Treat plain subclasses of frozen dataclasses as mutable for their own annotated attributes, while keeping inherited frozen dataclass fields read-only.
 - Add basic support for `pycroscope.extensions.Not[T]` negation types, including assignability and intersection simplification.

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -501,8 +501,8 @@ class Checker:
     assumed_compatibilities: list[tuple[TypeObject, TypeObject]] = field(
         default_factory=list
     )
-    alias_assumed_compatibilities: set[tuple[TypeAliasValue, TypeAliasValue]] = field(
-        default_factory=set
+    alias_assumed_compatibilities: list[tuple[TypeAliasValue, TypeAliasValue]] = field(
+        default_factory=list
     )
     vnv_map: dict[str, VariableNameValue] = field(default_factory=dict)
     type_alias_cache: dict[object, TypeAlias] = field(default_factory=dict)
@@ -844,11 +844,12 @@ class Checker:
         self, left: TypeAliasValue, right: TypeAliasValue
     ) -> Generator[None]:
         pair = (left, right)
-        self.alias_assumed_compatibilities.add(pair)
+        self.alias_assumed_compatibilities.append(pair)
         try:
             yield
         finally:
-            self.alias_assumed_compatibilities.discard(pair)
+            new_pair = self.alias_assumed_compatibilities.pop()
+            assert pair == new_pair
 
     def get_relation_cache(self) -> dict[object, object] | None:
         return self._relation_cache

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -2095,12 +2095,23 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return None, False
         self.log(logging.INFO, "Checking file", (self.filename, os.getpid()))
         if self.is_code_only:
-            mod_dict = {}
+            mod = types.ModuleType(self.filename)
+            mod.__file__ = self.filename
+            previous_module = sys.modules.get(self.filename, _UNSET)
+            sys.modules[self.filename] = mod
             try:
-                exec(compile(self.contents, self.filename, "exec"), mod_dict)
+                exec(compile(self.contents, self.filename, "exec"), mod.__dict__)
             except KeyboardInterrupt:
+                if previous_module is _UNSET:
+                    sys.modules.pop(self.filename, None)
+                else:
+                    sys.modules[self.filename] = previous_module
                 raise
             except BaseException as e:
+                if previous_module is _UNSET:
+                    sys.modules.pop(self.filename, None)
+                else:
+                    sys.modules[self.filename] = previous_module
                 node = self._get_import_failure_node(e)
                 self.show_error(
                     node,
@@ -2108,8 +2119,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     error_code=ErrorCode.import_failed,
                 )
                 return None, False
-            mod = types.ModuleType(self.filename)
-            mod.__dict__.update(mod_dict)
             return mod, False
         import_paths = self.options.get_value_for(ImportPaths)
 

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -135,6 +135,7 @@ class RelationContext:
     inferables: tuple[TypeParam, ...] | None = None
     original_left: GradualType | None = None
     original_right: GradualType | None = None
+    relation_goals: tuple[object, ...] = ()
 
     def with_relation(
         self, relation: Literal[Relation.SUBTYPE, Relation.ASSIGNABLE]
@@ -150,13 +151,15 @@ class RelationContext:
     def check_relation(
         self, left: Value, right: Value, relation: Relation
     ) -> CanAssign:
-        return has_relation(left, right, relation, self.ctx, inferables=self.inferables)
+        return has_relation_from_ctx(
+            left,
+            right,
+            replace(self, relation=relation, original_left=None, original_right=None),
+        )
 
     def has_relation(self, left: Value, right: Value) -> CanAssign:
         return _has_relation(
-            gradualize(left),
-            gradualize(right),
-            replace(self, original_left=None, original_right=None),
+            left, right, replace(self, original_left=None, original_right=None)
         )
 
 
@@ -300,17 +303,30 @@ def has_relation(
 def has_relation_from_ctx(
     left: Value, right: Value, relation_ctx: RelationContext
 ) -> CanAssign:
+    return _has_relation(left, right, relation_ctx)
+
+
+def _has_relation(
+    left: Value, right: Value, relation_ctx: RelationContext
+) -> CanAssign:
     left = gradualize(left)
     right = gradualize(right)
-    cache = _get_relation_cache(relation_ctx.ctx)
-    key = None
+    key = _make_relation_cache_key(
+        left, right, relation_ctx.relation, relation_ctx.inferables
+    )
+    if key in relation_ctx.relation_goals:
+        return {}
+
+    cache = None
+    if not relation_ctx.relation_goals:
+        cache = _get_relation_cache(relation_ctx.ctx)
     if cache is not None:
-        key = _make_relation_cache_key(
-            left, right, relation_ctx.relation, relation_ctx.inferables
-        )
         cached = _get_cached_relation_result(cache, key)
         if cached is not None:
             return cached
+    relation_ctx = replace(
+        relation_ctx, relation_goals=(*relation_ctx.relation_goals, key)
+    )
 
     if relation_ctx.relation in (Relation.EQUIVALENT, Relation.CONSISTENT):
         # EQUIVALENT checks both subtype directions; CONSISTENT checks both assignable directions.
@@ -334,10 +350,9 @@ def has_relation_from_ctx(
             result = unify_bounds_maps([result1, result2])
     else:
         assert relation_ctx.relation in (Relation.SUBTYPE, Relation.ASSIGNABLE)
-        result = _has_relation(left, right, relation_ctx)
+        result = _has_relation_impl(left, right, relation_ctx)
 
-    if key is not None:
-        assert cache is not None
+    if cache is not None:
         _store_cached_relation_result(cache, key, result)
     if not isinstance(result, CanAssignError):
         for tv in result:
@@ -347,26 +362,7 @@ def has_relation_from_ctx(
     return result
 
 
-def _specialized_synthetic_class_type(
-    synthetic_class: SyntheticClassObjectValue, ctx: CanAssignContext
-) -> TypedValue:
-    class_typ = synthetic_class.class_type.typ
-    tobj = synthetic_class.get_type_object(ctx)
-    declared = tobj.get_declared_type_params()
-    if declared:
-        substitutions = TypeVarMap()
-        specialized_args: list[Value] = []
-        for param in declared:
-            specialized_arg = default_value_for_type_param(param).substitute_typevars(
-                substitutions
-            )
-            substitutions = substitutions.with_value(param, specialized_arg)
-            specialized_args.append(specialized_arg)
-        return GenericValue(class_typ, specialized_args)
-    return synthetic_class.class_type
-
-
-def _has_relation(
+def _has_relation_impl(
     left: GradualType, right: GradualType, relation_ctx: RelationContext
 ) -> CanAssign:
     relation = relation_ctx.relation
@@ -910,7 +906,11 @@ def _has_relation(
             elif isinstance(left.typ, TypedValue):
                 left_tobj = left.typ.get_type_object(ctx)
                 return left_tobj.can_assign(
-                    left, TypedValue(right.val), ctx, relation=relation
+                    left,
+                    TypedValue(right.val),
+                    ctx,
+                    relation=relation,
+                    relation_ctx=relation_ctx,
                 )
             else:
                 assert_never(left.typ)
@@ -943,7 +943,9 @@ def _has_relation(
             if left_tobj.is_assignable_to_type(type):
                 return {}
             if isinstance(right.typ, TypedValue):
-                return left_tobj.can_assign(left, right, ctx, relation=relation)
+                return left_tobj.can_assign(
+                    left, right, ctx, relation=relation, relation_ctx=relation_ctx
+                )
             elif isinstance(right.typ, InferenceVarValue):
                 return {
                     right.typ.typevar_param: [UpperBound(right.typ.typevar_param, left)]
@@ -1044,7 +1046,7 @@ def _has_relation(
             and tuple_members_from_value(right, ctx) is not None
         ):
             return left.get_type_object(ctx).can_assign(
-                left, right, ctx, relation=relation
+                left, right, ctx, relation=relation, relation_ctx=relation_ctx
             )
         if relation is Relation.SUBTYPE:
             return CanAssignError(f"{right} is not {relation.description} {left}")
@@ -1080,7 +1082,7 @@ def _has_relation(
             and tuple_members_from_value(left, ctx) is not None
         ):
             return left.get_type_object(ctx).can_assign(
-                left, right, ctx, relation=relation
+                left, right, ctx, relation=relation, relation_ctx=relation_ctx
             )
         if (
             relation is Relation.ASSIGNABLE
@@ -1200,7 +1202,7 @@ def _has_relation(
             else:
                 right_for_check = right
             can_assign = left_tobj.can_assign(
-                left, right_for_check, ctx, relation=relation
+                left, right_for_check, ctx, relation=relation, relation_ctx=relation_ctx
             )
             if isinstance(can_assign, CanAssignError):
                 return can_assign
@@ -1215,7 +1217,7 @@ def _has_relation(
             else:
                 right_for_check = right
             can_assign = left_tobj.can_assign(
-                left, right_for_check, ctx, relation=relation
+                left, right_for_check, ctx, relation=relation, relation_ctx=relation_ctx
             )
             if isinstance(can_assign, CanAssignError):
                 if left_tobj.is_instance(right.val):
@@ -1230,6 +1232,25 @@ def _has_relation(
             return CanAssignError(f"{right} is not {relation.description} {left}")
 
     return CanAssignError(f"{right} is not {relation.description} {left}")
+
+
+def _specialized_synthetic_class_type(
+    synthetic_class: SyntheticClassObjectValue, ctx: CanAssignContext
+) -> TypedValue:
+    class_typ = synthetic_class.class_type.typ
+    tobj = synthetic_class.get_type_object(ctx)
+    declared = tobj.get_declared_type_params()
+    if declared:
+        substitutions = TypeVarMap()
+        specialized_args: list[Value] = []
+        for param in declared:
+            specialized_arg = default_value_for_type_param(param).substitute_typevars(
+                substitutions
+            )
+            substitutions = substitutions.with_value(param, specialized_arg)
+            specialized_args.append(specialized_arg)
+        return GenericValue(class_typ, specialized_args)
+    return synthetic_class.class_type
 
 
 def _coerce_paramspec_generic_arg_for_relation(arg: Value, *, other: Value) -> Value:
@@ -1423,7 +1444,7 @@ def _has_relation_for_generic_arg(
 def _allows_forward_only_invariant_rhs(value: Value) -> bool:
     if isinstance(value, AnnotatedValue):
         return _allows_forward_only_invariant_rhs(value.value)
-    return isinstance(value, GenericValue) and value.weak
+    return isinstance(value, GenericValue) and value.weak and value.typ is not tuple
 
 
 def _get_generic_variances(
@@ -1606,7 +1627,9 @@ def _has_relation_thrift_enum(
         tobj = right.get_type_object(ctx)
         if tobj.is_assignable_to_type(int):
             return {}
-        return left.get_type_object(ctx).can_assign(left, right, ctx, relation=relation)
+        return left.get_type_object(ctx).can_assign(
+            left, right, ctx, relation=relation, relation_ctx=relation_ctx
+        )
     else:
         assert_never(right)
 
@@ -1974,17 +1997,16 @@ def _has_relation_sequence(
 ) -> CanAssign:
     relation = relation_ctx.relation
     ctx = relation_ctx.ctx
+    if left.typ is tuple and right.typ is tuple:
+        return compare_tuple_sequences(left, right, relation_ctx)
+
     # TypeObject.can_assign() does the nominal/container-level compatibility check
-    # for all sequences. For tuple/tuple, it also already performs the full
-    # element-by-element comparison via compare_tuple_sequences(); preserve that
-    # detailed result instead of replacing it with a generic "tuple is not
-    # assignable to tuple" wrapper here.
+    # for all non-tuple sequences. Tuple/tuple comparisons are handled above so
+    # their element-by-element checks keep the active recursive relation goals.
     can_assign = left.get_type_object(ctx).can_assign(
-        left, right, ctx, relation=relation
+        left, right, ctx, relation=relation, relation_ctx=relation_ctx
     )
     if isinstance(can_assign, CanAssignError):
-        if left.typ is tuple and right.typ is tuple:
-            return can_assign
         return CanAssignError(
             f"{stringify_object(right.typ)} is not {relation.description}"
             f" {stringify_object(left.typ)}"
@@ -1992,9 +2014,6 @@ def _has_relation_sequence(
 
     # Non-tuple sequences still need the concrete SequenceValue relation pass
     # below, because the TypeObject check does not compare their known members.
-    if left.typ is tuple and right.typ is tuple:
-        return can_assign
-
     return compare_tuple_sequences(left, right, relation_ctx)
 
 

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -619,6 +619,30 @@ class TestImportFailureHandlingCodeSamples(TestNameCheckVisitorBase):
             force_runtime_module_load_failure=True,
         )
 
+    def test_code_only_recursive_generic_constructor_widens_literals(self):
+        self.assert_passes(
+            """
+            from __future__ import annotations
+
+            from typing import Generic, TypeVar
+
+            from typing_extensions import assert_type
+
+            T = TypeVar("T")
+
+            class Box(Generic[T]):
+                value: T
+                child: Box[T] | None
+
+                def __init__(self, value: T) -> None:
+                    self.value = value
+
+            def capybara() -> None:
+                assert_type(Box(1).value, int)
+        """,
+            is_code_only=True,
+        )
+
     @assert_passes(run_in_both_module_modes=True)
     def test_code_only_constructor_returns_are_weakened(self):
         from collections import defaultdict

--- a/pycroscope/test_protocol.py
+++ b/pycroscope/test_protocol.py
@@ -156,6 +156,110 @@ class TestProtocol(TestNameCheckVisitorBase):
         def f(xs: list[int]) -> None:
             assert_type(mysum(xs), int)
 
+    def test_recursive_gradual_protocol_materializations(self):
+        self.assert_passes("""
+            from __future__ import annotations
+
+            from typing import Any, Protocol
+
+            class ProtoR(Protocol):
+                def items(self) -> list[tuple[Any, ProtoR]]: ...
+
+            class ProtoInnerUnion(Protocol):
+                def items(
+                    self,
+                ) -> list[tuple[int, ProtoInnerUnion] | tuple[str, ProtoInnerUnion]]: ...
+
+            class ProtoAlternatingInt(Protocol):
+                def items(self) -> list[tuple[int, ProtoAlternatingStr]]: ...
+
+            class ProtoAlternatingStr(Protocol):
+                def items(self) -> list[tuple[str, ProtoAlternatingInt]]: ...
+
+            class ProtoAllFloat(Protocol):
+                def items(self) -> list[tuple[float, ProtoAllFloat]]: ...
+
+            class ProtoAnyTail(Protocol):
+                def items(self) -> list[tuple[int, ProtoAnyTail | Any]]: ...
+
+            class ProtoAltTail(Protocol):
+                def items(self) -> list[tuple[int, list[tuple[str, ProtoAltTail]]]]: ...
+
+            class AttrProtoAnyTail(Protocol):
+                items: list[tuple[int, AttrProtoAnyTail | Any]]
+
+            class AttrProtoAltTail(Protocol):
+                items: list[tuple[int, list[tuple[str, AttrProtoAltTail]]]]
+
+            def takes_r(x: ProtoR) -> None:
+                pass
+
+            def takes_inner_union(x: ProtoInnerUnion) -> None:
+                pass
+
+            def takes_alternating(x: ProtoAlternatingInt) -> None:
+                pass
+
+            def takes_any_tail(x: ProtoAnyTail) -> None:
+                pass
+
+            def takes_alt_tail(x: ProtoAltTail) -> None:
+                pass
+
+            def takes_attr_any_tail(x: AttrProtoAnyTail) -> None:
+                pass
+
+            def takes_attr_alt_tail(x: AttrProtoAltTail) -> None:
+                pass
+
+            def accepts_materializations(
+                inner_union: ProtoInnerUnion,
+                alternating: ProtoAlternatingInt,
+                all_float: ProtoAllFloat,
+            ) -> None:
+                takes_r(inner_union)
+                takes_r(alternating)
+                takes_r(all_float)
+
+            def rejects_static_mismatches(all_float: ProtoAllFloat) -> None:
+                takes_inner_union(all_float)  # E: incompatible_argument
+                takes_alternating(all_float)  # E: incompatible_argument
+
+            def rejects_gradual_tail_mismatches(
+                any_tail: ProtoAnyTail, alt_tail: ProtoAltTail
+            ) -> None:
+                takes_any_tail(alt_tail)  # E: incompatible_argument
+                takes_alt_tail(any_tail)  # E: incompatible_argument
+
+            def rejects_data_attribute_gradual_tail_mismatches(
+                any_tail: AttrProtoAnyTail, alt_tail: AttrProtoAltTail
+            ) -> None:
+                takes_attr_any_tail(alt_tail)  # E: incompatible_argument
+                takes_attr_alt_tail(any_tail)  # E: incompatible_argument
+        """)
+
+    def test_recursive_gradual_protocol_data_attributes_in_code_only_mode(self):
+        self.assert_passes(
+            """
+            from __future__ import annotations
+
+            from typing import Any, Protocol
+
+            class ProtoAnyTail(Protocol):
+                items: list[tuple[int, ProtoAnyTail | Any]]
+
+            class ProtoAltTail(Protocol):
+                items: list[tuple[int, list[tuple[str, ProtoAltTail]]]]
+
+            def takes_any_tail(x: ProtoAnyTail) -> None:
+                pass
+
+            def caller(x: ProtoAltTail) -> None:
+                takes_any_tail(x)  # E: incompatible_argument
+            """,
+            is_code_only=True,
+        )
+
     @assert_passes(allow_import_failures=True)
     def test_explicit_protocol_abstract_instantiation_in_unimportable_module(self):
         from abc import ABC, abstractmethod

--- a/pycroscope/test_type_aliases.py
+++ b/pycroscope/test_type_aliases.py
@@ -56,6 +56,65 @@ class TestRecursion(TestNameCheckVisitorBase):
             "hi",
         ]
 
+    @skip_before((3, 12))
+    def test_recursive_gradual_alias_materializations(self):
+        self.assert_passes("""
+            from typing import Any
+
+            type R = list[tuple[Any, R]]
+            type InnerUnion = list[tuple[int, InnerUnion] | tuple[str, InnerUnion]]
+            type Alternating = list[tuple[int, list[tuple[str, Alternating]]]]
+            type AllFloat = list[tuple[float, AllFloat]]
+            type AnyTail = list[tuple[int, AnyTail | Any]]
+            type AltTail = list[tuple[int, list[tuple[str, AltTail]]]]
+            type RecFirstAny = tuple[RecFirstAny | Any, int]
+            type RecFirstGood = tuple[RecFirstGood, int]
+            type RecFirstBad = tuple[RecFirstBad, str]
+
+            def takes_r(x: R) -> None:
+                pass
+
+            def takes_inner_union(x: InnerUnion) -> None:
+                pass
+
+            def takes_alternating(x: Alternating) -> None:
+                pass
+
+            def takes_any_tail(x: AnyTail) -> None:
+                pass
+
+            def takes_alt_tail(x: AltTail) -> None:
+                pass
+
+            def takes_rec_first(x: RecFirstAny) -> None:
+                pass
+
+            def accepts_materializations(
+                inner_union: InnerUnion, alternating: Alternating, all_float: AllFloat
+            ) -> None:
+                takes_r(inner_union)
+                takes_r(alternating)
+                takes_r(all_float)
+
+            def accepts_recursion_before_sibling_constraints(
+                rec_first_good: RecFirstGood,
+            ) -> None:
+                takes_rec_first(rec_first_good)
+
+            def rejects_static_mismatches(all_float: AllFloat) -> None:
+                takes_inner_union(all_float)  # E: incompatible_argument
+                takes_alternating(all_float)  # E: incompatible_argument
+
+            def rejects_gradual_tail_mismatches(
+                any_tail: AnyTail, alt_tail: AltTail
+            ) -> None:
+                takes_any_tail(alt_tail)  # E: incompatible_argument
+                takes_alt_tail(any_tail)  # E: incompatible_argument
+
+            def rejects_after_recursive_goal(rec_first_bad: RecFirstBad) -> None:
+                takes_rec_first(rec_first_bad)  # E: incompatible_argument
+        """)
+
     @assert_passes()
     def test_explicit_typealias_cycle_detection(self):
         from typing import TypeAlias, Union

--- a/pycroscope/test_typeddict.py
+++ b/pycroscope/test_typeddict.py
@@ -252,6 +252,113 @@ class TestExtraKeys(TestNameCheckVisitorBase):
 
 
 class TestTypedDict(TestNameCheckVisitorBase):
+    def test_recursive_gradual_typeddict_materializations(self):
+        self.assert_passes("""
+            from __future__ import annotations
+
+            from typing import Any
+
+            from typing_extensions import ReadOnly, TypedDict
+
+            class TDR(TypedDict):
+                items: list[tuple[Any, TDR]]
+
+            class TDInnerUnion(TypedDict):
+                items: list[tuple[int, TDInnerUnion] | tuple[str, TDInnerUnion]]
+
+            class TDAlternatingInt(TypedDict):
+                items: list[tuple[int, TDAlternatingStr]]
+
+            class TDAlternatingStr(TypedDict):
+                items: list[tuple[str, TDAlternatingInt]]
+
+            class TDAllFloat(TypedDict):
+                items: list[tuple[float, TDAllFloat]]
+
+            class TDAnyTail(TypedDict):
+                items: list[tuple[int, TDAnyTail | Any]]
+
+            class TDAltTail(TypedDict):
+                items: list[tuple[int, list[tuple[str, TDAltTail]]]]
+
+            def takes_r(x: TDR) -> None:
+                pass
+
+            def takes_inner_union(x: TDInnerUnion) -> None:
+                pass
+
+            def takes_alternating(x: TDAlternatingInt) -> None:
+                pass
+
+            def takes_any_tail(x: TDAnyTail) -> None:
+                pass
+
+            def takes_alt_tail(x: TDAltTail) -> None:
+                pass
+
+            def accepts_materializations(
+                inner_union: TDInnerUnion,
+                alternating: TDAlternatingInt,
+                all_float: TDAllFloat,
+            ) -> None:
+                takes_r(inner_union)
+                takes_r(alternating)
+                takes_r(all_float)
+
+            def rejects_static_mismatches(all_float: TDAllFloat) -> None:
+                takes_inner_union(all_float)  # E: incompatible_argument
+                takes_alternating(all_float)  # E: incompatible_argument
+
+            def rejects_gradual_tail_mismatches(
+                any_tail: TDAnyTail, alt_tail: TDAltTail
+            ) -> None:
+                takes_any_tail(alt_tail)  # E: incompatible_argument
+                takes_alt_tail(any_tail)  # E: incompatible_argument
+
+            class TDReadOnlyAnyTail(TypedDict):
+                items: ReadOnly[list[tuple[int, TDReadOnlyAnyTail | Any]]]
+
+            class TDReadOnlyAltTail(TypedDict):
+                items: ReadOnly[list[tuple[int, list[tuple[str, TDReadOnlyAltTail]]]]]
+
+            def takes_readonly_any_tail(x: TDReadOnlyAnyTail) -> None:
+                pass
+
+            def takes_readonly_alt_tail(x: TDReadOnlyAltTail) -> None:
+                pass
+
+            def readonly_caller(
+                any_tail: TDReadOnlyAnyTail, alt_tail: TDReadOnlyAltTail
+            ) -> None:
+                takes_readonly_any_tail(alt_tail)  # E: incompatible_argument
+                takes_readonly_alt_tail(any_tail)  # E: incompatible_argument
+        """)
+
+    def test_mutually_recursive_typeddicts_do_not_recurse_forever(self):
+        self.assert_passes("""
+            from __future__ import annotations
+
+            from typing_extensions import TypedDict
+
+            class A1(TypedDict):
+                x: A2
+
+            class A2(TypedDict):
+                x: A1
+
+            class B1(TypedDict):
+                x: B2
+
+            class B2(TypedDict):
+                x: B1
+
+            def takes_a(x: A1) -> None:
+                pass
+
+            def caller(b: B1) -> None:
+                takes_a(b)
+        """)
+
     @assert_passes()
     def test_constructor(self):
         from typing_extensions import NotRequired, TypedDict

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -1672,7 +1672,14 @@ class TypeObject:
         ctx: CanAssignContext,
         *,
         relation: Relation = Relation.ASSIGNABLE,
+        relation_ctx: RelationContext | None = None,
     ) -> CanAssign:
+        if relation_ctx is None:
+            relation_ctx = RelationContext(relation, ctx)
+        else:
+            relation_ctx = replace(
+                relation_ctx, relation=relation, original_left=None, original_right=None
+            )
 
         other_basic = replace_fallback(other_val)
         if not isinstance(other_basic, (KnownValue, TypedValue, SubclassValue)):
@@ -1684,7 +1691,7 @@ class TypeObject:
                 return compare_tuple_sequences(
                     SequenceValue(tuple, self_tuple_members),
                     SequenceValue(tuple, other_tuple_members),
-                    RelationContext(relation, ctx),
+                    relation_ctx,
                 )
         other = other_basic.get_type_object(ctx)
         if class_keys_match(self.typ, other.typ):
@@ -1718,7 +1725,7 @@ class TypeObject:
                 return {}
             with ctx.assume_compatibility(self, other):
                 result = self._is_compatible_with_protocol(
-                    self_val, other_basic, relation, ctx
+                    self_val, other_basic, relation, ctx, relation_ctx
                 )
                 if (
                     isinstance(result, CanAssignError)
@@ -1728,7 +1735,7 @@ class TypeObject:
                     for base in other.get_virtual_bases():
                         assert isinstance(base, TypedValue), (self, base)
                         subresult = self._is_compatible_with_protocol(
-                            self_val, base, relation, ctx
+                            self_val, base, relation, ctx, relation_ctx
                         )
                         if not isinstance(subresult, CanAssignError):
                             result = subresult
@@ -1775,6 +1782,7 @@ class TypeObject:
         other_val: KnownValue | TypedValue | SubclassValue,
         relation: Relation,
         ctx: CanAssignContext,
+        relation_ctx: RelationContext,
     ) -> CanAssign:
         """This type object is a protocol. Is other_val compatible with it?"""
         other_type_obj, is_class = self._get_tobj_for_protocol_rhs(other_val, ctx)
@@ -1884,6 +1892,7 @@ class TypeObject:
                 ctx,
                 inferables=tuple(inferables),
                 strict_variance=strict_variance,
+                relation_ctx=relation_ctx,
             )
             if isinstance(bounds_map, CanAssignError):
                 return CanAssignError(
@@ -3460,6 +3469,7 @@ def is_compatible_attribute(
     inferables: tuple[TypeParam, ...] | None = None,
     *,
     strict_variance: bool = False,
+    relation_ctx: RelationContext | None = None,
 ) -> CanAssign:
     if child_attr.symbol.is_classvar and base_attr.symbol.is_instance_only:
         return CanAssignError(
@@ -3484,7 +3494,16 @@ def is_compatible_attribute(
             f"but not writable on child class {child_attr.owner}"
         )
 
-    relation_ctx = RelationContext(relation, ctx, inferables=inferables)
+    if relation_ctx is None:
+        relation_ctx = RelationContext(relation, ctx, inferables=inferables)
+    else:
+        relation_ctx = replace(
+            relation_ctx,
+            relation=relation,
+            inferables=inferables,
+            original_left=None,
+            original_right=None,
+        )
 
     can_assign = _can_assign_to_base(
         base_attr, child_attr, relation_ctx, strict_variance=strict_variance


### PR DESCRIPTION
## Summary
- add recursive relation goals so recursive gradual alias, protocol, and TypedDict comparisons can terminate coherently
- thread relation context through protocol attribute checks and tuple sequence comparisons
- execute code-only snippets in a real module namespace so runtime annotation lookup sees local forward references
- add conformance-style recursive materialization coverage for aliases, protocols, TypedDicts, and code-only mode

## Root Cause
Recursive relation checks could re-enter the same structural comparison without an explicit active-goal model. Some paths also dropped the active relation context before reaching nested protocol attributes or tuple members, and code-only execution created runtime classes before a proper module namespace existed for resolving their forward references.