### PR TITLE
[codex] Support PEP 604 unions for extension annotations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Treat definitely missing attributes on intersection members as an error instead of ignoring them, while still allowing indeterminate members to be ignored when another member provides the attribute.
-- Normalize intersection annotations with union operands instead of producing an internal error.
+- Normalize pycroscope extension annotations with PEP 604 union operands, such as `Intersection[A, B | C]`, `A | Intersection[B, C]`, and `int | Not[str]`, instead of producing an internal error.
 - Improve recursive gradual type compatibility for aliases, protocols, and TypedDicts, so recursive `Any` tails no longer hide incompatible nested types and mutually recursive TypedDicts no longer produce internal recursion errors.
 - Infer and validate class type-parameter variance from the collected class API in both importable and static fallback analysis, including generic bases and callable member annotations.
 - Treat plain subclasses of frozen dataclasses as mutable for their own annotated attributes, while keeping inherited frozen dataclass fields read-only.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -28,6 +28,7 @@ import ast
 import builtins
 import contextlib
 import enum
+import itertools
 import sys
 import types
 import typing
@@ -748,9 +749,39 @@ def _annotation_expr_from_runtime(val: object, ctx: Context) -> AnnotationExpr:
 def _make_intersection_value(members: Sequence[Value], ctx: Context) -> Value:
     if not members:
         return TypedValue(object)
-    if ctx.can_assign_ctx is None:
-        return IntersectionValue(tuple(members))
-    return intersect_multi(members, ctx.can_assign_ctx)
+    if ctx.can_assign_ctx is not None:
+        return intersect_multi(members, ctx.can_assign_ctx)
+    return _make_intersection_value_without_context(members)
+
+
+def _make_intersection_value_without_context(members: Sequence[Value]) -> Value:
+    simple_members = []
+    union_members = []
+    for member in members:
+        if isinstance(member, IntersectionValue):
+            simple_members.extend(member.vals)
+        elif isinstance(member, MultiValuedValue):
+            union_members.append(member.vals)
+        else:
+            simple_members.append(member)
+    if not union_members:
+        return _intersection_value_from_members(simple_members)
+    return unite_values(
+        *(
+            _intersection_value_from_members((*simple_members, *union_branch))
+            for union_branch in itertools.product(*union_members)
+        )
+    )
+
+
+def _intersection_value_from_members(members: Sequence[Value]) -> IntersectionValue:
+    flattened_members = []
+    for member in members:
+        if isinstance(member, IntersectionValue):
+            flattened_members.extend(member.vals)
+        else:
+            flattened_members.append(member)
+    return IntersectionValue(tuple(flattened_members))
 
 
 def _type_from_runtime(val: Any, ctx: Context) -> Value:
@@ -1690,8 +1721,8 @@ def _type_from_alias_argument_value(arg: Value, ctx: Context) -> Value:
             *[_type_from_alias_argument_value(member, ctx) for member in arg.vals]
         )
     if isinstance(arg, IntersectionValue):
-        return IntersectionValue(
-            tuple(_type_from_alias_argument_value(member, ctx) for member in arg.vals)
+        return _make_intersection_value_without_context(
+            [_type_from_alias_argument_value(member, ctx) for member in arg.vals]
         )
     return _type_from_value(arg, ctx)
 

--- a/pycroscope/extensions.py
+++ b/pycroscope/extensions.py
@@ -237,6 +237,12 @@ class AsynqCallable(metaclass=_AsynqCallableMeta):
             yield from self.args
         yield self.return_type
 
+    def __or__(self, other: object) -> Any:
+        return typing.Union[self, other]  # noqa: UP007
+
+    def __ror__(self, other: object) -> Any:
+        return typing.Union[other, self]  # noqa: UP007
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         raise TypeError(f"{self} is not callable")
 
@@ -274,6 +280,12 @@ class Intersection:
             self, item  # static analysis: ignore[incompatible_argument]
         )
 
+    def __or__(self, other: object) -> Any:
+        return typing.Union[self, other]  # noqa: UP007
+
+    def __ror__(self, other: object) -> Any:
+        return typing.Union[other, self]  # noqa: UP007
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         raise TypeError(f"{self} is not callable")
 
@@ -309,6 +321,12 @@ class Not:
             self, item  # static analysis: ignore[incompatible_argument]
         )
 
+    def __or__(self, other: object) -> Any:
+        return typing.Union[self, other]  # noqa: UP007
+
+    def __ror__(self, other: object) -> Any:
+        return typing.Union[other, self]  # noqa: UP007
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         raise TypeError(f"{self} is not callable")
 
@@ -342,6 +360,12 @@ class Overlapping:
         return types.GenericAlias(
             self, item  # static analysis: ignore[incompatible_argument]
         )
+
+    def __or__(self, other: object) -> Any:
+        return typing.Union[self, other]  # noqa: UP007
+
+    def __ror__(self, other: object) -> Any:
+        return typing.Union[other, self]  # noqa: UP007
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         raise TypeError(f"{self} is not callable")

--- a/pycroscope/test_annotations.py
+++ b/pycroscope/test_annotations.py
@@ -1119,6 +1119,69 @@ class TestCallable(TestNameCheckVisitorBase):
             f(s)  # E: incompatible_argument
             bare(i)
 
+    @assert_passes(run_in_both_module_modes=True)
+    def test_extension_annotation_with_pep604_union(self):
+        from typing_extensions import assert_type
+
+        from pycroscope.extensions import AsynqCallable, Intersection, Not, Overlapping
+
+        class A:
+            pass
+
+        class B:
+            pass
+
+        class C:
+            pass
+
+        class AB(A, B):
+            pass
+
+        class AC(A, C):
+            pass
+
+        class BC(B, C):
+            pass
+
+        def takes_intersection_union(x: Intersection[A, B | C]) -> None:
+            assert_type(x, Intersection[A, B] | Intersection[A, C])
+
+        def takes_union_intersection(x: A | Intersection[B, C]) -> None:
+            assert_type(x, A | Intersection[B, C])
+
+        def takes_intersection_not_union(x: Intersection[int | str, Not[str]]) -> None:
+            assert_type(x, int)
+
+        def takes_not_union(x: int | Not[str]) -> None:
+            pass
+
+        def takes_union_not(x: Not[str] | int) -> None:
+            pass
+
+        def takes_overlapping_union(x: int | Overlapping[str]) -> None:
+            pass
+
+        def takes_asynq_callable_union(x: AsynqCallable[..., int] | None) -> None:
+            pass
+
+        def capybara(ab: AB, ac: AC, bc: BC) -> None:
+            takes_intersection_union(ab)
+            takes_intersection_union(ac)
+            takes_intersection_union(bc)  # E: incompatible_argument
+            takes_union_intersection(ab)
+            takes_union_intersection(bc)
+            takes_intersection_not_union(1)
+            takes_intersection_not_union("x")  # E: incompatible_argument
+            takes_not_union(1)
+            takes_not_union(1.0)
+            takes_not_union("x")  # E: incompatible_argument
+            takes_union_not(1)
+            takes_union_not(1.0)
+            takes_union_not("x")  # E: incompatible_argument
+            takes_overlapping_union(1)
+            takes_overlapping_union("x")
+            takes_asynq_callable_union(None)
+
     @assert_passes()
     def test_not_annotation(self):
         from typing_extensions import Literal


### PR DESCRIPTION
## Summary

This fixes PEP 604 union handling for pycroscope extension annotations. `Intersection[...]` now distributes union operands when annotation parsing has no assignability context, so forms like `Intersection[A, B | C]` no longer produce invalid internal intersection values.

The extension runtime objects also now participate in `|` and reverse `|`, so annotations such as `A | Intersection[B, C]`, `int | Not[str]`, `int | Overlapping[str]`, and `AsynqCallable[..., int] | None` can be constructed before pycroscope parses them.

## Impact

Users can freely combine PEP 604 unions with pycroscope extension annotations instead of spelling these cases through `typing.Union[...]` or hitting runtime/type-parser failures.