### PR TITLE
Adopt Scriv changelog fragments

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,7 +18,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Run unit tests for conformance tooling
-        run: uv run --frozen --extra tests pytest tools/test_conformance_ci.py
+        run: uv run --locked --extra tests pytest tools/test_conformance_ci.py
 
       - name: Check out typing conformance suite
         uses: actions/checkout@v7
@@ -27,4 +27,4 @@ jobs:
           path: typing
 
       - name: Run conformance gate
-        run: uv run --frozen python tools/conformance_ci.py --typing-repo typing
+        run: uv run --locked python tools/conformance_ci.py --typing-repo typing

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,7 +29,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync --frozen --group docs
+        run: uv sync --locked --group docs
 
       - name: Build documentation
-        run: uv run --frozen --group docs sphinx-build -a -b html -n -W --keep-going docs/ docs/_build
+        run: uv run --locked --group docs sphinx-build -a -b html -n -W --keep-going docs/ docs/_build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,13 +32,13 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - name: test
         if: matrix.python-version != '3.14'
-        run: uv run --frozen --extra tests --extra asynq --extra codemod pytest pycroscope
+        run: uv run --locked --extra tests --extra asynq --extra codemod pytest pycroscope
       - name: test with coverage
         if: matrix.python-version == '3.14'
-        run: uv run --frozen --extra tests --extra asynq --extra codemod --group coverage pytest --cov=pycroscope --cov-report=term-missing --cov-report=json:coverage.json pycroscope tools/test_duplicate_tests.py
+        run: uv run --locked --extra tests --extra asynq --extra codemod --group coverage pytest --cov=pycroscope --cov-report=term-missing --cov-report=json:coverage.json pycroscope tools/test_duplicate_tests.py
       - name: check pinned full coverage
         if: matrix.python-version == '3.14'
-        run: uv run --frozen --group coverage python tools/check_full_coverage.py coverage.json tools/full_coverage_files.txt
+        run: uv run --locked --group coverage python tools/check_full_coverage.py coverage.json tools/full_coverage_files.txt
 
   test-no-deps:
     runs-on: ubuntu-latest
@@ -51,4 +51,4 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: test-no-deps
-        run: uv run --frozen --group test-runner pytest pycroscope
+        run: uv run --locked --group test-runner pytest pycroscope

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -18,4 +18,4 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Run third-party checks
-        run: uv run --frozen python tools/third_party_ci.py
+        run: uv run --locked python tools/third_party_ci.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,20 @@
 
 ## Changelog
 
-- Any change with a user-visible effect must include an entry in `docs/changelog.md`.
-- Add changelog entries under `## Unreleased` in `docs/changelog.md`.
-- Changelog entries should be single bullets in plain language that explain the user-visible effect (not internal refactors).
+- Any change with a user-visible effect must include a Scriv fragment in `changelog.d/`.
+- Create fragments with `uv run --locked --group release scriv create`. Do not edit
+  `docs/changelog.md` directly except while preparing a release.
+- Fragments should contain a single bullet in plain language that explains the
+  user-visible effect (not internal refactors).
 - Bugfixes for bugs that were not in any release do not need changelog entries.
+
+## uv lockfile
+
+- Use `uv run --locked` and `uv sync --locked` for ordinary development and test
+  commands so they fail instead of modifying `uv.lock`.
+- Modify `uv.lock` only when `pyproject.toml` dependency declarations or the project
+  version change. Run `uv lock` explicitly and include the resulting lockfile change
+  in the same commit.
 
 ## Architecture
 
@@ -43,7 +53,7 @@
 - `test_self.py` is often useful for finding regressions. Run it with the `full` extra enabled or it will be skipped.
 - Run conformance CI with the same interpreter you want pycroscope itself to use, because `tools/conformance_ci.py`
   invokes `sys.executable -m pycroscope` under the hood.
-- Use this form from the repo root: `uv run --python 3.12 python tools/conformance_ci.py --typing-repo ~/py/typing`
+- Use this form from the repo root: `uv run --locked --python 3.12 python tools/conformance_ci.py --typing-repo ~/py/typing`
   (optionally prefix `UV_CACHE_DIR=/tmp/uv-cache`).
 - When fixing regressions found by `test_self.py`, add separate test cases instead of just relying on `test_self.py`.
 - When writing test cases, always use code samples (`@assert_passes()`) instead of tests that directly
@@ -56,7 +66,7 @@
 ## Coverage
 
 - To reproduce the CI coverage run locally, use Python 3.14 and `pytest-cov`, for example:
-  `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.14 --extra tests --extra asynq --extra codemod --with pytest-cov pytest --cov=pycroscope --cov-report=term-missing --cov-report=json:coverage.json pycroscope`
+  `UV_CACHE_DIR=/tmp/uv-cache uv run --locked --python 3.14 --extra tests --extra asynq --extra codemod --with pytest-cov pytest --cov=pycroscope --cov-report=term-missing --cov-report=json:coverage.json pycroscope`
 - To generate an HTML line-by-line coverage report locally, add `--cov-report=html` to the coverage command above.
   The report is written to `htmlcov/index.html`.
 - The pinned-full-coverage check is checked in as `tools/check_full_coverage.py`; run it with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ commands like these:
 
 ```
 $ cd pycroscope
-$ uv sync --frozen --extra tests --extra full --group docs
+$ uv sync --locked --extra tests --extra full --group docs
 ```
 
 ## Black
@@ -15,7 +15,7 @@ The code is formatted using [_Black_](https://black.readthedocs.io).
 You can run the formatter with:
 
 ```
-$ uv run --with black black pycroscope
+$ uv run --locked --with black black pycroscope
 ```
 
 ## ruff
@@ -23,7 +23,7 @@ $ uv run --with black black pycroscope
 We use [ruff](https://docs.astral.sh/ruff/) as a linter and import sorter:
 
 ```
-$ uv run --with ruff ruff check pycroscope
+$ uv run --locked --with ruff ruff check pycroscope
 ```
 
 ## Unit tests
@@ -31,7 +31,7 @@ $ uv run --with ruff ruff check pycroscope
 The unit tests are run with [pytest](https://docs.pytest.org/):
 
 ```
-$ uv run --extra tests pytest -v pycroscope
+$ uv run --locked --extra tests pytest -v pycroscope
 ```
 
 Running all of the tests takes a few minutes, so I often use the
@@ -39,7 +39,7 @@ Running all of the tests takes a few minutes, so I often use the
 For example:
 
 ```
-$ uv run --extra tests pytest -v pycroscope -k PEP673
+$ uv run --locked --extra tests pytest -v pycroscope -k PEP673
 ```
 
 We run tests on all supported Python versions on GitHub Actions,
@@ -61,3 +61,18 @@ taxonomy = "/path/to/taxonomy"
 
 Command-line `--local NAME:PATH` values override the config file. Dependency
 installation output is hidden by default; pass `-v` or `--verbose` to show it.
+
+## Changelog
+
+For each user-visible change, create a changelog fragment:
+
+```
+$ uv run --locked --group release scriv create
+```
+
+Replace the generated placeholder with one plain-language bullet and commit the
+fragment with the change. Do not edit `docs/changelog.md` directly; Scriv updates
+that shared file when a release is prepared. Internal refactors and fixes for bugs
+that have never appeared in a release do not need fragments.
+
+See [the release guide](docs/releasing.md) for the maintainer workflow.

--- a/changelog.d/20260813-existing-unreleased.md
+++ b/changelog.d/20260813-existing-unreleased.md
@@ -1,0 +1,16 @@
+- Fix bug with calling methods on values typed as intersections.
+- Reject protocol matches that provide a required `ClassVar` only through an instance attribute.
+- Fix implicit generic subclasses so type variables nested inside base-class arguments remain class type parameters in method annotations.
+- Support `P.args`, `P.kwargs`, and generic specialization with PEP 695 parameter specifications without crashing, and exclude `__type_params__` metadata from protocol requirements.
+- Narrow negative `TypeIs` checks against covariant generic `Any` arms more precisely when the checked type uses `object`.
+- Normalize `Not[...]` inside expected-type expressions such as `assert_type(x, Intersection[A, Not[B]])`.
+- Implement call checking for callable intersection types.
+- Treat definitely missing attributes on intersection members as an error instead of ignoring them, while still allowing indeterminate members to be ignored when another member provides the attribute.
+- Normalize pycroscope extension annotations with PEP 604 union operands, such as `Intersection[A, B | C]`, `A | Intersection[B, C]`, and `int | Not[str]`, instead of producing an internal error.
+- Improve recursive gradual type compatibility for aliases, protocols, and TypedDicts, so recursive `Any` tails no longer hide incompatible nested types and mutually recursive TypedDicts no longer produce internal recursion errors.
+- Infer and validate class type-parameter variance from the collected class API in both importable and static fallback analysis, including generic bases and callable member annotations.
+- Treat plain subclasses of frozen dataclasses as mutable for their own annotated attributes, while keeping inherited frozen dataclass fields read-only.
+- Add basic support for `pycroscope.extensions.Not[T]` negation types, including assignability and intersection simplification.
+- Simplify unions containing an exact fully static `Not[T]` complement pair, such as `Literal[1] | Not[Literal[1]]`, to `object`.
+- Deduplicate unions containing equivalent intersections written in different orders, such as `Any & int` and `int & Any`.
+- Preserve `Not[T]` intersections in negative `TypeIs[T]` narrowing, while keeping other narrowing paths pragmatic.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,12 @@
+# Changelog fragments
+
+Add one Scriv fragment for each user-visible change instead of editing
+`docs/changelog.md` directly:
+
+```console
+uv run --locked --group release scriv create
+```
+
+Replace the generated placeholder with a single plain-language bullet. Internal
+refactors and fixes for bugs that have never appeared in a release do not need a
+fragment. Scriv combines and removes the fragments when a release is prepared.

--- a/changelog.d/new_fragment.md.j2
+++ b/changelog.d/new_fragment.md.j2
@@ -1,0 +1,1 @@
+- Describe the user-visible change in plain language.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,23 +1,6 @@
 # Changelog
 
-## Unreleased
-
-- Fix bug with calling methods on values typed as intersections.
-- Reject protocol matches that provide a required `ClassVar` only through an instance attribute.
-- Fix implicit generic subclasses so type variables nested inside base-class arguments remain class type parameters in method annotations.
-- Support `P.args`, `P.kwargs`, and generic specialization with PEP 695 parameter specifications without crashing, and exclude `__type_params__` metadata from protocol requirements.
-- Narrow negative `TypeIs` checks against covariant generic `Any` arms more precisely when the checked type uses `object`.
-- Normalize `Not[...]` inside expected-type expressions such as `assert_type(x, Intersection[A, Not[B]])`.
-- Implement call checking for callable intersection types.
-- Treat definitely missing attributes on intersection members as an error instead of ignoring them, while still allowing indeterminate members to be ignored when another member provides the attribute.
-- Normalize pycroscope extension annotations with PEP 604 union operands, such as `Intersection[A, B | C]`, `A | Intersection[B, C]`, and `int | Not[str]`, instead of producing an internal error.
-- Improve recursive gradual type compatibility for aliases, protocols, and TypedDicts, so recursive `Any` tails no longer hide incompatible nested types and mutually recursive TypedDicts no longer produce internal recursion errors.
-- Infer and validate class type-parameter variance from the collected class API in both importable and static fallback analysis, including generic bases and callable member annotations.
-- Treat plain subclasses of frozen dataclasses as mutable for their own annotated attributes, while keeping inherited frozen dataclass fields read-only.
-- Add basic support for `pycroscope.extensions.Not[T]` negation types, including assignability and intersection simplification.
-- Simplify unions containing an exact fully static `Not[T]` complement pair, such as `Literal[1] | Not[Literal[1]]`, to `object`.
-- Deduplicate unions containing equivalent intersections written in different orders, such as `Any & int` and `int & Any`.
-- Preserve `Not[T]` intersections in negative `TypeIs[T]` narrowing, while keeping other narrowing paths pragmatic.
+<!-- scriv-insert-here -->
 
 ## Version 0.4.0 (May 2, 2026)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ pycroscope: A semi-static typechecker
    reference/signature
    reference/stacked_scopes
    reference/value
+   releasing
    changelog
 
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,64 @@
+# Releasing pycroscope
+
+Release preparation happens in a pull request so that the generated changelog,
+version, and lockfile can be reviewed together.
+
+## Prepare the release
+
+1. Start from the latest `main` and choose the new version.
+2. Confirm that every user-visible change since the previous release has a
+   fragment in `changelog.d/`.
+3. Update `project.version` in `pyproject.toml`.
+4. Update the lockfile explicitly:
+
+   ```console
+   uv lock
+   ```
+
+   The project itself is represented in `uv.lock`, so every version bump must
+   include this step. Review the diff and make sure unrelated dependencies did
+   not change.
+
+5. Collect the fragments into a dated release section:
+
+   ```console
+   uv run --locked --group release scriv collect
+   ```
+
+   Scriv reads the version from `pyproject.toml`, adds a section to
+   `docs/changelog.md`, and removes the collected fragment files. Review the
+   generated text and optionally add a short release summary below the heading.
+
+6. Run the relevant tests and build the distributions:
+
+   ```console
+   uv run --locked --extra tests --extra asynq --extra codemod pytest pycroscope
+   uv build
+   ```
+
+7. Commit the version bump, `uv.lock`, generated changelog, and removed
+   fragments in the release pull request. Merge it after CI passes.
+
+## Publish the release
+
+GitHub Releases are the authoritative release mechanism. After the release pull
+request is merged, open the repository's **Releases** page and draft a new
+release:
+
+1. Create a new tag whose name exactly matches the version in `pyproject.toml`
+   (for example, `0.5.0`) and target it at the release pull request's merge
+   commit on `main`. Do not create or push the tag separately.
+2. Use the version as the release title.
+3. Copy the corresponding section from `docs/changelog.md` into the release
+   notes. Scriv can print only that section for convenient copying:
+
+   ```console
+   uv run --locked --group release scriv print --version 0.5.0
+   ```
+
+4. Save and review the draft before publishing it.
+
+Publishing the GitHub release creates the tag and triggers
+`.github/workflows/publish.yml`, which builds the distributions and publishes
+them to PyPI. Confirm that the workflow completes successfully and that the new
+version is available on PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,21 @@ test-runner = [
 coverage = [
   "pytest-cov",
 ]
+release = [
+  "scriv==1.8.0",
+]
+
+[tool.scriv]
+changelog = "docs/changelog.md"
+fragment_directory = "changelog.d"
+categories = []
+compact_fragments = true
+entry_title_template = "Version {{ version }} ({{ date.strftime('%B') }} {{ date.day }}, {{ date.year }})"
+format = "md"
+md_header_level = 2
+md_html_anchors = false
+new_fragment_template = "file: new_fragment.md.j2"
+version = "literal: pyproject.toml: project.version"
 
 [project.urls]
 Homepage = "https://github.com/JelleZijlstra/pycroscope"

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,30 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "click-log"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/32/228be4f971e4bd556c33d52a22682bfe318ffe57a1ddb7a546f347a90260/click-log-0.4.0.tar.gz", hash = "sha256:3970f8570ac54491237bcdb3d8ab5e3eef6c057df29f8c3d1151a51a9c23b975", size = 9985, upload-time = "2022-03-13T11:10:15.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/5a/4f025bc751087833686892e17e7564828e409c43b632878afeae554870cd/click_log-0.4.0-py2.py3-none-any.whl", hash = "sha256:a43e394b528d52112af599f2fc9e4b7cf3c15f94e53581f74fa6867e68c91756", size = 4273, upload-time = "2022-03-13T11:10:17.594Z" },
+]
+
+[[package]]
 name = "codemod"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -336,7 +360,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -596,6 +620,9 @@ docs = [
     { name = "pygments" },
     { name = "sphinx" },
 ]
+release = [
+    { name = "scriv" },
+]
 test-runner = [
     { name = "pytest" },
 ]
@@ -618,7 +645,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1.0" },
     { name = "typeshed-client", specifier = ">=2.1.0" },
     { name = "typing-extensions", specifier = ">=4.14.0" },
-    { name = "typing-extensions", marker = "extra == 'tests'", specifier = "==4.16.0rc1" },
+    { name = "typing-extensions", marker = "extra == 'tests'", specifier = "==4.16.0" },
 ]
 provides-extras = ["tests", "asynq", "codemod", "full"]
 
@@ -629,6 +656,7 @@ docs = [
     { name = "pygments", specifier = "==2.20.0" },
     { name = "sphinx", specifier = "==7.4.7" },
 ]
+release = [{ name = "scriv", specifier = "==1.8.0" }]
 test-runner = [{ name = "pytest" }]
 
 [[package]]
@@ -921,6 +949,23 @@ wheels = [
 ]
 
 [[package]]
+name = "scriv"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "click" },
+    { name = "click-log" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/9a/2ef2209e0672b264a2f2574dc88ea3cd9cfc9adfecbfd3165a900980ec8c/scriv-1.8.0.tar.gz", hash = "sha256:7b1a105dd411ac541998250fc8594742419f94cee984ca1257c5ebf5af21918b", size = 98160, upload-time = "2025-12-30T00:01:10.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/e7/062480ede84ecb56ee0f8f2e5b5a3b2a5bceeb73bbdf909d3c13f5438749/scriv-1.8.0-py3-none-any.whl", hash = "sha256:f00f51325b2f4bc96b16fbb1239d4ab577cc2422301a5dd4f5f9378aae2549e0", size = 39085, upload-time = "2025-12-30T00:01:08.599Z" },
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1080,11 +1125,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.16.0rc1"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0e/4dd5afda382a7e7bf18592053016fba8a9f9bfc3a8a5765787b9d21f716c/typing_extensions-4.16.0rc1.tar.gz", hash = "sha256:7a37af645610662314adfd9063487f4fcbe60e21ec1e52e1b3707d4f8a376e57", size = 113200, upload-time = "2026-06-24T17:49:04.43Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/dc/2ae4dbb753f6c4418a07f4cbcddeffaf16d63a4e0ac1dde736bf0058c3f3/typing_extensions-4.16.0rc1-py3-none-any.whl", hash = "sha256:a1119bae81849f293d9167389101ba6bbe33f2d6c79ba86aa67327d018e9447c", size = 45566, upload-time = "2026-06-24T17:49:03.063Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- adopt Scriv fragments so user-visible changes no longer edit a shared Unreleased section
- make ordinary local and CI uv commands use `--locked`, reserving lockfile updates for explicit dependency or version changes
- document release preparation and publication through GitHub Releases

## Motivation

Plain `uv run` can update `uv.lock` as a side effect, while adding every changelog entry at the top of one file creates frequent merge conflicts. This workflow makes both shared files stable during ordinary development: pull requests add unique changelog fragments, and only release preparation collects them and intentionally updates the lockfile.