### PR TITLE
Fix TypedDict kwargs forwarding

### DIFF
--- a/changelog.d/20260813_100158_jelle.zijlstra_HEAD.md
+++ b/changelog.d/20260813_100158_jelle.zijlstra_HEAD.md
@@ -1,0 +1,1 @@
+- Preserve open and explicit-extra-item TypedDict tails when forwarding `**kwargs` or comparing callables, so incompatible typed destinations are rejected while closed TypedDicts remain exact.

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -1430,12 +1430,15 @@ class Signature:
                         dict, [TypedValue(str), AnyValue(AnySource.ellipsis_callable)]
                     )
                 elif actual_args.star_kwargs is not None:
-                    value_value = unite_values(
-                        *(pair.value for pair in kv_pairs), actual_args.star_kwargs
+                    kv_pairs.append(
+                        KVPair(
+                            TypedValue(str),
+                            actual_args.star_kwargs,
+                            is_many=True,
+                            is_required=actual_args.kwargs_required,
+                        )
                     )
-                    star_kwargs_value = GenericValue(
-                        dict, [TypedValue(str), value_value]
-                    )
+                    star_kwargs_value = DictIncompleteValue(dict, kv_pairs)
                 else:
                     if not kv_pairs:
                         star_kwargs_value = DictIncompleteValue(dict, [])
@@ -1983,7 +1986,9 @@ class Signature:
             self, other, RelationContext(Relation.ASSIGNABLE, ctx, None)
         )
 
-    def _expand_typed_dict_kwargs(self) -> "Signature":
+    def _expand_typed_dict_kwargs(
+        self, *, include_open_extras: bool = False
+    ) -> "Signature":
         params: list[SigParameter] = []
         expanded = False
         for param in self.parameters.values():
@@ -2003,13 +2008,28 @@ class Signature:
                             annotation=entry.typ,
                         )
                     )
-                if annotation.extra_keys is not None:
+                if (
+                    annotation.extra_keys is not None
+                    and annotation.extra_keys is not NO_RETURN_VALUE
+                ):
+                    extra_keys = annotation.extra_keys
+                elif include_open_extras and annotation.extra_keys is None:
+                    extra_keys = TypedValue(object)
+                else:
+                    extra_keys = None
+                if extra_keys is not None:
+                    extra_param_name = param.name
+                    used_param_names = {existing.name for existing in params}
+                    unnamed_index = len(params)
+                    while extra_param_name in used_param_names:
+                        extra_param_name = f"@{unnamed_index}"
+                        unnamed_index += 1
                     params.append(
                         SigParameter(
-                            param.name,
+                            extra_param_name,
                             ParameterKind.VAR_KEYWORD,
                             annotation=GenericValue(
-                                dict, [TypedValue(str), annotation.extra_keys]
+                                dict, [TypedValue(str), extra_keys]
                             ),
                         )
                     )
@@ -2567,6 +2587,7 @@ def preprocess_args(
                 continue
             items = {}
             extra_values = []
+            extra_kwargs_required: list[bool | None] = []
             if arg.value is NO_RETURN_VALUE:
                 new_value = GenericValue(dict, [TypedValue(str), NO_RETURN_VALUE])
                 processed_args.append((Composite(new_value), KWARGS))
@@ -2578,9 +2599,10 @@ def preprocess_args(
                 result = _preprocess_kwargs_no_mvv(subval, ctx)
                 if result is None:
                     return None
-                new_items, new_value = result
+                new_items, new_value, new_kwargs_required = result
                 if new_value is not None:
                     extra_values.append(new_value)
+                    extra_kwargs_required.append(new_kwargs_required)
                 for key, (required, value) in new_items.items():
                     if key in items:
                         old_required, old_value = items[key]
@@ -2597,7 +2619,13 @@ def preprocess_args(
                 else:
                     processed_args.append((Composite(value), PossibleArg(key)))
             if extra_values:
-                kwargs_requireds.append(not items)
+                kwargs_requireds.append(
+                    any(required is True for required in extra_kwargs_required)
+                    or (
+                        not items
+                        and any(required is None for required in extra_kwargs_required)
+                    )
+                )
                 new_value = GenericValue(
                     dict, [TypedValue(str), unite_values(*extra_values)]
                 )
@@ -2690,27 +2718,42 @@ def preprocess_args(
 
 def _preprocess_kwargs_no_mvv(
     value: Value, ctx: CheckCallContext
-) -> tuple[dict[str, tuple[bool, Value]], Value | None] | None:
+) -> tuple[dict[str, tuple[bool, Value]], Value | None, bool | None] | None:
     """Preprocess a Value passed as **kwargs.
 
     Two possible return types:
 
     - None if there was a blocking error (the passed in type is not a mapping).
-    - A pair of two values:
+    - A tuple of three values:
         - An {argument: (required, Value)} dict if we know the precise arguments (e.g.,
             for a TypedDict).
         - A single Value if the argument is a mapping, but we don't know all the precise keys.
             This is None if all the keys are known. The Value represents the values in the
             mapping (all the keys must be strings).
+        - Whether the possible extra keys must be consumed by a ``**kwargs``
+            parameter. This is true for an explicit ``extra_items`` type, false
+            for an open TypedDict, and None for other mapping values, whose
+            existing behavior depends on whether any keys are known.
 
     """
     value = replace_known_sequence_value(value)
     if isinstance(value, TypedDictValue):
-        return {
-            key: (entry.required, entry.typ) for key, entry in value.items.items()
-        }, None
+        items = {key: (entry.required, entry.typ) for key, entry in value.items.items()}
+        if value.extra_keys is NO_RETURN_VALUE:
+            return items, None, False
+        if value.extra_keys is None:
+            # Open TypedDicts may contain hidden values of type object. We retain
+            # those values so typed parameters are checked, but allow the tail to
+            # go unused to preserve the ecosystem-compatible behavior for calls
+            # to an exact signature.
+            return items, TypedValue(object), False
+        return items, value.extra_keys, True
     elif isinstance(value, DictIncompleteValue):
-        return _preprocess_kwargs_kv_pairs(value.kv_pairs, ctx)
+        result = _preprocess_kwargs_kv_pairs(value.kv_pairs, ctx)
+        if result is None:
+            return None
+        items, extra_value = result
+        return items, extra_value, None
     else:
         mapping_tv_map = relations.get_tv_map(
             MappingValue,
@@ -2728,9 +2771,13 @@ def _preprocess_kwargs_no_mvv(
         value_type = mapping_tv_map.get_typevar(
             VParam, AnyValue(AnySource.generic_argument)
         )
-        return _preprocess_kwargs_kv_pairs(
+        result = _preprocess_kwargs_kv_pairs(
             [KVPair(key_type, value_type, is_many=True)], ctx
         )
+        if result is None:
+            return None
+        items, extra_value = result
+        return items, extra_value, None
 
 
 def _preprocess_kwargs_kv_pairs(
@@ -4095,18 +4142,22 @@ def signatures_have_relation(
     my_kwargs = left.get_param_of_kind(ParameterKind.VAR_KEYWORD)
     their_kwargs = right.get_param_of_kind(ParameterKind.VAR_KEYWORD)
     their_ellipsis = right.get_param_of_kind(ParameterKind.ELLIPSIS)
-    if my_kwargs is not None and isinstance(my_kwargs.get_annotation(), TypedDictValue):
+    my_kwargs_annotation = my_kwargs.get_annotation() if my_kwargs is not None else None
+    if isinstance(my_kwargs_annotation, TypedDictValue):
         accepts_arbitrary_keywords = (
             their_kwargs is not None
             or their_ellipsis is not None
             or right.get_param_of_kind(ParameterKind.PARAM_SPEC) is not None
         )
-        if not accepts_arbitrary_keywords:
+        if (
+            my_kwargs_annotation.extra_keys is not NO_RETURN_VALUE
+            and not accepts_arbitrary_keywords
+        ):
             return CanAssignError(
                 f"{right} does not accept arbitrary keyword arguments"
             )
-    left = left._expand_typed_dict_kwargs()
-    right = right._expand_typed_dict_kwargs()
+    left = left._expand_typed_dict_kwargs(include_open_extras=True)
+    right = right._expand_typed_dict_kwargs(include_open_extras=True)
 
     their_return = right.return_value
     my_return = left.return_value

--- a/pycroscope/test_signature.py
+++ b/pycroscope/test_signature.py
@@ -2014,9 +2014,7 @@ class TestUnpack(TestNameCheckVisitorBase):
 
     @assert_passes(run_in_both_module_modes=True)
     def test_kwargs_forwarding_respects_closed_and_extra_items(self):
-        from typing import Never
-
-        from typing_extensions import ReadOnly, TypedDict, Unpack
+        from typing_extensions import Never, ReadOnly, TypedDict, Unpack
 
         class Open(TypedDict):
             name: str
@@ -2120,9 +2118,9 @@ class TestUnpack(TestNameCheckVisitorBase):
 
     @assert_passes(run_in_both_module_modes=True)
     def test_callable_assignment_respects_closed_and_extra_items(self):
-        from typing import Never, Protocol
+        from typing import Protocol
 
-        from typing_extensions import ReadOnly, TypedDict, Unpack
+        from typing_extensions import Never, ReadOnly, TypedDict, Unpack
 
         class Open(TypedDict):
             name: str

--- a/pycroscope/test_signature.py
+++ b/pycroscope/test_signature.py
@@ -433,8 +433,7 @@ class TestCanAssign:
             {"a": TypedDictEntry(TypedValue(int)), "b": TypedDictEntry(TypedValue(int))}
         )
         # This is still OK because TypedDicts are allowed to have extra keys.
-        # TODO change to can
-        self.cannot(
+        self.can(
             three_ints_sig,
             Signature.make([P("a", annotation=smaller_td, kind=K.VAR_KEYWORD)]),
         )
@@ -2012,6 +2011,185 @@ class TestUnpack(TestNameCheckVisitorBase):
             capybara()  # E: incompatible_call
             capybara(a="x", b="x")  # E: incompatible_argument
             capybara(a=1, b="x", c=3)  # E: incompatible_call
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_kwargs_forwarding_respects_closed_and_extra_items(self):
+        from typing import Never
+
+        from typing_extensions import ReadOnly, TypedDict, Unpack
+
+        class Open(TypedDict):
+            name: str
+
+        class ExplicitOpen(TypedDict, closed=False):
+            name: str
+
+        class Closed(TypedDict, closed=True):
+            name: str
+
+        class NeverExtra(TypedDict, extra_items=Never):
+            name: str
+
+        class ExtraInt(TypedDict, extra_items=int):
+            name: str
+
+        class ReadOnlyExtraInt(TypedDict, extra_items=ReadOnly[int]):
+            name: str
+
+        def exact(name: str) -> None: ...
+
+        def object_tail(name: str, **kwargs: object) -> None: ...
+
+        def int_tail(name: str, **kwargs: int) -> None: ...
+
+        def str_tail(name: str, **kwargs: str) -> None: ...
+
+        def optional_str(name: str, *, label: str = "", **kwargs: int) -> None: ...
+
+        def optional_int(name: str, *, label: int = 0, **kwargs: int) -> None: ...
+
+        def forward_open(**kwargs: Unpack[Open]) -> None:
+            exact(**kwargs)
+            object_tail(**kwargs)
+            int_tail(**kwargs)  # E: incompatible_argument
+            optional_str(**kwargs)  # E: incompatible_argument
+
+        def forward_explicit_open(**kwargs: Unpack[ExplicitOpen]) -> None:
+            exact(**kwargs)
+            int_tail(**kwargs)  # E: incompatible_argument
+
+        def forward_closed(**kwargs: Unpack[Closed]) -> None:
+            exact(**kwargs)
+            int_tail(**kwargs)
+
+        def forward_never(**kwargs: Unpack[NeverExtra]) -> None:
+            exact(**kwargs)
+            int_tail(**kwargs)
+
+        def forward_extra(**kwargs: Unpack[ExtraInt]) -> None:
+            exact(**kwargs)  # E: incompatible_call
+            object_tail(**kwargs)
+            str_tail(**kwargs)  # E: incompatible_argument
+            int_tail(**kwargs)
+            optional_str(**kwargs)  # E: incompatible_argument
+            optional_int(**kwargs)
+
+        def forward_readonly_extra(**kwargs: Unpack[ReadOnlyExtraInt]) -> None:
+            exact(**kwargs)  # E: incompatible_call
+            object_tail(**kwargs)
+            str_tail(**kwargs)  # E: incompatible_argument
+            int_tail(**kwargs)
+            optional_str(**kwargs)  # E: incompatible_argument
+            optional_int(**kwargs)
+
+        def direct(
+            opened: Open,
+            explicit_open: ExplicitOpen,
+            closed: Closed,
+            never: NeverExtra,
+            extra: ExtraInt,
+            readonly_extra: ReadOnlyExtraInt,
+        ) -> None:
+            exact(**opened)
+            int_tail(**opened)  # E: incompatible_argument
+            exact(**explicit_open)
+            int_tail(**explicit_open)  # E: incompatible_argument
+            exact(**closed)
+            exact(**never)
+            exact(**extra)  # E: incompatible_call
+            object_tail(**extra)
+            str_tail(**extra)  # E: incompatible_argument
+            int_tail(**extra)
+            optional_str(**extra)  # E: incompatible_argument
+            exact(**readonly_extra)  # E: incompatible_call
+            str_tail(**readonly_extra)  # E: incompatible_argument
+
+        def union_calls(
+            open_or_closed: Open | Closed,
+            extra_or_closed: ExtraInt | Closed,
+            open_or_extra: Open | ExtraInt,
+        ) -> None:
+            exact(**open_or_closed)
+            int_tail(**open_or_closed)  # E: incompatible_argument
+            exact(**extra_or_closed)  # E: incompatible_call
+            object_tail(**extra_or_closed)
+            int_tail(**extra_or_closed)
+            exact(**open_or_extra)  # E: incompatible_call
+            object_tail(**open_or_extra)
+            int_tail(**open_or_extra)  # E: incompatible_argument
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_callable_assignment_respects_closed_and_extra_items(self):
+        from typing import Never, Protocol
+
+        from typing_extensions import ReadOnly, TypedDict, Unpack
+
+        class Open(TypedDict):
+            name: str
+
+        class ExplicitOpen(TypedDict, closed=False):
+            name: str
+
+        class Closed(TypedDict, closed=True):
+            name: str
+
+        class NeverExtra(TypedDict, extra_items=Never):
+            name: str
+
+        class ExtraInt(TypedDict, extra_items=int):
+            name: str
+
+        class ReadOnlyExtraInt(TypedDict, extra_items=ReadOnly[int]):
+            name: str
+
+        class AcceptsOpen(Protocol):
+            def __call__(self, **kwargs: Unpack[Open]) -> None: ...
+
+        class AcceptsExplicitOpen(Protocol):
+            def __call__(self, **kwargs: Unpack[ExplicitOpen]) -> None: ...
+
+        class AcceptsClosed(Protocol):
+            def __call__(self, **kwargs: Unpack[Closed]) -> None: ...
+
+        class AcceptsNever(Protocol):
+            def __call__(self, **kwargs: Unpack[NeverExtra]) -> None: ...
+
+        class AcceptsExtraInt(Protocol):
+            def __call__(self, **kwargs: Unpack[ExtraInt]) -> None: ...
+
+        class AcceptsReadOnlyExtraInt(Protocol):
+            def __call__(self, **kwargs: Unpack[ReadOnlyExtraInt]) -> None: ...
+
+        def exact(name: str) -> None: ...
+
+        def object_tail(name: str, **kwargs: object) -> None: ...
+
+        def int_tail(name: str, **kwargs: int) -> None: ...
+
+        def str_tail(name: str, **kwargs: str) -> None: ...
+
+        def optional_str(name: str, *, label: str = "", **kwargs: int) -> None: ...
+
+        def optional_int(name: str, *, label: int = 0, **kwargs: int) -> None: ...
+
+        open_exact: AcceptsOpen = exact  # E: incompatible_assignment
+        open_object: AcceptsOpen = object_tail
+        open_int: AcceptsOpen = int_tail  # E: incompatible_assignment
+        explicit_open_exact: AcceptsExplicitOpen = exact  # E: incompatible_assignment
+        explicit_open_object: AcceptsExplicitOpen = object_tail
+        explicit_open_int: AcceptsExplicitOpen = int_tail  # E: incompatible_assignment
+        closed_exact: AcceptsClosed = exact
+        never_exact: AcceptsNever = exact
+        extra_exact: AcceptsExtraInt = exact  # E: incompatible_assignment
+        extra_object: AcceptsExtraInt = object_tail
+        extra_int: AcceptsExtraInt = int_tail
+        extra_str: AcceptsExtraInt = str_tail  # E: incompatible_assignment
+        extra_optional_str: AcceptsExtraInt = optional_str  # E: incompatible_assignment
+        extra_optional_int: AcceptsExtraInt = optional_int
+        readonly_exact: AcceptsReadOnlyExtraInt = exact  # E: incompatible_assignment
+        readonly_object: AcceptsReadOnlyExtraInt = object_tail
+        readonly_int: AcceptsReadOnlyExtraInt = int_tail
+        readonly_str: AcceptsReadOnlyExtraInt = str_tail  # E: incompatible_assignment
 
     @assert_passes()
     def test_invalid(self):


### PR DESCRIPTION
## Summary

- preserve possible extra-key value types when forwarding open and `extra_items` TypedDicts through `**kwargs`
- reject incompatible typed `**kwargs` destinations and optional-parameter collisions while continuing to allow open TypedDicts to exact signatures
- treat `closed=True` and `extra_items=Never` as exact for callable assignment, and add regression coverage for direct forwarding, unions, readonly extras, and callable variance

## Root cause

TypedDict call preprocessing discarded the possible extra-key tail, while callable comparison used a blanket requirement that every `Unpack[TypedDict]` destination be implemented by a callable with `**kwargs`. This made explicit extra items too permissive during calls and closed TypedDicts too restrictive during callable assignment.