### PR TITLE
Fix overloaded property accessors

### DIFF
--- a/changelog.d/20260813-property-accessors.md
+++ b/changelog.d/20260813-property-accessors.md
@@ -1,0 +1,1 @@
+- Check property assignments and deletions against the matching accessor, including separately overloaded getters, setters, and deleters and deprecations on individual overloads.

--- a/pycroscope/arg_spec.py
+++ b/pycroscope/arg_spec.py
@@ -14,7 +14,7 @@ import typing
 from collections.abc import Callable, Generator, Mapping, Sequence
 from dataclasses import dataclass, replace
 from re import Pattern
-from types import FunctionType, MethodType, ModuleType
+from types import CodeType, FunctionType, MethodType, ModuleType
 from typing import Any, Generic, TypeVar
 from unittest import mock
 
@@ -169,6 +169,64 @@ def _unwrap_overload_callable(func: Callable[..., Any]) -> Callable[..., Any]:
             return unwrapped
         seen.add(id(wrapped))
         unwrapped = wrapped
+
+
+def _get_overload_callable_code(obj: object) -> CodeType | None:
+    obj = safe_getattr(obj, "__func__", obj)
+    if not isinstance(obj, FunctionType):
+        return None
+    unwrapped = _unwrap_overload_callable(obj)
+    if not isinstance(unwrapped, FunctionType):
+        return None
+    return unwrapped.__code__
+
+
+def _filter_overloads_for_callable(
+    obj: object,
+    overloads: Sequence[Callable[..., Any]],
+    *,
+    earlier_implementations: Sequence[Callable[..., Any]] = (),
+) -> list[Callable[..., Any]]:
+    """Return overload declarations between the surrounding implementations.
+
+    Runtime overload registries are keyed by module and qualified name, so distinct
+    implementations with the same qualified name may share an entry. The concrete
+    implementation is the upper boundary. Callers that know about earlier related
+    implementations, such as accessors on the same property, may also provide the
+    lower boundaries needed to split the registry into separate overload blocks.
+
+    If source locations are unavailable or incomparable, retain the registry's
+    answer because filtering it reliably is impossible.
+    """
+    implementation_code = _get_overload_callable_code(obj)
+    if implementation_code is None:
+        return list(overloads)
+    earlier_implementation_lines = []
+    for earlier_implementation in earlier_implementations:
+        earlier_code = _get_overload_callable_code(earlier_implementation)
+        if earlier_code is None:
+            continue
+        if (
+            earlier_code.co_filename == implementation_code.co_filename
+            and earlier_code.co_firstlineno < implementation_code.co_firstlineno
+        ):
+            earlier_implementation_lines.append(earlier_code.co_firstlineno)
+    lower_bound = max(earlier_implementation_lines, default=-1)
+
+    result = []
+    for overload in overloads:
+        overload_code = _get_overload_callable_code(overload)
+        if overload_code is None:
+            return list(overloads)
+        if overload_code.co_filename != implementation_code.co_filename:
+            return list(overloads)
+        if (
+            lower_bound
+            < overload_code.co_firstlineno
+            < implementation_code.co_firstlineno
+        ):
+            result.append(overload)
+    return result
 
 
 @used  # exposed as an API
@@ -824,6 +882,54 @@ class ArgSpecCache:
             raise TypeError(f"failed to find a concrete signature or {obj}")
         return replace(sig, allow_call=allow_call)
 
+    def get_property_accessor_overload_signature(
+        self, prop: property, accessor: Callable[..., Any]
+    ) -> OverloadedSignature | None:
+        """Return only the overloads associated with one property accessor."""
+        return self._get_overloaded_signature(
+            accessor,
+            None,
+            False,
+            earlier_implementations=tuple(
+                candidate
+                for candidate in (prop.fget, prop.fset, prop.fdel)
+                if candidate is not None and candidate is not accessor
+            ),
+        )
+
+    def _get_overloaded_signature(
+        self,
+        obj: object,
+        impl: Impl | None,
+        is_asynq: bool,
+        *,
+        earlier_implementations: Sequence[Callable[..., Any]] = (),
+    ) -> OverloadedSignature | None:
+        inner_obj = safe_getattr(obj, "__func__", obj)
+        if safe_hasattr(inner_obj, "__module__") and safe_hasattr(
+            inner_obj, "__qualname__"
+        ):
+            for get_overloads_func in _GET_OVERLOADS:
+                overloads = _filter_overloads_for_callable(
+                    inner_obj,
+                    get_overloads_func(inner_obj),
+                    earlier_implementations=earlier_implementations,
+                )
+                signature = self._maybe_make_overloaded_signature(
+                    overloads, impl, is_asynq
+                )
+                if signature is not None:
+                    return signature
+        fq_name = get_fully_qualified_name(obj)
+        if fq_name is None:
+            return None
+        overloads = _filter_overloads_for_callable(
+            obj,
+            pycroscope_get_overloads(fq_name),
+            earlier_implementations=earlier_implementations,
+        )
+        return self._maybe_make_overloaded_signature(overloads, impl, is_asynq)
+
     def _cached_get_argspec(
         self,
         obj: object,
@@ -948,23 +1054,11 @@ class ArgSpecCache:
         # Must be after the check for bound methods, because otherwise we
         # won't bind self correctly.
         if not in_overload_resolution:
-            for get_overloads_func in _GET_OVERLOADS:
-                inner_obj = safe_getattr(obj, "__func__", obj)
-                if safe_hasattr(inner_obj, "__module__") and safe_hasattr(
-                    inner_obj, "__qualname__"
-                ):
-                    sig = self._maybe_make_overloaded_signature(
-                        get_overloads_func(inner_obj), impl, is_asynq
-                    )
-                    if sig is not None:
-                        return sig
+            sig = self._get_overloaded_signature(obj, impl, is_asynq)
+            if sig is not None:
+                return sig
             fq_name = get_fully_qualified_name(obj)
             if fq_name is not None:
-                sig = self._maybe_make_overloaded_signature(
-                    pycroscope_get_overloads(fq_name), impl, is_asynq
-                )
-                if sig is not None:
-                    return sig
                 evaluator_sig = self._maybe_make_evaluator_sig(obj, impl, is_asynq)
                 if evaluator_sig is not None:
                     return evaluator_sig

--- a/pycroscope/arg_spec.py
+++ b/pycroscope/arg_spec.py
@@ -201,6 +201,13 @@ def _filter_overloads_for_callable(
     implementation_code = _get_overload_callable_code(obj)
     if implementation_code is None:
         return list(overloads)
+    if any(
+        _get_overload_callable_code(overload) is implementation_code
+        for overload in overloads
+    ):
+        # Overload-only protocols leave one of their declarations as the runtime
+        # member. There is no concrete implementation to use as a boundary.
+        return list(overloads)
     earlier_implementation_lines = []
     for earlier_implementation in earlier_implementations:
         earlier_code = _get_overload_callable_code(earlier_implementation)

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -294,6 +294,7 @@ from .value import (
     PartialValue,
     PartialValueOperation,
     PredicateValue,
+    PropertyAccessKind,
     PropertyInfo,
     ReferencingValue,
     SelfOwnerExtension,
@@ -2972,16 +2973,8 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         deprecation_message = self._deprecation_message_from_value(
             function_value
         ) or self._deprecation_message_from_decorators(info.decorators)
-        if any(
-            isinstance(unapplied, KnownValue) and unapplied.val is property
-            for unapplied, _, _ in info.decorators
-        ) or any(
-            # TODO: do we need this branch? we shouldn't look at exact names
-            isinstance(decorator, ast.Name) and decorator.id == "property"
-            for decorator in node.decorator_list
-        ):
-
-            getter = self._undecorated_function_value(info)
+        if self._is_property_getter(info):
+            getter = self._property_accessor_function_value(info, function_value)
             fget = info.get_symbol(getter, deprecation_message)
             self._set_complete_synthetic_class_symbol(
                 node.name,
@@ -2992,17 +2985,8 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             )
             return
 
-        setter_target_name: str | None = None
-        for decorator in node.decorator_list:
-            # TODO: this is not a precise way to recognize property setters
-            if (
-                isinstance(decorator, ast.Attribute)
-                and decorator.attr == "setter"
-                and isinstance(decorator.value, ast.Name)
-            ):
-                setter_target_name = decorator.value.id
-                break
-        if setter_target_name is None:
+        mutator = _property_mutator(node)
+        if mutator is None:
             self._set_complete_synthetic_class_symbol(
                 node.name,
                 initializer=function_value,
@@ -3014,16 +2998,18 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             )
             return
 
-        mangled_target = _mangle_class_attribute_name(class_name, setter_target_name)
-        fset = info.get_symbol(
-            self._undecorated_function_value(info), deprecation_message
-        )
+        accessor_kind, target_name = mutator
+        mangled_target = _mangle_class_attribute_name(class_name, target_name)
+        accessor_value = self._property_accessor_function_value(info, function_value)
+        accessor_symbol = info.get_symbol(accessor_value, deprecation_message)
         existing = synthetic_type.get_declared_symbol(mangled_target)
         existing_property_info = (
             existing.property_info if existing is not None else None
         )
+        property_info = existing_property_info or PropertyInfo(fget=None)
+        property_info = property_info.with_accessor(accessor_kind, accessor_symbol)
         self._set_complete_synthetic_class_symbol(
-            setter_target_name,
+            target_name,
             node=node,
             initializer=(
                 existing.initializer if existing is not None else TypedValue(property)
@@ -3032,15 +3018,32 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             is_instance_only=(
                 existing.is_instance_only if existing is not None else False
             ),
-            property_info=PropertyInfo(
-                fget=(
-                    existing_property_info.fget
-                    if existing_property_info is not None
-                    else None
-                ),
-                fset=fset,
-            ),
+            property_info=property_info,
         )
+
+    def _is_property_getter(self, info: FunctionInfo) -> bool:
+        return any(
+            isinstance(unapplied, KnownValue) and unapplied.val is property
+            for unapplied, _, _ in info.decorators
+        )
+
+    def _property_accessor_function_value(
+        self, info: FunctionInfo, function_value: Value
+    ) -> Value:
+        function_fallback = replace_fallback(function_value)
+        if isinstance(function_fallback, CallableValue) and isinstance(
+            function_fallback.signature, OverloadedSignature
+        ):
+            return function_value
+        return self._undecorated_function_value(info)
+
+    def _property_access_kind(self, info: FunctionInfo) -> PropertyAccessKind | None:
+        if self._is_property_getter(info):
+            return PropertyAccessKind.read
+        mutator = _property_mutator(info.node)
+        if mutator is None:
+            return None
+        return mutator[0]
 
     def _undecorated_function_value(self, info: FunctionInfo) -> Value:
         return compute_value_of_function(replace(info, decorators=[]), self)
@@ -7155,6 +7158,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 computed_function,
                 direct_dataclass_transform_info=direct_dataclass_transform_info,
             )
+            is_property_accessor = self._property_access_kind(info) is not None
             use_runtime_function_value = potential_function is not None
             if (
                 use_runtime_function_value
@@ -7167,12 +7171,20 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 # loses the original callable signature; preserve the static signature.
                 use_runtime_function_value = False
             if not use_runtime_function_value:
-                if static_overload_signature is not None:
+                if static_overload_signature is not None and not is_property_accessor:
                     val = CallableValue(static_overload_signature, types.FunctionType)
                 else:
                     val = computed_function
             else:
                 val = KnownValue(potential_function)
+            synthetic_function_value = val
+            if static_overload_signature is not None and is_property_accessor:
+                # A runtime property exposes only its concrete accessor function.
+                # Preserve the statically collected overload set in property
+                # metadata, while leaving the property itself bound in scope.
+                synthetic_function_value = CallableValue(
+                    static_overload_signature, types.FunctionType
+                )
             if (
                 FunctionDecorator.overload not in info.decorator_kinds
                 and FunctionDecorator.evaluated not in info.decorator_kinds
@@ -7200,7 +7212,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 self._set_name_in_scope(
                     node.name, node, val, record_synthetic_symbol=False
                 )
-                self._record_complete_synthetic_function_symbol(node, info, val)
+                self._record_complete_synthetic_function_symbol(
+                    node, info, synthetic_function_value
+                )
 
             if (
                 node.name in METHODS_ALLOWING_NOTIMPLEMENTED
@@ -7715,7 +7729,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def _signature_for_overload_consistency(
         self, info: FunctionInfo, computed_function: Value
     ) -> ConcreteSignature | None:
-        if FunctionDecorator.overload in info.decorator_kinds:
+        is_property_accessor = self._property_access_kind(info) is not None
+        if is_property_accessor:
+            computed_function = self._undecorated_function_value(info)
+        elif FunctionDecorator.overload in info.decorator_kinds:
             decorators = [
                 decorator
                 for decorator in info.decorators
@@ -7728,6 +7745,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         signature = self.signature_from_value(computed_function)
         if isinstance(signature, BoundMethodSignature):
             signature = signature.get_signature(ctx=self)
+        if isinstance(signature, Signature) and is_property_accessor:
+            deprecated = self._deprecation_message_from_decorators(info.decorators)
+            if deprecated is not None:
+                signature = replace(signature, deprecated=deprecated)
         if isinstance(signature, (Signature, OverloadedSignature)):
             return signature
         return None
@@ -13962,7 +13983,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 use_fallback=True,
                 ignore_none=self.options.get_value_for(IgnoreNoneAttributes),
             )
-            self._check_deprecated_property_getter(node, root_composite.value)
+            self._check_deprecated_property_accessor(
+                node, root_composite.value, PropertyAccessKind.read
+            )
             self.check_deprecation(node, value)
             if self._should_use_varname_value(value):
                 varname_value = self.checker.maybe_get_variable_name_value(node.attr)
@@ -14099,6 +14122,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         )
         if not has_precise_attribute_type:
             return None
+        if attr.symbol.property_info is not None:
+            # Assignment calls the setter, but a subsequent read still has the
+            # getter's type; do not narrow the property to the assigned value.
+            return attr.value
         if self.being_assigned is None:
             return attr.value
         if transformed_attribute_types is not None:
@@ -14194,6 +14221,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         self, node: ast.Attribute, root: SimpleType, *, is_deletion: bool = False
     ) -> None:
         wording = "delete" if is_deletion else "assign to"
+        property_access_kind = (
+            PropertyAccessKind.delete if is_deletion else PropertyAccessKind.write
+        )
         if isinstance(root, AnyValue):
             return  # always ok
         elif isinstance(root, UnboundMethodValue):
@@ -14237,7 +14267,13 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     return
         attr = tobj.get_attribute(
             node.attr,
-            AttributePolicy(on_class=on_class, receiver=root, visitor=self, node=node),
+            AttributePolicy(
+                on_class=on_class,
+                receiver=root,
+                visitor=self,
+                node=node,
+                property_access=property_access_kind,
+            ),
         )
         if attr is None:
             if (
@@ -14283,14 +14319,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 error_code=ErrorCode.incompatible_assignment,
             )
             return
-        if attr.symbol.property_info is not None and not attr.symbol.property_info.fset:
-            self._show_error_if_checking(
-                node,
-                f"Cannot {wording} read-only property {node.attr!r}",
-                error_code=ErrorCode.incompatible_assignment,
-            )
-            return
-        self._check_deprecated_property_setter(node, root)
+        if attr.symbol.property_info is not None:
+            accessor = attr.symbol.property_info.get_accessor(property_access_kind)
+            if accessor is None:
+                message = (
+                    f"Cannot delete property {node.attr!r} without a deleter"
+                    if is_deletion
+                    else f"Cannot assign to read-only property {node.attr!r}"
+                )
+                self._show_error_if_checking(
+                    node, message, error_code=ErrorCode.incompatible_assignment
+                )
+                return
+        self._check_deprecated_property_accessor(node, root, property_access_kind)
         if (
             attr.symbol.is_readonly
             and not self._is_allowed_readonly_attribute_initialization(node, root)
@@ -14321,11 +14362,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if self._check_final_attribute_assignment(node, attr, wording):
             return
         if is_deletion:
+            if attr.is_property:
+                self.get_call_result(attr.value, (root,), node=node)
+                return
             self._show_error_if_checking(
                 node,
                 f"Cannot delete attribute {node.attr!r}",
                 error_code=ErrorCode.incompatible_assignment,
             )
+            return
+        if attr.is_property:
+            if self.being_assigned is not None:
+                self.get_call_result(attr.value, (root, self.being_assigned), node=node)
+                self._record_type_attr_set_for_value(
+                    root, node.attr, node, self.being_assigned
+                )
+                self._record_synthetic_attr_set(node, root)
             return
         transformed_attribute_types = self._get_transformed_attribute_types(
             attr.raw_value
@@ -14413,36 +14465,20 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         )
         return True
 
-    def _check_deprecated_property_getter(
-        self, node: ast.Attribute, root_value: Value
-    ) -> None:
-        if self._is_class_object_attribute_root(root_value) is True:
-            return
-        message = self._property_deprecation_message(
-            root_value, node.attr, is_setter=False
-        )
-        if message is None:
-            return
-        self._show_error_if_checking(
-            node,
-            f"Property getter {node.attr!r} is deprecated: {message}",
-            error_code=ErrorCode.deprecated,
-        )
-
     # TODO: move relevant information into the type object
-    def _check_deprecated_property_setter(
-        self, node: ast.Attribute, root_value: Value
+    def _check_deprecated_property_accessor(
+        self, node: ast.Attribute, root_value: Value, access_kind: PropertyAccessKind
     ) -> None:
         if self._is_class_object_attribute_root(root_value) is True:
             return
         message = self._property_deprecation_message(
-            root_value, node.attr, is_setter=True
+            root_value, node.attr, access_kind=access_kind
         )
         if message is None:
             return
         self._show_error_if_checking(
             node,
-            f"Property setter {node.attr!r} is deprecated: {message}",
+            f"Property {access_kind.value} {node.attr!r} is deprecated: {message}",
             error_code=ErrorCode.deprecated,
         )
 
@@ -14460,7 +14496,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             yield class_key
 
     def _deprecation_message_for_attribute(
-        self, root_value: Value, attr_name: str, *, is_property: bool, is_setter: bool
+        self,
+        root_value: Value,
+        attr_name: str,
+        *,
+        property_access_kind: PropertyAccessKind | None,
     ) -> str | None:
         for class_key in self._iter_distinct_attribute_root_class_keys(root_value):
             match = self._get_type_object_attribute_match_for_class_key(
@@ -14470,17 +14510,13 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 continue
             _, attribute = match
             symbol = attribute.symbol
-            if is_property:
+            if property_access_kind is not None:
                 if symbol.property_info is None:
                     continue
-                if is_setter:
-                    if symbol.property_info.fset is None:
-                        return None
-                    return symbol.property_info.fset.deprecation_message
-                else:
-                    if symbol.property_info.fget is None:
-                        return None
-                    return symbol.property_info.fget.deprecation_message
+                accessor = symbol.property_info.get_accessor(property_access_kind)
+                if accessor is None:
+                    return None
+                return accessor.deprecation_message
             if symbol.property_info is not None:
                 continue
             if symbol.deprecation_message is not None:
@@ -14493,14 +14529,14 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         self, root_value: Value, attr_name: str
     ) -> str | None:
         return self._deprecation_message_for_attribute(
-            root_value, attr_name, is_property=False, is_setter=False
+            root_value, attr_name, property_access_kind=None
         )
 
     def _property_deprecation_message(
-        self, root_value: Value, attr_name: str, *, is_setter: bool
+        self, root_value: Value, attr_name: str, *, access_kind: PropertyAccessKind
     ) -> str | None:
         return self._deprecation_message_for_attribute(
-            root_value, attr_name, is_property=True, is_setter=is_setter
+            root_value, attr_name, property_access_kind=access_kind
         )
 
     def _property_attr_candidates(
@@ -16826,6 +16862,25 @@ def _mangle_class_attribute_name(class_name: str, attribute_name: str) -> str:
     if attribute_name.startswith("__") and not attribute_name.endswith("__"):
         return f"_{class_name}{attribute_name}"
     return attribute_name
+
+
+def _property_mutator(node: FunctionNode) -> tuple[PropertyAccessKind, str] | None:
+    if isinstance(node, ast.Lambda):
+        return None
+    for decorator in node.decorator_list:
+        # TODO: this is not a precise way to recognize property mutators
+        if (
+            isinstance(decorator, ast.Attribute)
+            and decorator.attr in {"setter", "deleter"}
+            and isinstance(decorator.value, ast.Name)
+        ):
+            access_kind = (
+                PropertyAccessKind.write
+                if decorator.attr == "setter"
+                else PropertyAccessKind.delete
+            )
+            return access_kind, decorator.value.id
+    return None
 
 
 def _class_body_attribute_names(node: ast.ClassDef) -> Iterable[str]:

--- a/pycroscope/test_arg_spec.py
+++ b/pycroscope/test_arg_spec.py
@@ -8,7 +8,13 @@ from typing_extensions import ParamSpec, Self, TypeVar, TypeVarTuple
 
 from .checker import Checker
 from .maybe_asynq import asynq
-from .signature import BoundMethodSignature, ParameterKind, Signature, SigParameter
+from .signature import (
+    BoundMethodSignature,
+    OverloadedSignature,
+    ParameterKind,
+    Signature,
+    SigParameter,
+)
 from .stacked_scopes import Composite
 from .test_name_check_visitor import (
     ConfiguredNameCheckVisitor,
@@ -75,6 +81,23 @@ def test_get_type_parameters_ignores_non_iterable_runtime_type_params() -> None:
         __type_params__ = property(lambda self: ())
 
     assert checker.arg_spec_cache.get_type_parameters(Weird) == []
+
+
+def test_get_argspec_preserves_overload_only_callable_registry(monkeypatch) -> None:
+    from . import arg_spec
+
+    def callback(value: int) -> int: ...
+
+    first_overload = callback
+
+    def callback(value: str) -> str: ...
+
+    overloads = [first_overload, callback]
+    checker = Checker()
+    monkeypatch.setattr(arg_spec, "_GET_OVERLOADS", [lambda _: overloads])
+    signature = checker.arg_spec_cache.get_argspec(first_overload)
+    assert isinstance(signature, OverloadedSignature)
+    assert len(signature.signatures) == 2
 
 
 @skip_before((3, 12))

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1,12 +1,12 @@
 # static analysis: ignore
 
 import sys
-from typing import Generic, TypeVar, overload
+from typing import Generic, TypeVar
 
 import pytest
 from typing_extensions import assert_type, deprecated
 
-from .extensions import LiteralOnly
+from .extensions import LiteralOnly, overload
 from .test_name_check_visitor import TestNameCheckVisitorBase
 from .test_node_visitor import (
     assert_passes,

--- a/pycroscope/test_attributes.py
+++ b/pycroscope/test_attributes.py
@@ -1,9 +1,10 @@
 # static analysis: ignore
 
 import sys
+from typing import Generic, TypeVar, overload
 
 import pytest
-from typing_extensions import assert_type
+from typing_extensions import assert_type, deprecated
 
 from .extensions import LiteralOnly
 from .test_name_check_visitor import TestNameCheckVisitorBase
@@ -34,6 +35,47 @@ EXPECTED_ASCII_TYPEVARS = TypeVarMap(
         )
     }
 )
+
+_T = TypeVar("_T")
+
+
+class _RuntimeOverloadedProperty(Generic[_T]):
+    """Imported fixture that exercises runtime property metadata construction."""
+
+    @property
+    @overload
+    def value(self: "_RuntimeOverloadedProperty[int]") -> int: ...
+
+    @property
+    @overload
+    def value(self: "_RuntimeOverloadedProperty[str]") -> str: ...
+
+    @property
+    def value(self) -> int | str:
+        return 1
+
+    @value.setter
+    @overload
+    def value(self: "_RuntimeOverloadedProperty[int]", value: int) -> None: ...
+
+    @value.setter
+    @overload
+    def value(self: "_RuntimeOverloadedProperty[str]", value: str) -> None: ...
+
+    @value.setter
+    def value(self, value: int | str) -> None: ...
+
+    @value.deleter
+    @overload
+    @deprecated("deleting the int fixture is deprecated")
+    def value(self: "_RuntimeOverloadedProperty[int]") -> None: ...
+
+    @value.deleter
+    @overload
+    def value(self: "_RuntimeOverloadedProperty[str]") -> None: ...
+
+    @value.deleter
+    def value(self) -> None: ...
 
 
 class TestAttributes(TestNameCheckVisitorBase):
@@ -374,6 +416,189 @@ class TestAttributes(TestNameCheckVisitorBase):
 
         def use_it():
             assert_type(Unhashable().prop, Any)
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_overloaded_property_setter(self):
+        from typing import overload
+
+        from typing_extensions import assert_type, deprecated
+
+        class Capybara:
+            @property
+            def age(self) -> int:
+                return 1
+
+            @age.setter
+            @overload
+            @deprecated("None is deprecated")
+            def age(self, value: None) -> None: ...
+
+            @age.setter
+            @overload
+            def age(self, value: int) -> None: ...
+
+            @age.setter
+            def age(self, value: int | None) -> None: ...
+
+        def use_it(capybara: Capybara) -> None:
+            capybara.age = None  # E: deprecated
+            capybara.age = 1
+            capybara.age = "old"  # E: incompatible_argument
+            assert_type(capybara.age, int)
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_all_property_accessors_overloaded(self):
+        from typing import Generic, TypeVar, overload
+
+        from typing_extensions import assert_type, deprecated
+
+        T = TypeVar("T")
+
+        class Box(Generic[T]):
+            @property
+            @overload
+            def value(self: "Box[int]") -> int: ...
+
+            @property
+            @overload
+            def value(self: "Box[str]") -> str: ...
+
+            @property
+            def value(self) -> int | str:
+                return 1
+
+            @value.setter
+            @overload
+            def value(self: "Box[int]", value: int) -> None: ...
+
+            @value.setter
+            @overload
+            def value(self: "Box[str]", value: str) -> None: ...
+
+            @value.setter
+            def value(self, value: int | str) -> None: ...
+
+            @value.deleter
+            @overload
+            @deprecated("deleting an int box is deprecated")
+            def value(self: "Box[int]") -> None: ...
+
+            @value.deleter
+            @overload
+            def value(self: "Box[str]") -> None: ...
+
+            @value.deleter
+            def value(self) -> None: ...
+
+        def use_it(int_box: Box[int], str_box: Box[str]) -> None:
+            assert_type(int_box.value, int)
+            assert_type(str_box.value, str)
+            int_box.value = 1
+            int_box.value = "wrong"  # E: incompatible_argument
+            str_box.value = "right"
+            str_box.value = 1  # E: incompatible_argument
+            del int_box.value  # E: deprecated
+            del str_box.value
+
+    @assert_passes()
+    def test_runtime_overloaded_property_accessors(self):
+        from typing_extensions import assert_type
+
+        from pycroscope.test_attributes import _RuntimeOverloadedProperty
+
+        def use_it(
+            int_box: _RuntimeOverloadedProperty[int],
+            str_box: _RuntimeOverloadedProperty[str],
+        ) -> None:
+            assert_type(int_box.value, int)
+            assert_type(str_box.value, str)
+            int_box.value = 1
+            int_box.value = "wrong"  # E: incompatible_argument
+            str_box.value = "right"
+            str_box.value = 1  # E: incompatible_argument
+            del int_box.value  # E: deprecated
+            del str_box.value
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_property_deleter(self):
+        from typing_extensions import deprecated
+
+        class Capybara:
+            @property
+            def name(self) -> str:
+                return "Mindy"
+
+            @name.deleter
+            @deprecated("keep the name")
+            def name(self) -> None: ...
+
+        class BadDeleter:
+            @property
+            def name(self) -> str:
+                return "Mindy"
+
+            @name.deleter  # E: incompatible_argument
+            def name(self, extra: int) -> None: ...
+
+        class NoDeleter:
+            @property
+            def name(self) -> str:
+                return "Mindy"
+
+        def use_it(capybara: Capybara, bad: BadDeleter, missing: NoDeleter) -> None:
+            del capybara.name  # E: deprecated
+            del bad.name  # E: incompatible_call
+            del missing.name  # E: incompatible_assignment
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_property_setter_type_can_differ_from_getter_type(self):
+        from typing_extensions import assert_type
+
+        class Capybara:
+            @property
+            def name(self) -> int:
+                return 1
+
+            @name.setter
+            def name(self, value: str) -> None: ...
+
+        def use_it(capybara: Capybara) -> None:
+            capybara.name = "Mindy"
+            capybara.name = 1  # E: incompatible_argument
+            assert_type(capybara.name, int)
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_property_decorator_recognized_by_value(self):
+        from typing_extensions import assert_type
+
+        property_alias = property
+
+        class Capybara:
+            @property_alias
+            def name(self) -> str:
+                return "Mindy"
+
+        def use_it(capybara: Capybara) -> None:
+            assert_type(capybara.name, str)
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_unrelated_decorator_named_property(self):
+        from typing import TypeVar
+
+        from typing_extensions import assert_type
+
+        T = TypeVar("T")
+
+        def property(function: T) -> T:
+            return function
+
+        class Capybara:
+            @property
+            def name(self) -> str:
+                return "Mindy"
+
+        def use_it(capybara: Capybara) -> None:
+            assert_type(capybara.name(), str)
 
     @assert_passes()
     def test_protocol_property_assignment_does_not_internal_error_in_function_scope(

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -91,6 +91,7 @@ from .value import (
     PartialValue,
     PartialValueOperation,
     PredicateValue,
+    PropertyAccessKind,
     PropertyInfo,
     Qualifier,
     SequenceValue,
@@ -240,6 +241,8 @@ class AttributePolicy:
     visitor: "pycroscope.name_check_visitor.NameCheckVisitor | None" = None
     node: ast.AST | None = None
     receiver_composite: Composite | None = None
+    property_access: PropertyAccessKind = PropertyAccessKind.read
+    """Which accessor to resolve when the attribute is a property."""
 
     def get_receiver_instance(self, ctx: CanAssignContext) -> Value:
         if self.on_class:
@@ -600,7 +603,9 @@ class TypeObject:
 
         direct_symbols: dict[str, ClassSymbol] = {}
         if isinstance(self.typ, type):
-            type_object_builder.add_runtime_declared_symbols(self.typ, direct_symbols)
+            type_object_builder.add_runtime_declared_symbols(
+                self.typ, direct_symbols, self._checker.arg_spec_cache
+            )
         if self._virtual_symbols is not None:
             _add_synthetic_declared_symbols(self._virtual_symbols, direct_symbols)
         synthetic_symbols: Mapping[str, ClassSymbol] = (
@@ -1024,7 +1029,7 @@ class TypeObject:
         self.set_direct_bases((TypedValue(tuple),))
         declared_symbols: dict[str, ClassSymbol] = {}
         type_object_builder.add_runtime_declared_symbols(
-            runtime_class, declared_symbols
+            runtime_class, declared_symbols, self._checker.arg_spec_cache
         )
         self.replace_virtual_symbols(declared_symbols)
         if namedtuple_fields:
@@ -2590,9 +2595,17 @@ def _apply_descriptor_protocol_to_property(
         return _make_resolved_attribute(
             merged_attribute,
             value=merged_attribute.initializer or TypedValue(property),
-            is_property=False,
+            is_property=policy.property_access is not PropertyAccessKind.read,
         )
-    if property_info.fget is None or property_info.fget.initializer is None:
+    if policy.property_access is not PropertyAccessKind.read:
+        accessor = property_info.get_accessor(policy.property_access)
+        if accessor is None or accessor.initializer is None:
+            value = AnyValue(AnySource.inference)
+        else:
+            value = accessor.initializer
+        return _make_resolved_attribute(merged_attribute, value=value, is_property=True)
+    getter = property_info.get_accessor(PropertyAccessKind.read)
+    if getter is None or getter.initializer is None:
         return _make_error_attribute(
             merged_attribute,
             CanAssignError(
@@ -2602,7 +2615,7 @@ def _apply_descriptor_protocol_to_property(
     receiver_arg = policy.get_self_value(
         ctx, is_metaclass=merged_attribute.is_metaclass_owner
     )
-    fget = property_info.fget.initializer
+    fget = getter.initializer
     value = _make_call(fget, (receiver_arg,), policy=policy, ctx=ctx)
     return _make_resolved_attribute(merged_attribute, value=value, is_property=True)
 

--- a/pycroscope/type_object_builder.py
+++ b/pycroscope/type_object_builder.py
@@ -303,7 +303,9 @@ def iter_base_type_values_from_simple(
         assert_never(value)
 
 
-def add_runtime_declared_symbols(typ: type, symbols: dict[str, ClassSymbol]) -> None:
+def add_runtime_declared_symbols(
+    typ: type, symbols: dict[str, ClassSymbol], arg_spec_cache: ArgSpecCache
+) -> None:
     class_dict = safe_getattr(typ, "__dict__", None)
     namedtuple_fields = frozenset(_runtime_namedtuple_field_names(typ))
     runtime_dataclass_fields = {
@@ -325,7 +327,7 @@ def add_runtime_declared_symbols(typ: type, symbols: dict[str, ClassSymbol]) -> 
             qualifiers=frozenset({Qualifier.ReadOnly}),
             is_instance_only=True,
             property_info=(
-                _runtime_property_info(property_value.val, typ)
+                _runtime_property_info(property_value.val, typ, arg_spec_cache)
                 if property_value is not None
                 and isinstance(property_value.val, property)
                 else None
@@ -365,7 +367,7 @@ def add_runtime_declared_symbols(typ: type, symbols: dict[str, ClassSymbol]) -> 
                 continue
             existing = symbols.get(name)
             symbols[name] = _symbol_from_runtime_member(
-                raw_value, typ, existing=existing
+                raw_value, typ, arg_spec_cache, existing=existing
             )
 
     try:
@@ -393,7 +395,10 @@ def add_runtime_declared_symbols(typ: type, symbols: dict[str, ClassSymbol]) -> 
 
 
 def _symbol_from_runtime_member(
-    raw_value: object, owner: type, existing: ClassSymbol | None = None
+    raw_value: object,
+    owner: type,
+    arg_spec_cache: ArgSpecCache,
+    existing: ClassSymbol | None = None,
 ) -> ClassSymbol:
     function_decorators = set()
     wrapped_method_kind = _get_runtime_wrapped_method_kind(raw_value, owner)
@@ -431,7 +436,7 @@ def _symbol_from_runtime_member(
         and (existing is None or existing.annotation is None),
         deprecation_message=_runtime_deprecation_message(raw_value),
         function_decorators=frozenset(function_decorators),
-        property_info=_runtime_property_info(raw_value, owner),
+        property_info=_runtime_property_info(raw_value, owner, arg_spec_cache),
         initializer=_runtime_member_value(raw_value, owner),
         dataclass_field=existing.dataclass_field if existing is not None else None,
     )
@@ -520,27 +525,43 @@ def _is_runtime_member_final(raw_value: object) -> bool:
 UNKNOWN_SYMBOL = ClassSymbol(initializer=AnyValue(AnySource.unannotated))
 
 
-def _runtime_property_info(raw_value: object, owner: type) -> PropertyInfo | None:
+def _runtime_property_info(
+    raw_value: object, owner: type, arg_spec_cache: ArgSpecCache
+) -> PropertyInfo | None:
     if isinstance(raw_value, types.GetSetDescriptorType):
         return PropertyInfo(
             fget=UNKNOWN_SYMBOL, fset=UNKNOWN_SYMBOL, fdel=UNKNOWN_SYMBOL
         )
     if not isinstance(raw_value, property):
         return None
-    if raw_value.fget is None:
-        fget = None
-    else:
-        fget = _symbol_from_runtime_member(raw_value.fget, owner)
-    if raw_value.fset is None:
-        fset = None
-    else:
-        fset = _symbol_from_runtime_member(raw_value.fset, owner)
-    if raw_value.fdel is None:
-        fdel = None
-    else:
-        fdel = _symbol_from_runtime_member(raw_value.fdel, owner)
+    return PropertyInfo(
+        fget=_runtime_property_accessor_symbol(
+            raw_value, raw_value.fget, owner, arg_spec_cache
+        ),
+        fset=_runtime_property_accessor_symbol(
+            raw_value, raw_value.fset, owner, arg_spec_cache
+        ),
+        fdel=_runtime_property_accessor_symbol(
+            raw_value, raw_value.fdel, owner, arg_spec_cache
+        ),
+    )
 
-    return PropertyInfo(fget=fget, fset=fset, fdel=fdel)
+
+def _runtime_property_accessor_symbol(
+    prop: property,
+    accessor: Callable[..., object] | None,
+    owner: type,
+    arg_spec_cache: ArgSpecCache,
+) -> ClassSymbol | None:
+    if accessor is None:
+        return None
+    symbol = _symbol_from_runtime_member(accessor, owner, arg_spec_cache)
+    overload_signature = arg_spec_cache.get_property_accessor_overload_signature(
+        prop, accessor
+    )
+    if overload_signature is None:
+        return symbol
+    return replace(symbol, initializer=CallableValue(overload_signature))
 
 
 def _runtime_deprecation_message(raw_value: object) -> str | None:

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -3774,12 +3774,34 @@ class DataclassFieldInfo:
             yield from self.converter_input_type.walk_values()
 
 
+class PropertyAccessKind(enum.Enum):
+    read = "getter"
+    write = "setter"
+    delete = "deleter"
+
+
 @dataclass(frozen=True, kw_only=True)
 class PropertyInfo:
     # Can be None if a property is manually constructed (property(fset=...))
     fget: "ClassSymbol | None"
     fset: "ClassSymbol | None" = None
     fdel: "ClassSymbol | None" = None
+
+    def get_accessor(self, kind: PropertyAccessKind) -> "ClassSymbol | None":
+        if kind is PropertyAccessKind.read:
+            return self.fget
+        if kind is PropertyAccessKind.write:
+            return self.fset
+        return self.fdel
+
+    def with_accessor(
+        self, kind: PropertyAccessKind, accessor: "ClassSymbol"
+    ) -> "PropertyInfo":
+        if kind is PropertyAccessKind.read:
+            return replace(self, fget=accessor)
+        if kind is PropertyAccessKind.write:
+            return replace(self, fset=accessor)
+        return replace(self, fdel=accessor)
 
     def substitute_typevars(self, typevars: TypeVarMap) -> "PropertyInfo":
         return PropertyInfo(


### PR DESCRIPTION
Fixes #509.

Runtime overload registries are keyed by module and qualified name, so property getters, setters, and deleters with the same name can share one overload entry. Split those overloads using the concrete accessor implementations as source boundaries and preserve the resulting signatures in runtime and synthetic property metadata.

Property writes now call the setter signature without changing the getter's read type, and property deletion calls the deleter signature. This also preserves per-overload deprecation reporting and recognizes `property` decorators by inferred value rather than AST spelling.

Includes a standalone Scriv changelog fragment.
