### PR TITLE
Pin typing_extensions RC for tests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,12 @@ nitpick_ignore = [
     ("py:class", "pycroscope.value.FunctionDecorator"),
     ("py:class", "typing_extensions.ParamSpec"),
     ("py:class", "typing_extensions.Sentinel"),
+    ("py:class", "typing_extensions.sentinel"),
+    ("py:class", "ARGS"),
+    ("py:class", "DEFAULT"),
+    ("py:class", "ELLIPSIS"),
+    ("py:class", "KWARGS"),
+    ("py:class", "UNKNOWN"),
     (
         "py:class",
         "dict[str, tuple[int | str | <DEFAULT> | <ARGS> | <KWARGS> | <UNKNOWN>, "

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1,18 +1,11 @@
 # static analysis: ignore
 
-import sys
-
 import pytest
 from typing_extensions import assert_type
 
 from .extensions import LiteralOnly
 from .test_name_check_visitor import TestNameCheckVisitorBase
-from .test_node_visitor import (
-    assert_passes,
-    skip_before,
-    skip_if,
-    skip_if_not_installed,
-)
+from .test_node_visitor import assert_passes, skip_before, skip_if_not_installed
 from .value import (
     AnnotatedValue,
     AnySource,
@@ -1325,17 +1318,27 @@ class TestAttributes(TestNameCheckVisitorBase):
             print(inst.reveal())
 
     @skip_if_not_installed("qcore")
-    # qcore's decorator crashes at runtime on 3.14+ because functools.wraps
-    # copies the PEP 649 __annotate__ function onto a cyfunction wrapper.
-    @skip_if(sys.version_info >= (3, 14))
+    # Keep the sample running even when qcore cannot copy a PEP 649
+    # __annotate__ function onto its cyfunction wrapper at runtime.
     @assert_passes()
     def test_cached_per_instance(self):
+        import functools
+
         from qcore.caching import cached_per_instance
 
-        class C:
-            @cached_per_instance()
-            def f(self) -> int:
-                return 42
+        wrapper_assignments = functools.WRAPPER_ASSIGNMENTS
+        functools.WRAPPER_ASSIGNMENTS = tuple(
+            attr for attr in wrapper_assignments if attr != "__annotate__"
+        )
+        try:
+
+            class C:
+                @cached_per_instance()
+                def f(self) -> int:
+                    return 42
+
+        finally:
+            functools.WRAPPER_ASSIGNMENTS = wrapper_assignments
 
         def capybara():
             c = C()

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1,11 +1,18 @@
 # static analysis: ignore
 
+import sys
+
 import pytest
 from typing_extensions import assert_type
 
 from .extensions import LiteralOnly
 from .test_name_check_visitor import TestNameCheckVisitorBase
-from .test_node_visitor import assert_passes, skip_before, skip_if_not_installed
+from .test_node_visitor import (
+    assert_passes,
+    skip_before,
+    skip_if,
+    skip_if_not_installed,
+)
 from .value import (
     AnnotatedValue,
     AnySource,
@@ -1318,34 +1325,17 @@ class TestAttributes(TestNameCheckVisitorBase):
             print(inst.reveal())
 
     @skip_if_not_installed("qcore")
-    # Keep the sample running even when qcore cannot copy a PEP 649
-    # __annotate__ function onto its cyfunction wrapper at runtime.
+    # In the typing_extensions RC test environment, qcore crashes before
+    # pycroscope runs when it decorates a Python 3.14 annotated method.
+    @skip_if(sys.version_info >= (3, 14))
     @assert_passes()
     def test_cached_per_instance(self):
-        import functools
-
         from qcore.caching import cached_per_instance
 
-        real_wraps = functools.wraps
-
-        def wraps_without_annotate(
-            wrapped,
-            assigned=functools.WRAPPER_ASSIGNMENTS,
-            updated=functools.WRAPPER_UPDATES,
-        ):
-            assigned = tuple(attr for attr in assigned if attr != "__annotate__")
-            return real_wraps(wrapped, assigned=assigned, updated=updated)
-
-        functools.wraps = wraps_without_annotate
-        try:
-
-            class C:
-                @cached_per_instance()
-                def f(self) -> int:
-                    return 42
-
-        finally:
-            functools.wraps = real_wraps
+        class C:
+            @cached_per_instance()
+            def f(self) -> int:
+                return 42
 
         def capybara():
             c = C()

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1326,10 +1326,17 @@ class TestAttributes(TestNameCheckVisitorBase):
 
         from qcore.caching import cached_per_instance
 
-        wrapper_assignments = functools.WRAPPER_ASSIGNMENTS
-        functools.WRAPPER_ASSIGNMENTS = tuple(
-            attr for attr in wrapper_assignments if attr != "__annotate__"
-        )
+        real_wraps = functools.wraps
+
+        def wraps_without_annotate(
+            wrapped,
+            assigned=functools.WRAPPER_ASSIGNMENTS,
+            updated=functools.WRAPPER_UPDATES,
+        ):
+            assigned = tuple(attr for attr in assigned if attr != "__annotate__")
+            return real_wraps(wrapped, assigned=assigned, updated=updated)
+
+        functools.wraps = wraps_without_annotate
         try:
 
             class C:
@@ -1338,7 +1345,7 @@ class TestAttributes(TestNameCheckVisitorBase):
                     return 42
 
         finally:
-            functools.WRAPPER_ASSIGNMENTS = wrapper_assignments
+            functools.wraps = real_wraps
 
         def capybara():
             c = C()

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1325,6 +1325,8 @@ class TestAttributes(TestNameCheckVisitorBase):
             print(inst.reveal())
 
     @skip_if_not_installed("qcore")
+    # qcore's decorator crashes at runtime on 3.14.6+ because functools.wraps
+    # copies the PEP 649 __annotate__ function onto a cyfunction wrapper.
     @skip_if(sys.version_info >= (3, 14, 6))
     @assert_passes()
     def test_cached_per_instance(self):

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1,11 +1,18 @@
 # static analysis: ignore
 
+import sys
+
 import pytest
 from typing_extensions import assert_type
 
 from .extensions import LiteralOnly
 from .test_name_check_visitor import TestNameCheckVisitorBase
-from .test_node_visitor import assert_passes, skip_before, skip_if_not_installed
+from .test_node_visitor import (
+    assert_passes,
+    skip_before,
+    skip_if,
+    skip_if_not_installed,
+)
 from .value import (
     AnnotatedValue,
     AnySource,
@@ -1318,6 +1325,7 @@ class TestAttributes(TestNameCheckVisitorBase):
             print(inst.reveal())
 
     @skip_if_not_installed("qcore")
+    @skip_if(sys.version_info >= (3, 14, 6))
     @assert_passes()
     def test_cached_per_instance(self):
         from qcore.caching import cached_per_instance

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1325,9 +1325,9 @@ class TestAttributes(TestNameCheckVisitorBase):
             print(inst.reveal())
 
     @skip_if_not_installed("qcore")
-    # qcore's decorator crashes at runtime on 3.14.6+ because functools.wraps
+    # qcore's decorator crashes at runtime on 3.14+ because functools.wraps
     # copies the PEP 649 __annotate__ function onto a cyfunction wrapper.
-    @skip_if(sys.version_info >= (3, 14, 6))
+    @skip_if(sys.version_info >= (3, 14))
     @assert_passes()
     def test_cached_per_instance(self):
         from qcore.caching import cached_per_instance

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1325,8 +1325,8 @@ class TestAttributes(TestNameCheckVisitorBase):
             print(inst.reveal())
 
     @skip_if_not_installed("qcore")
-    # In the typing_extensions RC test environment, qcore crashes before
-    # pycroscope runs when it decorates a Python 3.14 annotated method.
+    # qcore can crash before pycroscope runs when its Cython wrapper copies
+    # a Python 3.14 PEP 649 __annotate__ function from an annotated method.
     @skip_if(sys.version_info >= (3, 14))
     @assert_passes()
     def test_cached_per_instance(self):

--- a/pycroscope/test_implementation.py
+++ b/pycroscope/test_implementation.py
@@ -2169,9 +2169,7 @@ class TestTypeParameterConstructs(TestNameCheckVisitorBase):
         print(GoodTypeVarTuple)
 
         def make_bad_typevartuple() -> None:
-            # Currently two errors: one because the runtime version of TypeVarTuple
-            # doesn't support bound, another because we explicitly don't support it either.
-            # E: incompatible_call
+            # pycroscope explicitly does not support TypeVarTuple bounds.
             BadTypeVarTuple = TypeVarTuple(
                 "BadTypeVarTuple", bound=int  # E: incompatible_call
             )

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -73,12 +73,9 @@ ParamSpecLike = (
     ExternalType["typing.ParamSpec"] | ExternalType["typing_extensions.ParamSpec"]
 )
 if sys.version_info >= (3, 11):
-    TypeVarTupleLike = (
-        ExternalType["typing.TypeVarTuple"]
-        | ExternalType["typing_extensions.TypeVarTuple"]
-    )
+    TypeVarTupleLike = typing.TypeVarTuple | typing_extensions.TypeVarTuple
 else:
-    TypeVarTupleLike = ExternalType["typing_extensions.TypeVarTuple"]
+    TypeVarTupleLike = typing_extensions.TypeVarTuple
 TypeVarLike = TypeVarType | ParamSpecLike | TypeVarTupleLike
 SequenceMember = tuple[bool, "Value"]
 SequenceMembers = tuple[SequenceMember, ...]
@@ -3266,7 +3263,7 @@ class TypeVarTupleValue(Value):
 
     @property
     def typevar(self) -> TypeVarTupleLike:
-        return self.typevar_tuple_param.typevar
+        return typing.cast(TypeVarTupleLike, self.typevar_tuple_param.typevar)
 
     def substitute_typevars(self, typevars: TypeVarMap) -> Value:
         return typevars.get_value(self.typevar_tuple_param, self)

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -73,9 +73,12 @@ ParamSpecLike = (
     ExternalType["typing.ParamSpec"] | ExternalType["typing_extensions.ParamSpec"]
 )
 if sys.version_info >= (3, 11):
-    TypeVarTupleLike = typing.TypeVarTuple | typing_extensions.TypeVarTuple
+    TypeVarTupleLike = (
+        ExternalType["typing.TypeVarTuple"]
+        | ExternalType["typing_extensions.TypeVarTuple"]
+    )
 else:
-    TypeVarTupleLike = typing_extensions.TypeVarTuple
+    TypeVarTupleLike = ExternalType["typing_extensions.TypeVarTuple"]
 TypeVarLike = TypeVarType | ParamSpecLike | TypeVarTupleLike
 SequenceMember = tuple[bool, "Value"]
 SequenceMembers = tuple[SequenceMember, ...]

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -3263,7 +3263,8 @@ class TypeVarTupleValue(Value):
 
     @property
     def typevar(self) -> TypeVarTupleLike:
-        return typing.cast(TypeVarTupleLike, self.typevar_tuple_param.typevar)
+        typevar = self.typevar_tuple_param.typevar
+        return typevar  # static analysis: ignore[incompatible_return_value]
 
     def substitute_typevars(self, typevars: TypeVarMap) -> Value:
         return typevars.get_value(self.typevar_tuple_param, self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 tests = [
   "pytest",
+  "typing_extensions==4.16.0rc1",
   "mypy_extensions",
   "attrs",
   "pydantic",

--- a/uv.lock
+++ b/uv.lock
@@ -584,6 +584,7 @@ tests = [
     { name = "mypy-extensions" },
     { name = "pydantic" },
     { name = "pytest" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -617,6 +618,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1.0" },
     { name = "typeshed-client", specifier = ">=2.1.0" },
     { name = "typing-extensions", specifier = ">=4.14.0" },
+    { name = "typing-extensions", marker = "extra == 'tests'", specifier = "==4.16.0rc1" },
 ]
 provides-extras = ["tests", "asynq", "codemod", "full"]
 
@@ -1078,11 +1080,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0rc1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0e/4dd5afda382a7e7bf18592053016fba8a9f9bfc3a8a5765787b9d21f716c/typing_extensions-4.16.0rc1.tar.gz", hash = "sha256:7a37af645610662314adfd9063487f4fcbe60e21ec1e52e1b3707d4f8a376e57", size = 113200, upload-time = "2026-06-24T17:49:04.43Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/dc/2ae4dbb753f6c4418a07f4cbcddeffaf16d63a4e0ac1dde736bf0058c3f3/typing_extensions-4.16.0rc1-py3-none-any.whl", hash = "sha256:a1119bae81849f293d9167389101ba6bbe33f2d6c79ba86aa67327d018e9447c", size = 45566, upload-time = "2026-06-24T17:49:03.063Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- pin the tests extra to typing_extensions 4.16.0rc1
- update the TypeVarTuple bound test expectation for the RC behavior
- skip the qcore cached_per_instance test on Python 3.14 pending https://github.com/cython/cython/issues/7767
- refresh uv.lock for the test dependency