### PR TITLE
[codex] Handle Any-to-object TypeIs narrowing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Narrow negative `TypeIs` checks against covariant generic `Any` arms more precisely when the checked type uses `object`.
+- Normalize `Not[...]` inside expected-type expressions such as `assert_type(x, Intersection[A, Not[B]])`.
 - Implement call checking for callable intersection types.
 - Treat definitely missing attributes on intersection members as an error instead of ignoring them, while still allowing indeterminate members to be ignored when another member provides the attribute.
 - Normalize pycroscope extension annotations with PEP 604 union operands, such as `Intersection[A, B | C]`, `A | Intersection[B, C]`, and `int | Not[str]`, instead of producing an internal error.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -2885,6 +2885,10 @@ def _type_from_subscripted_value(
         return _make_intersection_value(
             [_type_from_value(subval, ctx) for subval in members], ctx
         )
+    elif root is Not:
+        if not _require_exact_argument_count(members, 1, "Not", ctx):
+            return AnyValue(AnySource.error)
+        return NotValue(_type_from_value(members[0], ctx))
     elif root is Overlapping:
         if not _require_exact_argument_count(members, 1, "Overlapping", ctx):
             return AnyValue(AnySource.error)

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -783,6 +783,8 @@ def _has_relation_impl(
         return {}  # everything is assignable to Any
     if isinstance(right, AnyValue):
         if relation is Relation.SUBTYPE:
+            if left == TypedValue(object):
+                return {}
             return CanAssignError("Any is not a subtype of anything")
         return {}  # Any is assignable to everything
     assert not isinstance(left, NewTypeValue)

--- a/pycroscope/test_relations.py
+++ b/pycroscope/test_relations.py
@@ -83,6 +83,14 @@ def test_unite_multi_removes_subtype_arms() -> None:
     assert unite_multi([int_value, int_and_any], checker) == int_value
 
 
+def test_any_is_subtype_of_object_only() -> None:
+    checker = Checker()
+    any_value = AnyValue(AnySource.explicit)
+
+    assert has_relation(TypedValue(object), any_value, Relation.SUBTYPE, checker) == {}
+    assert has_relation(TypedValue(int), any_value, Relation.SUBTYPE, checker) != {}
+
+
 def test_unite_multi_keeps_incomparable_arms() -> None:
     checker = Checker()
 

--- a/pycroscope/test_typeis.py
+++ b/pycroscope/test_typeis.py
@@ -648,6 +648,38 @@ class TestTypeIs(TestNameCheckVisitorBase):
             )
 
     @assert_passes()
+    def testTypeIsNegativeNarrowingGenericAnyToObject(self):
+        from typing import Any, Generic, TypeVar
+
+        from typing_extensions import Never, TypeIs, assert_type
+
+        from pycroscope.extensions import Intersection, Not
+
+        T_contra = TypeVar("T_contra", contravariant=True)
+
+        class Sink(Generic[T_contra]):
+            pass
+
+        def is_sink(x: object) -> TypeIs[Sink[Never]]:
+            return False
+
+        def takes_sink(x: int | Sink[Any]) -> None:
+            assert not is_sink(x)
+            assert_type(x, Intersection[int, Not[Sink[Never]]])
+
+        T_co = TypeVar("T_co", covariant=True)
+
+        class Source(Generic[T_co]):
+            pass
+
+        def is_source(x: object) -> TypeIs[Source[object]]:
+            return False
+
+        def takes_source(x: int | Source[Any]) -> None:
+            assert not is_source(x)
+            assert_type(x, Intersection[int, Not[Source[object]]])
+
+    @assert_passes()
     def testTypeIsMultipleCondition(self):
         from typing_extensions import TypeIs, assert_type
 


### PR DESCRIPTION
## Summary

This fixes negative TypeIs narrowing when a covariant generic arm contains Any and the TypeIs target uses object. The relation checker now treats Any as a subtype of object, while keeping the existing rule that Any is not a strict subtype of other concrete types.

It also normalizes pycroscope.extensions.Not when it appears inside expected-type expressions such as Intersection[A, Not[B]], so assert_type-based regressions can use the public annotation spelling.

## Root Cause

Negative TypeIs narrowing removes a union arm only when the arm is proven covered by the negated target. Source[Any] was not considered a subtype of Source[object] because strict subtype checks rejected Any as a subtype of object. Separately, expected-type parsing for nested Not[...] treated the extension marker as an ordinary generic class instead of converting it to the internal NotValue representation.