### PR TITLE
Fix TypeVar identity in implicit generic subclasses

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix bug with calling methods on values typed as intersections.
+- Fix implicit generic subclasses so type variables nested inside base-class arguments remain class type parameters in method annotations.
 - Support `P.args`, `P.kwargs`, and generic specialization with PEP 695 parameter specifications without crashing, and exclude `__type_params__` metadata from protocol requirements.
 - Narrow negative `TypeIs` checks against covariant generic `Any` arms more precisely when the checked type uses `object`.
 - Normalize `Not[...]` inside expected-type expressions such as `assert_type(x, Intersection[A, Not[B]])`.

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -3740,7 +3740,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             effective_type_param_values = (
                 type_param_values
                 if type_param_values
-                else self._type_params_from_base_values(base_values)
+                else self._type_params_from_base_values(
+                    [
+                        self._canonicalize_generic_base_value(base)
+                        for base in base_values
+                    ]
+                )
             )
             annotation_type_param_values = (
                 self._type_params_from_base_annotations_for_default_rules(node.bases)
@@ -3840,6 +3845,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                     for base in base_values_for_registration
                 ]
+            base_values_for_registration = [
+                self._canonicalize_generic_base_value(base)
+                for base in base_values_for_registration
+            ]
             if should_register_generic_bases:
                 self.checker.register_synthetic_type_bases(
                     generic_class_key,
@@ -5937,6 +5946,18 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             self._value_for_variance_annotation(base_node) for base_node in node.bases
         ]
         return analyzed_bases
+
+    def _canonicalize_generic_base_value(self, value: Value) -> Value:
+        if (
+            not isinstance(value, PartialValue)
+            or value.operation is not PartialValueOperation.SUBSCRIPT
+            or self._is_type_parameter_base(value)
+        ):
+            return value
+        normalized = type_from_value(value, self, value.node, suppress_errors=True)
+        if isinstance(normalized, AnyValue):
+            return value
+        return normalized
 
     def _check_duplicate_type_params_in_generic_bases(
         self, node: ast.ClassDef, base_values: Sequence[Value]

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -336,6 +336,27 @@ class TestTypeVar(TestNameCheckVisitorBase):
             ...
 
     @assert_passes(run_in_both_module_modes=True)
+    def test_nested_typevar_in_implicit_generic_base(self):
+        from collections.abc import Sequence
+        from typing import Generic, TypeVar
+
+        T = TypeVar("T")
+
+        class Field(Generic[T]):
+            def serialize(self, value: T) -> str:
+                return repr(value)
+
+            def validate(self, value: T) -> None:
+                pass
+
+        class SequenceField(Field[Sequence[T]]):
+            def prepare(self, value: Sequence[T]) -> str:
+                return self.serialize(value)
+
+            def validate(self, value: Sequence[T]) -> None:
+                super().validate(value)
+
+    @assert_passes(run_in_both_module_modes=True)
     def test_typevar_scoping_in_annotations(self):
         from typing import Generic, TypeVar
 


### PR DESCRIPTION
## Summary

- canonicalize resolvable generic base annotations before discovering implicit class type parameters
- register the same canonical base representation after owner rebinding
- cover nested TypeVars in implicit generic subclass methods in importable and static-fallback analysis

## Root cause

For a base such as `Field[Sequence[T]]`, the initial class-base value kept the nested `Sequence[T]` as a partial subscript expression. Type-parameter discovery therefore missed `T`, and method annotation processing rebound it as a fresh method-local TypeVar. Normalizing only the identity was insufficient because the registered base could still degrade to `types.GenericAlias`.

The class analysis now collects parameters from the same canonical representation that is registered with the type object.

Fixes #521