### PR TITLE
Infer ParamSpec and TypeVarTuple variance

### DIFF
--- a/changelog.d/20260813_093342_jelle.zijlstra_type_parameter_variance_inference.md
+++ b/changelog.d/20260813_093342_jelle.zijlstra_type_parameter_variance_inference.md
@@ -1,0 +1,1 @@
+- Infer and enforce variance for `ParamSpec` and `TypeVarTuple`, including mixed PEP 695 generic classes and traditional declarations with explicit or inferred variance.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -49,18 +49,15 @@ from typing import (
 from weakref import WeakKeyDictionary
 
 import typing_extensions
-from typing_extensions import (
-    NoDefault,
-    ParamSpec,
-    Protocol,
-    TypedDict,
-    TypeIs,
-    runtime_checkable,
-)
+from typing_extensions import NoDefault, Protocol, TypedDict, TypeIs, runtime_checkable
 
 import pycroscope
 from pycroscope.annotated_types import get_annotated_types_extension
-from pycroscope.input_sig import FullSignature, InputSigValue
+from pycroscope.input_sig import (
+    FullSignature,
+    InputSigValue,
+    coerce_paramspec_specialization_to_input_sig,
+)
 from pycroscope.relations import (
     HashableProtoValue,
     Relation,
@@ -168,7 +165,7 @@ from .value import (
     bound_self_type_from_class_key,
     class_owner_from_key,
     get_single_typevartuple_param,
-    get_typevar_variance,
+    get_type_param_variance,
     iter_type_params_in_value,
     match_typevar_arguments,
     replace_fallback,
@@ -176,6 +173,7 @@ from .value import (
     stringify_object,
     type_param_to_value,
     typevartuple_binding_to_generic_args,
+    typevartuple_value_to_members,
     unite_values,
 )
 
@@ -988,10 +986,13 @@ def make_type_param_from_value(
                 name = _extract_type_param_name_arg(value)
                 if name is None:
                     return None
+                variance = _extract_partial_type_param_variance(value, ctx)
+                if variance is None:
+                    return None
                 ps = typing.cast(
                     ParamSpecLike,
                     _synthetic_type_param_for_partial_call(
-                        value, name, lambda name: ParamSpec(name)
+                        value, name, typing_extensions.ParamSpec
                     ),
                 )
                 active_type_param = ctx.active_type_params.get_type_param(ps)
@@ -1003,23 +1004,32 @@ def make_type_param_from_value(
                 else:
                     default = _paramspec_default_from_value(default_val, ctx)
                 return ParamSpecParam(
-                    ps, owner=ctx.new_type_param_owner, default=default
+                    ps,
+                    owner=ctx.new_type_param_owner,
+                    default=default,
+                    variance=variance,
                 )
             elif is_typing_name(runtime_val.typ, "TypeVarTuple"):
                 name, default = _extract_common_type_param_args(value, ctx)
                 if name is None:
                     return None
+                variance = _extract_partial_type_param_variance(value, ctx)
+                if variance is None:
+                    return None
                 tvt = typing.cast(
                     TypeVarTupleLike,
                     _synthetic_type_param_for_partial_call(
-                        value, name, lambda name: typing_extensions.TypeVarTuple(name)
+                        value, name, typing_extensions.TypeVarTuple
                     ),
                 )
                 active_type_param = ctx.active_type_params.get_type_param(tvt)
                 if active_type_param is not None:
                     return active_type_param
                 return TypeVarTupleParam(
-                    tvt, owner=ctx.new_type_param_owner, default=default
+                    tvt,
+                    owner=ctx.new_type_param_owner,
+                    default=default,
+                    variance=variance,
                 )
     typevartuple_param = get_single_typevartuple_param(value)
     if typevartuple_param is not None:
@@ -1217,22 +1227,15 @@ def _make_typevar_param_from_partial_call(
     name, default = _extract_common_type_param_args(value, ctx)
     if name is None:
         return None
-    infer_variance = _extract_boolean_arg(value, "infer_variance")
-    covariant = _extract_boolean_arg(value, "covariant")
-    contravariant = _extract_boolean_arg(value, "contravariant")
-    if covariant is None or contravariant is None:
+    variance = _extract_partial_type_param_variance(value, ctx)
+    if variance is None:
         return None
     tv = typing.cast(
         TypeVarType,
         _synthetic_type_param_for_partial_call(
             value,
             name,
-            lambda name: _make_synthetic_partial_typevar(
-                name,
-                covariant=covariant,
-                contravariant=contravariant,
-                infer_variance=bool(infer_variance),
-            ),
+            lambda name: _make_synthetic_partial_typevar(name, variance=variance),
         ),
     )
     active_type_param = ctx.active_type_params.get_type_param(tv)
@@ -1261,29 +1264,6 @@ def _make_typevar_param_from_partial_call(
         _show_type_param_call_error(
             ctx, "TypeVar cannot have both bound and constraints", value=value
         )
-    if infer_variance and (covariant or contravariant):
-        _show_type_param_call_error(
-            ctx,
-            "TypeVar cannot combine infer_variance with explicit variance",
-            value=value,
-            node=ctx.get_error_node(),
-        )
-    if covariant and contravariant:
-        _show_type_param_call_error(
-            ctx,
-            "Bivariant types are not supported",
-            value=value,
-            node=ctx.get_error_node(),
-        )
-    match (infer_variance, covariant, contravariant):
-        case (True, _, _):
-            variance = Variance.INFERRED
-        case (_, True, _):
-            variance = Variance.COVARIANT
-        case (_, _, True):
-            variance = Variance.CONTRAVARIANT
-        case _:
-            variance = Variance.INVARIANT
     type_param = TypeVarParam(
         tv,
         owner=ctx.new_type_param_owner,
@@ -1296,6 +1276,39 @@ def _make_typevar_param_from_partial_call(
     return type_param
 
 
+def _extract_partial_type_param_variance(
+    value: PartialCallValue, ctx: Context
+) -> Variance | None:
+    infer_variance = _extract_boolean_arg(value, "infer_variance")
+    covariant = _extract_boolean_arg(value, "covariant")
+    contravariant = _extract_boolean_arg(value, "contravariant")
+    if infer_variance is None or covariant is None or contravariant is None:
+        return None
+    if infer_variance and (covariant or contravariant):
+        _show_type_param_call_error(
+            ctx,
+            "Type parameter cannot combine infer_variance with explicit variance",
+            value=value,
+            node=ctx.get_error_node(),
+        )
+    if covariant and contravariant:
+        _show_type_param_call_error(
+            ctx,
+            "Bivariant types are not supported",
+            value=value,
+            node=ctx.get_error_node(),
+        )
+    if infer_variance:
+        variance = Variance.INFERRED
+    elif covariant:
+        variance = Variance.COVARIANT
+    elif contravariant:
+        variance = Variance.CONTRAVARIANT
+    else:
+        variance = Variance.INVARIANT
+    return variance
+
+
 def _make_partial_type_param_call(
     *, callee: Value, runtime_value: Value, arguments: dict[str, Value], node: ast.AST
 ) -> PartialCallValue:
@@ -1304,22 +1317,19 @@ def _make_partial_type_param_call(
     )
 
 
-def _make_synthetic_partial_typevar(
-    name: str, *, covariant: bool, contravariant: bool, infer_variance: bool
-) -> TypeVarType:
+def _make_synthetic_partial_typevar(name: str, *, variance: Variance) -> TypeVarType:
     try:
-        if infer_variance:
+        if variance is Variance.INFERRED:
             return typing.cast(
-                TypeVarType,
-                typing_extensions.TypeVar(
-                    name,
-                    covariant=covariant,
-                    contravariant=contravariant,
-                    infer_variance=True,
-                ),
+                TypeVarType, typing_extensions.TypeVar(name, infer_variance=True)
             )
         return typing.cast(
-            TypeVarType, TypeVar(name, covariant=covariant, contravariant=contravariant)
+            TypeVarType,
+            TypeVar(
+                name,
+                covariant=variance is Variance.COVARIANT,
+                contravariant=variance is Variance.CONTRAVARIANT,
+            ),
         )
     except Exception:
         return typing.cast(TypeVarType, TypeVar(name))
@@ -1395,12 +1405,16 @@ def make_type_param(
             bound=bound,
             constraints=constraints,
             default=default,
-            variance=get_typevar_variance(tv),
+            variance=get_type_param_variance(tv),
         )
     if is_instance_of_typing_name(tv, "ParamSpec"):
-        return ParamSpecParam(tv, owner=owner, default=default)
+        return ParamSpecParam(
+            tv, owner=owner, default=default, variance=get_type_param_variance(tv)
+        )
     if is_instance_of_typing_name(tv, "TypeVarTuple"):
-        return TypeVarTupleParam(tv, owner=owner, default=default)
+        return TypeVarTupleParam(
+            tv, owner=owner, default=default, variance=get_type_param_variance(tv)
+        )
     raise TypeError(f"Unsupported type parameter: {tv!r}")
 
 
@@ -1713,6 +1727,43 @@ def _type_from_value_type_alias_arg(
     return _type_from_alias_argument_value(arg, ctx)
 
 
+def type_generic_args_from_members(
+    type_params: Sequence[TypeParam], members: Sequence[Value], ctx: Context
+) -> list[Value]:
+    if len(type_params) == len(members) and all(
+        not isinstance(type_param, TypeVarTupleParam)
+        or _is_unpack_annotation_member(member)
+        for type_param, member in zip(type_params, members)
+    ):
+        return [
+            _type_from_value_type_alias_arg(member, type_param, ctx)
+            for type_param, member in zip(type_params, members)
+        ]
+    matched = match_typevar_arguments(type_params, members)
+    if matched is None:
+        return [_type_from_value(member, ctx) for member in members]
+    typed_members: list[Value] = []
+    for type_param, argument in matched:
+        if isinstance(type_param, TypeVarTupleParam):
+            if not isinstance(argument, TypeVarTupleBindingValue):
+                argument = TypeVarTupleBindingValue(
+                    typevartuple_value_to_members(argument)
+                )
+            typed_members.append(
+                TypeVarTupleBindingValue(
+                    tuple(
+                        (is_many, _type_from_alias_argument_value(member, ctx))
+                        for is_many, member in argument.binding
+                    )
+                )
+            )
+        else:
+            typed_members.append(
+                _type_from_value_type_alias_arg(argument, type_param, ctx)
+            )
+    return typed_members
+
+
 def _type_from_alias_argument_value(arg: Value, ctx: Context) -> Value:
     if type(arg) is TypedValue:
         return arg
@@ -1757,9 +1808,11 @@ def _normalize_paramspec_generic_arg_in_context(
     if isinstance(arg, InputSigValue):
         return arg
     if isinstance(arg, SequenceValue) and arg.typ in (list, tuple):
-        return arg
+        return coerce_paramspec_specialization_to_input_sig(arg)
     if arg == KnownValue(Ellipsis):
-        return AnyValue(AnySource.ellipsis_callable)
+        return coerce_paramspec_specialization_to_input_sig(
+            AnyValue(AnySource.ellipsis_callable)
+        )
     if isinstance(arg, AnyValue):
         return arg
     type_param = make_type_param_from_value(arg, ctx=ctx)
@@ -1770,7 +1823,9 @@ def _normalize_paramspec_generic_arg_in_context(
         assert isinstance(type_param, ParamSpecParam)
         return InputSigValue(type_param)
     if allow_flat_form:
-        return SequenceValue(tuple, [(False, arg)])
+        return coerce_paramspec_specialization_to_input_sig(
+            SequenceValue(tuple, [(False, arg)])
+        )
     ctx.show_error(
         "ParamSpec specialization must use list form, Concatenate[..., P], P, or ...",
         error_code=ErrorCode.invalid_annotation,
@@ -1788,7 +1843,11 @@ def normalize_paramspec_generic_args_in_context(
                     args[0], allow_flat_form=True, ctx=ctx
                 )
             ]
-        return [SequenceValue(tuple, [(False, arg) for arg in args])]
+        return [
+            coerce_paramspec_specialization_to_input_sig(
+                SequenceValue(tuple, [(False, arg) for arg in args])
+            )
+        ]
     if len(type_params) == len(args):
         return [
             (
@@ -1844,6 +1903,16 @@ def _canonicalize_generic_args_for_value(args: Sequence[Value]) -> list[Value]:
         else:
             canonical_args.append(arg)
     return canonical_args
+
+
+def _canonicalize_generic_args_for_type_params(
+    type_params: Sequence[TypeParam], args: Sequence[Value], ctx: Context
+) -> list[Value]:
+    normalized = normalize_paramspec_generic_args(type_params, args, ctx)
+    matched = match_typevar_arguments(type_params, normalized)
+    if matched is not None:
+        normalized = [argument for _, argument in matched]
+    return list(normalized)
 
 
 def _normalize_generic_unpack_members(
@@ -2044,8 +2113,7 @@ def _validate_type_alias_arg_values(
     )
     if matched_args is None:
         ctx.show_error(
-            f"Expected {len(type_params)} type arguments for type alias,"
-            f" got {len(args_vals)}",
+            f"Expected {len(type_params)} type arguments for type alias, got {len(args_vals)}",
             error_code=ErrorCode.invalid_specialization,
             node=node,
         )
@@ -2588,7 +2656,7 @@ def _type_from_subscripted_value(
                         evaluator=lambda root=root: root,
                         evaluate_type_params=lambda generic_type_params=tuple(
                             root_type_params
-                        ): generic_type_params,
+                        ): (generic_type_params),
                     )
                     return TypeAliasValue(
                         "<generic_alias>", "typing", alias, tuple(typed_members)
@@ -2643,7 +2711,10 @@ def _type_from_subscripted_value(
             and isinstance(typed_dict_type_params[0], TypeVarTupleParam)
         ):
             typed_members = [TypeVarTupleBindingValue(())]
-        elif len(typed_dict_type_params) == len(members):
+        elif len(typed_dict_type_params) == len(members) and not any(
+            isinstance(type_param, TypeVarTupleParam)
+            for type_param in typed_dict_type_params
+        ):
             typed_members = [
                 _type_from_value_type_alias_arg(elt, type_param, ctx)
                 for elt, type_param in zip(members, typed_dict_type_params)
@@ -2653,7 +2724,9 @@ def _type_from_subscripted_value(
                 root.class_key, typed_dict_type_params, members, ctx
             ):
                 return AnyValue(AnySource.error)
-            typed_members = [_type_from_value(elt, ctx) for elt in members]
+            typed_members = type_generic_args_from_members(
+                typed_dict_type_params, members, ctx
+            )
         typed_members = normalize_paramspec_generic_args(
             typed_dict_type_params, typed_members, ctx
         )
@@ -2683,7 +2756,10 @@ def _type_from_subscripted_value(
             and isinstance(synthetic_type_params[0], TypeVarTupleParam)
         ):
             typed_members = [TypeVarTupleBindingValue(())]
-        elif len(synthetic_type_params) == len(members):
+        elif len(synthetic_type_params) == len(members) and not any(
+            isinstance(type_param, TypeVarTupleParam)
+            for type_param in synthetic_type_params
+        ):
             typed_members = [
                 _type_from_value_type_alias_arg(elt, type_param, ctx)
                 for elt, type_param in zip(members, synthetic_type_params)
@@ -2693,12 +2769,14 @@ def _type_from_subscripted_value(
                 synthetic_typ, synthetic_type_params, members, ctx
             ):
                 return AnyValue(AnySource.error)
-            typed_members = [_type_from_value(elt, ctx) for elt in members]
-        typed_members = normalize_paramspec_generic_args(
-            synthetic_type_params, typed_members, ctx
-        )
+            typed_members = type_generic_args_from_members(
+                synthetic_type_params, members, ctx
+            )
         return GenericValue(
-            synthetic_typ, _canonicalize_generic_args_for_value(typed_members)
+            synthetic_typ,
+            _canonicalize_generic_args_for_type_params(
+                synthetic_type_params, typed_members, ctx
+            ),
         )
 
     if isinstance(root, TypedValue) and isinstance(root.typ, ClassOwner):
@@ -2719,7 +2797,10 @@ def _type_from_subscripted_value(
             and isinstance(synthetic_type_params_for_str[0], TypeVarTupleParam)
         ):
             typed_members = [TypeVarTupleBindingValue(())]
-        elif len(synthetic_type_params_for_str) == len(members):
+        elif len(synthetic_type_params_for_str) == len(members) and not any(
+            isinstance(type_param, TypeVarTupleParam)
+            for type_param in synthetic_type_params_for_str
+        ):
             typed_members = [
                 _type_from_value_type_alias_arg(elt, type_param, ctx)
                 for elt, type_param in zip(members, synthetic_type_params_for_str)
@@ -2729,12 +2810,14 @@ def _type_from_subscripted_value(
                 synthetic_typ, synthetic_type_params_for_str, members, ctx
             ):
                 return AnyValue(AnySource.error)
-            typed_members = [_type_from_value(elt, ctx) for elt in members]
-        typed_members = normalize_paramspec_generic_args(
-            synthetic_type_params_for_str, typed_members, ctx
-        )
+            typed_members = type_generic_args_from_members(
+                synthetic_type_params_for_str, members, ctx
+            )
         return GenericValue(
-            synthetic_typ, _canonicalize_generic_args_for_value(typed_members)
+            synthetic_typ,
+            _canonicalize_generic_args_for_type_params(
+                synthetic_type_params_for_str, typed_members, ctx
+            ),
         )
     if isinstance(root, TypeAliasValue):
         return specialize_type_alias_value(root, members, ctx)
@@ -2906,7 +2989,9 @@ def _type_from_subscripted_value(
             and isinstance(type_params[0], TypeVarTupleParam)
         ):
             typed_members = [TypeVarTupleBindingValue(())]
-        elif len(type_params) == len(members):
+        elif len(type_params) == len(members) and not any(
+            isinstance(type_param, TypeVarTupleParam) for type_param in type_params
+        ):
             typed_members = [
                 _type_from_value_type_alias_arg(elt, type_param, ctx)
                 for elt, type_param in zip(members, type_params)
@@ -2916,11 +3001,11 @@ def _type_from_subscripted_value(
                 root, type_params, members, ctx
             ):
                 return AnyValue(AnySource.error)
-            typed_members = [_type_from_value(elt, ctx) for elt in members]
-        typed_members = normalize_paramspec_generic_args(
-            type_params, typed_members, ctx
+            typed_members = type_generic_args_from_members(type_params, members, ctx)
+        return GenericValue(
+            root,
+            _canonicalize_generic_args_for_type_params(type_params, typed_members, ctx),
         )
-        return GenericValue(root, _canonicalize_generic_args_for_value(typed_members))
     elif is_typing_name(root, "ClassVar"):
         ctx.show_error("ClassVar[] used in unsupported context")
         return AnyValue(AnySource.error)
@@ -3465,17 +3550,16 @@ class _Visitor(ast.NodeVisitor):
                     "ParamSpec name must be a literal", node=node.args[0]
                 )
                 return AnyValue(AnySource.error)
-            default = NO_ARG_SENTINEL
-            for name, kwarg_value in kwarg_values:
-                if name == "default":
-                    default = kwarg_value
-                    continue
-                self.ctx.show_error(f"Unrecognized ParamSpec kwarg {name}", node=node)
+            arguments = _parse_variadic_type_param_call_kwargs(
+                kwarg_values, "ParamSpec", self.ctx, node
+            )
+            if arguments is None:
                 return AnyValue(AnySource.error)
+            arguments["name"] = name_val
             partial = _make_partial_type_param_call(
                 callee=func,
                 runtime_value=TypedValue(func.val),
-                arguments={"name": name_val, "default": default},
+                arguments=arguments,
                 node=node,
             )
             make_type_param_from_value(partial, ctx=self.ctx)
@@ -3494,19 +3578,16 @@ class _Visitor(ast.NodeVisitor):
                     "TypeVarTuple name must be a literal", node=node.args[0]
                 )
                 return AnyValue(AnySource.error)
-            default = NO_ARG_SENTINEL
-            for name, kwarg_value in kwarg_values:
-                if name == "default":
-                    default = kwarg_value
-                    continue
-                self.ctx.show_error(
-                    f"Unrecognized TypeVarTuple kwarg {name}", node=node
-                )
+            arguments = _parse_variadic_type_param_call_kwargs(
+                kwarg_values, "TypeVarTuple", self.ctx, node
+            )
+            if arguments is None:
                 return AnyValue(AnySource.error)
+            arguments["name"] = name_val
             partial = _make_partial_type_param_call(
                 callee=func,
                 runtime_value=TypedValue(func.val),
-                arguments={"name": name_val, "default": default},
+                arguments=arguments,
                 node=node,
             )
             make_type_param_from_value(partial, ctx=self.ctx)
@@ -3524,6 +3605,32 @@ class _Visitor(ast.NodeVisitor):
                 return AnyValue(AnySource.inference)
             return TypedValue(func.val)
         raise _UnsupportedAnnotationExpression
+
+
+def _parse_variadic_type_param_call_kwargs(
+    kwarg_values: Sequence[tuple[str | None, Value]],
+    kind: str,
+    ctx: Context,
+    node: ast.Call,
+) -> dict[str, Value] | None:
+    arguments: dict[str, Value] = {
+        "default": NO_ARG_SENTINEL,
+        "covariant": KnownValue(False),
+        "contravariant": KnownValue(False),
+        "infer_variance": KnownValue(False),
+    }
+    for name, value in kwarg_values:
+        if name == "default":
+            arguments[name] = value
+        elif name in {"covariant", "contravariant", "infer_variance"}:
+            if not isinstance(value, KnownValue) or not isinstance(value.val, bool):
+                ctx.show_error(f"{kind} kwarg {name} must be a bool literal", node=node)
+                return None
+            arguments[name] = value
+        else:
+            ctx.show_error(f"Unrecognized {kind} kwarg {name}", node=node)
+            return None
+    return arguments
 
 
 def _is_tuple(typ: object) -> bool:

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1045,7 +1045,7 @@ def make_type_param_from_value(
 def _extract_boolean_arg(pcv: PartialCallValue, arg_name: str) -> bool | None:
     arg_val = pcv.arguments.get(arg_name, NO_ARG_SENTINEL)
     if arg_val is NO_ARG_SENTINEL:
-        return None
+        return False
     if isinstance(arg_val, KnownValue) and isinstance(arg_val.val, bool):
         return arg_val.val
     return None

--- a/pycroscope/arg_spec.py
+++ b/pycroscope/arg_spec.py
@@ -112,6 +112,7 @@ from .value import (
     is_iterable,
     iter_type_params_in_value,
     make_coro_type,
+    pack_typevartuple_binding,
     type_param_to_value,
     with_type_param_owner,
 )
@@ -1594,8 +1595,9 @@ class ArgSpecCache:
     ) -> list[Value]:
         """Map concrete generic args to declared type parameters.
 
-        TypeVarTuple parameters consume zero or more type arguments and are
-        represented as tuple values during substitution.
+        The returned list has one canonical value per declared parameter:
+        ParamSpecs use InputSigValue and TypeVarTuples use
+        TypeVarTupleBindingValue.
         """
 
         if not type_params:
@@ -1662,12 +1664,6 @@ class ArgSpecCache:
             variadic_arg = generic_args[variadic_index]
             if isinstance(variadic_arg, (TypeVarTupleValue, TypeVarTupleBindingValue)):
                 return list(generic_args)
-        # TODO: This still materializes a TypeVarTuple slot as SequenceValue(tuple, ...)
-        # while other code paths use TypeVarTupleBindingValue for the same concept.
-        # That split makes empty and partially-specialized variadics easy to mishandle.
-        # Refactor this helper to produce the same canonical binding wrapper as
-        # match_typevar_arguments()/TypeVarMap, then update the downstream callers to
-        # consume that single representation.
         split = self._split_variadic_generic_args(
             type_params, generic_args, variadic_index
         )
@@ -1693,13 +1689,19 @@ class ArgSpecCache:
                     )
                 )
             elif i == variadic_index:
-                value = SequenceValue(
-                    tuple,
-                    [
-                        (False, member)
-                        for member in generic_args[variadic_start:variadic_end]
-                    ],
-                )
+                variadic_args = generic_args[variadic_start:variadic_end]
+                if (
+                    not variadic_args
+                    and type_params[i].default is not None
+                    and use_defaults_for_omitted_args
+                ):
+                    value = self._default_type_argument_for_param(
+                        type_params[i], variadic_substitutions, use_defaults=True
+                    )
+                else:
+                    value = TypeVarTupleBindingValue(
+                        pack_typevartuple_binding(variadic_args)
+                    )
             else:
                 suffix_index = i - variadic_index - 1
                 value = (

--- a/pycroscope/checker.py
+++ b/pycroscope/checker.py
@@ -18,7 +18,12 @@ from typing import TypeVar, cast
 from typing_extensions import assert_never
 
 from . import dataclass as dataclass_helpers
-from .annotations import Context, type_from_runtime, type_from_value
+from .annotations import (
+    Context,
+    normalize_paramspec_generic_args,
+    type_from_runtime,
+    type_generic_args_from_members,
+)
 from .arg_spec import ArgSpecCache, GenericBases
 from .attributes import AttrContext, get_attribute
 from .extensions import get_overloads as get_runtime_overloads
@@ -101,6 +106,7 @@ from .value import (
     UnboundMethodValue,
     Value,
     VariableNameValue,
+    default_value_for_type_param,
     flatten_values,
     get_self_param,
     is_union,
@@ -161,7 +167,9 @@ def _apply_type_parameter_defaults(type_params: Sequence[TypeParam]) -> list[Val
     substitutions = TypeVarMap()
     for type_param in type_params:
         if type_param.default is not None:
-            value = type_param.default.substitute_typevars(substitutions)
+            value = default_value_for_type_param(type_param).substitute_typevars(
+                substitutions
+            )
         else:
             value = type_param_to_value(type_param)
         if isinstance(type_param, TypeVarParam):
@@ -2601,12 +2609,12 @@ class Checker:
             return origin_argspec
         type_params = self.get_type_parameters(class_type)
         annotation_ctx = Context(can_assign_ctx=self, self_key=class_type)
-        explicit_member_values = [
-            type_from_value(
-                member, node=value.node, ctx=annotation_ctx, suppress_errors=True
-            )
-            for member in value.members
-        ]
+        explicit_member_values = normalize_paramspec_generic_args(
+            type_params,
+            type_generic_args_from_members(type_params, value.members, annotation_ctx),
+            annotation_ctx,
+            node=value.node,
+        )
         member_values = self.arg_spec_cache._specialize_generic_type_params(
             type_params, explicit_member_values
         )
@@ -2650,26 +2658,10 @@ class Checker:
                 *compatibility_member_values,
                 *member_values[len(compatibility_member_values) :],
             ]
-        typevar_map = TypeVarMap()
-        for param, member in zip(type_params, member_values):
-            if isinstance(param, ParamSpecParam):
-                continue
-            if isinstance(param, TypeVarParam):
-                typevar_map = typevar_map.with_typevar(param, member)
-            else:
-                typevar_map = typevar_map.with_typevartuple(
-                    param, typevartuple_value_to_members(member)
-                )
-        exact_typevar_map = TypeVarMap()
-        for param, member in zip(type_params, exact_member_values):
-            if isinstance(param, ParamSpecParam):
-                continue
-            if isinstance(param, TypeVarParam):
-                exact_typevar_map = exact_typevar_map.with_typevar(param, member)
-            else:
-                exact_typevar_map = exact_typevar_map.with_typevartuple(
-                    param, typevartuple_value_to_members(member)
-                )
+        typevar_map = typevar_map_from_varlike_pairs(zip(type_params, member_values))
+        exact_typevar_map = typevar_map_from_varlike_pairs(
+            zip(type_params, exact_member_values)
+        )
         specialized_instance_type: Value
         if compatibility_member_values:
             specialized_instance_type = GenericValue(

--- a/pycroscope/input_sig.py
+++ b/pycroscope/input_sig.py
@@ -139,6 +139,12 @@ def input_sigs_have_relation(
             return CanAssignError("Cannot be assigned to")
         return {}
     elif isinstance(left, ParamSpecParam):
+        if isinstance(right, AnySig) and relation is Relation.ASSIGNABLE:
+            return {}
+        if inferables is not None and left not in inferables:
+            if isinstance(right, ParamSpecParam) and left == right:
+                return {}
+            return CanAssignError(f"Cannot assign {right} to rigid ParamSpec {left}")
         return {left: [LowerBound(left, InputSigValue(right))]}
     elif isinstance(left, ActualArguments):
         if left == right:
@@ -150,6 +156,10 @@ def input_sigs_have_relation(
                 return CanAssignError("Cannot be assigned")
             return {}
         elif isinstance(right, ParamSpecParam):
+            if inferables is not None and right not in inferables:
+                return CanAssignError(
+                    f"Cannot assign rigid ParamSpec {right} to {left}"
+                )
             return {right: [UpperBound(right, InputSigValue(left))]}
         elif isinstance(right, ActualArguments):
             # TODO: pass inferables

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -88,6 +88,7 @@ from .annotations import (
     normalize_paramspec_generic_args,
     specialize_type_alias_value,
     type_from_value,
+    type_generic_args_from_members,
     value_from_ast,
 )
 from .arg_spec import ArgSpecCache, IgnoredCallees, UnwrapClass, is_dot_asynq_function
@@ -243,6 +244,7 @@ from .type_object import (
 from .type_params import (
     ActiveTypeParams,
     TypeParamIdentity,
+    find_incompatible_callable_type_param_variances,
     infer_type_param_variances_from_class_api,
 )
 from .typeshed import TypeshedFinder
@@ -333,7 +335,8 @@ from .value import (
     flatten_values,
     get_self_param,
     get_type_alias_root,
-    get_typevar_variance,
+    get_type_param_variance,
+    get_typevartuple_members,
     is_async_iterable,
     is_iterable,
     is_property_initializer,
@@ -2376,8 +2379,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 if isinstance(can_assign, CanAssignError):
                     self._show_error_if_checking(
                         node,
-                        f"Incompatible assignment: expected {declared_type}, got"
-                        f" {value}",
+                        f"Incompatible assignment: expected {declared_type}, got {value}",
                         error_code=ErrorCode.incompatible_assignment,
                         detail=can_assign.display(),
                     )
@@ -4189,10 +4191,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 if keyword.arg is None:
                     message = "TypedDict definitions do not support **kwargs"
                 else:
-                    message = (
-                        f"Unexpected keyword argument {keyword.arg!r}"
-                        " in TypedDict definition"
-                    )
+                    message = f"Unexpected keyword argument {keyword.arg!r} in TypedDict definition"
                 self._show_error_if_checking(
                     keyword, message, error_code=ErrorCode.invalid_typeddict
                 )
@@ -5465,11 +5464,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         type_params = tobj.get_declared_type_params()
         if not type_params:
             return
-        checked_type_params = [
-            type_param
-            for type_param in type_params
-            if isinstance(type_param, TypeVarParam)
-        ]
+        checked_type_params = list(type_params)
         if not checked_type_params:
             return
         inferred_type_params = infer_type_param_variances_from_class_api(
@@ -5478,9 +5473,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if inferred_type_params is None:
             return
         inferred_type_params_by_identity = {
-            type_param.typevar: type_param
-            for type_param in inferred_type_params
-            if isinstance(type_param, TypeVarParam)
+            type_param.typevar: type_param for type_param in inferred_type_params
         }
         for declared_type_param in checked_type_params:
             inferred_type_param = inferred_type_params_by_identity.get(
@@ -5497,8 +5490,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             )
             self._show_error_if_checking(
                 node,
-                f"{type_param_name} should be "
-                f"{inferred_type_param.variance.display_name()}",
+                f"{type_param_name} should be {inferred_type_param.variance.display_name()}",
                 error_code=ErrorCode.invalid_protocol,
             )
 
@@ -5512,14 +5504,14 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     ) -> None:
         if self._is_protocol_class(base_values, class_scope_object):
             return
-        typevars_to_check = {
-            type_param.typevar
-            for type_param in type_params
-            if isinstance(type_param, TypeVarParam)
-        }
+        typevars_to_check = {type_param.typevar for type_param in type_params}
         for base_variance_info in base_type_param_variance_infos:
             for typevar in base_variance_info.type_param_polarities:
-                if is_instance_of_typing_name(typevar, "TypeVar"):
+                if (
+                    is_instance_of_typing_name(typevar, "TypeVar")
+                    or is_instance_of_typing_name(typevar, "ParamSpec")
+                    or is_instance_of_typing_name(typevar, "TypeVarTuple")
+                ):
                     typevars_to_check.add(typevar)
         if not typevars_to_check:
             return
@@ -5534,7 +5526,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 used_polarities = base_variance_info.type_param_polarities.get(
                     typevar, set()
                 )
-                variance = get_typevar_variance(typevar)
+                variance = get_type_param_variance(typevar)
                 if _variance_is_compatible_with_usage(variance, used_polarities):
                     continue
                 type_param_name = safe_getattr(typevar, "__name__", str(typevar))
@@ -7053,6 +7045,38 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     ),
                     *params[1:],
                 ]
+            if (
+                not isinstance(node, ast.Lambda)
+                and node.name not in {"__init__", "__new__"}
+                and self.scopes.scope_type() is ScopeType.class_scope
+                and self.current_class_type_params
+            ):
+                first_checked_index = (
+                    0 if FunctionDecorator.staticmethod in decorator_kinds else 1
+                )
+                incompatible_type_params = (
+                    find_incompatible_callable_type_param_variances(
+                        self.current_class_type_params,
+                        [
+                            param_info.param.annotation
+                            for param_info in params[first_checked_index:]
+                        ],
+                        return_annotation,
+                        self,
+                    )
+                )
+                if incompatible_type_params:
+                    type_param_names = ", ".join(
+                        safe_getattr(
+                            type_param.typevar, "__name__", str(type_param.typevar)
+                        )
+                        for type_param in incompatible_type_params
+                    )
+                    self._show_error_if_checking(
+                        node,
+                        f"{type_param_names} has incompatible variance in method",
+                        error_code=ErrorCode.invalid_annotation,
+                    )
             yield FunctionInfo(
                 async_kind=async_kind,
                 decorator_kinds=frozenset(decorator_kinds),
@@ -8072,7 +8096,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return None
         normalized_members: list[Value] = []
         for member in value.members:
-            normalized = type_from_value(member, self, value.node, suppress_errors=True)
+            if isinstance(member, (InputSigValue, TypeVarTupleBindingValue)):
+                normalized = member
+            else:
+                normalized = type_from_value(
+                    member, self, value.node, suppress_errors=True
+                )
             if (
                 isinstance(normalized, AnyValue)
                 and normalized.source is AnySource.error
@@ -8278,8 +8307,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             if param is None:
                 self._show_error_if_checking(
                     info.node,
-                    "TypeIs must be used on a function taking at least one positional"
-                    " parameter",
+                    "TypeIs must be used on a function taking at least one positional parameter",
                     error_code=ErrorCode.invalid_typeguard,
                 )
                 continue
@@ -8300,8 +8328,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             if param is None:
                 self._show_error_if_checking(
                     info.node,
-                    "TypeGuard must be used on a function taking at least one"
-                    " positional parameter",
+                    "TypeGuard must be used on a function taking at least one positional parameter",
                     error_code=ErrorCode.invalid_typeguard,
                 )
 
@@ -10693,8 +10720,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             if isinstance(can_assign, CanAssignError):
                 self._show_error_if_checking(
                     node,
-                    f"Cannot send {send_type} to a generator (expected"
-                    f" {expected_send})",
+                    f"Cannot send {send_type} to a generator (expected {expected_send})",
                     error_code=ErrorCode.incompatible_yield,
                     detail=can_assign.display(),
                 )
@@ -10734,8 +10760,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if isinstance(can_assign, CanAssignError):
             self._show_error_if_checking(
                 node,
-                f"Cannot assign value of type {value} to yield expression of type"
-                f" {yield_type}",
+                f"Cannot assign value of type {value} to yield expression of type {yield_type}",
                 error_code=ErrorCode.incompatible_yield,
                 detail=can_assign.display(),
             )
@@ -12052,8 +12077,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         if isinstance(can_assign, CanAssignError):
                             self._show_error_if_checking(
                                 node,
-                                f"Incompatible assignment: expected {expected_type}, got"
-                                f" {value}",
+                                f"Incompatible assignment: expected {expected_type}, got {value}",
                                 error_code=ErrorCode.incompatible_assignment,
                                 detail=can_assign.display(),
                             )
@@ -12721,7 +12745,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 )
             else:
                 legacy_message = (
-                    "Type alias must declare type parameters in the" " type statement"
+                    "Type alias must declare type parameters in the type statement"
                 )
             legacy_type_param_ctx = self.active_type_params.reject_legacy_type_params(
                 legacy_message,
@@ -12824,8 +12848,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     )
                 else:
                     legacy_param_message = (
-                        "Type alias must declare type parameters in the"
-                        " type statement"
+                        "Type alias must declare type parameters in the type statement"
                     )
                 with (
                     self.scopes.add_scope(
@@ -12971,7 +12994,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 ps = typing.ParamSpec(node.name)
             else:
                 ps = typing.cast(Any, maybe_runtime_param_spec)
-            typevar = InputSigValue(ParamSpecParam(ps, owner=owner))
+            typevar = InputSigValue(
+                ParamSpecParam(ps, owner=owner, variance=Variance.INFERRED)
+            )
             self._set_name_in_scope(node.name, node, typevar)
             return typevar
 
@@ -12986,7 +13011,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 tv = typing.cast(Any, getattr(typing, "TypeVarTuple"))(node.name)
             else:
                 tv = typing.cast(Any, maybe_runtime_typevar_tuple)
-            typevar = TypeVarTupleValue(TypeVarTupleParam(tv, owner=owner))
+            typevar = TypeVarTupleValue(
+                TypeVarTupleParam(tv, owner=owner, variance=Variance.INFERRED)
+            )
             self._set_name_in_scope(node.name, node, typevar)
             return typevar
 
@@ -13534,6 +13561,14 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return None
 
         def _normalize_member(member: Value) -> Value:
+            if (
+                isinstance(member, PartialValue)
+                and member.operation is PartialValueOperation.UNPACK
+            ):
+                unpacked = _normalize_member(member.root)
+                unpacked_members = get_typevartuple_members(unpacked)
+                if unpacked_members is not None:
+                    return TypeVarTupleBindingValue(unpacked_members)
             normalized = type_from_value(member, self, node, suppress_errors=True)
             if (
                 isinstance(normalized, AnyValue)
@@ -13565,7 +13600,27 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return None
 
         members = self._maybe_unpack_tuple(index)
-        normalized_members = tuple(_normalize_member(member) for member in members)
+        normalized_members_list = [_normalize_member(member) for member in members]
+        slice_nodes = (
+            list(node.slice.elts) if isinstance(node.slice, ast.Tuple) else [node.slice]
+        )
+        if len(slice_nodes) == len(normalized_members_list):
+            for i, slice_member in enumerate(slice_nodes):
+                if not isinstance(slice_member, ast.Starred):
+                    continue
+                unpacked = normalized_members_list[i]
+                if (
+                    isinstance(unpacked, TypeVarTupleBindingValue)
+                    and len(unpacked.binding) == 1
+                    and not unpacked.binding[0][0]
+                ):
+                    unpacked = unpacked.binding[0][1]
+                unpacked_members = get_typevartuple_members(unpacked)
+                if unpacked_members is not None:
+                    normalized_members_list[i] = TypeVarTupleBindingValue(
+                        unpacked_members
+                    )
+        normalized_members = tuple(normalized_members_list)
         tobj = self.checker.make_type_object(synthetic_typ)
         type_parameters = tobj.get_declared_type_params()
         has_explicit_class_getitem = "__class_getitem__" in tobj.get_declared_symbols()
@@ -15532,10 +15587,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     for member in callee.members
                 ]
             else:
-                type_args = [
-                    type_from_value(member, self, node, suppress_errors=True)
-                    for member in callee.members
-                ]
+                type_params = self.checker.get_type_parameters(origin)
+                if type_params:
+                    annotation_ctx = DefaultContext(visitor=self, node=node)
+                    type_args = normalize_paramspec_generic_args(
+                        type_params,
+                        type_generic_args_from_members(
+                            type_params, callee.members, annotation_ctx
+                        ),
+                        annotation_ctx,
+                        node=node,
+                    )
+                else:
+                    type_args = [
+                        type_from_value(member, self, node, suppress_errors=True)
+                        for member in callee.members
+                    ]
         else:
             return return_value
         type_args = [promote_constructor_type_arg(arg) for arg in type_args]

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -1028,8 +1028,7 @@ def _has_relation_impl(
             for is_many, member in left.members:
                 if not is_many:
                     return CanAssignError(
-                        f"{right} may be empty and cannot satisfy"
-                        f" known-non-empty {left}"
+                        f"{right} may be empty and cannot satisfy known-non-empty {left}"
                     )
                 can_assign = relation_ctx.has_relation(member, right_member)
                 if isinstance(can_assign, CanAssignError):
@@ -1105,7 +1104,20 @@ def _has_relation_impl(
                 comparison_left = left
                 left_tobj = left.get_type_object(ctx)
                 declared_type_params = left_tobj.get_declared_type_params()
-                if len(left.args) != len(generic_args):
+                packed_generic_args = _pack_typevartuple_generic_args(
+                    declared_type_params, generic_args
+                )
+                packed_left_args = _pack_typevartuple_generic_args(
+                    declared_type_params, left.args
+                )
+                if (
+                    packed_left_args is not None
+                    and packed_generic_args is not None
+                    and len(packed_left_args) == len(packed_generic_args)
+                ):
+                    comparison_left = GenericValue(left.typ, packed_left_args)
+                    generic_args = packed_generic_args
+                if len(comparison_left.args) != len(generic_args):
                     # TODO: GenericValue.args still arrive here in a mix of flattened
                     # and packed variadic forms, so this branch has to repair both sides
                     # before comparison. That works, but it's brittle and hard to reason
@@ -1132,11 +1144,11 @@ def _has_relation_impl(
                         declared_type_params, generic_args
                     )
                     packed_left_args = _pack_typevartuple_generic_args(
-                        declared_type_params, left.args
+                        declared_type_params, comparison_left.args
                     )
-                    if packed_generic_args is not None and len(left.args) == len(
-                        packed_generic_args
-                    ):
+                    if packed_generic_args is not None and len(
+                        comparison_left.args
+                    ) == len(packed_generic_args):
                         generic_args = packed_generic_args
                     elif (
                         packed_left_args is not None
@@ -1264,7 +1276,11 @@ def _coerce_paramspec_generic_arg_for_relation(arg: Value, *, other: Value) -> V
 
 
 def _has_relation_for_generic_arg_pair(
-    left: Value, right: Value, relation_ctx: RelationContext
+    left: Value,
+    right: Value,
+    relation_ctx: RelationContext,
+    *,
+    reverse_paramspec: bool = False,
 ) -> CanAssign:
     assert not isinstance(left, (TypeVarParam, ParamSpecParam, TypeVarTupleParam))
     assert not isinstance(right, (TypeVarParam, ParamSpecParam, TypeVarTupleParam))
@@ -1277,12 +1293,14 @@ def _has_relation_for_generic_arg_pair(
     if isinstance(left, pycroscope.input_sig.InputSigValue) and isinstance(
         right, pycroscope.input_sig.InputSigValue
     ):
+        if reverse_paramspec:
+            left, right = right, left
         return pycroscope.input_sig.input_sigs_have_relation(
             left.input_sig,
             right.input_sig,
             relation_ctx.relation,
             relation_ctx.ctx,
-            relation_ctx.inferables,
+            relation_ctx.inferables if relation_ctx.inferables is not None else (),
         )
     if isinstance(left, pycroscope.input_sig.InputSigValue) or isinstance(
         right, pycroscope.input_sig.InputSigValue
@@ -1426,9 +1444,13 @@ def _has_relation_for_generic_arg(
 ) -> CanAssign:
     relation = relation_ctx.relation
     if variance is Variance.COVARIANT:
-        return _has_relation_for_generic_arg_pair(left, right, relation_ctx)
+        return _has_relation_for_generic_arg_pair(
+            left, right, relation_ctx, reverse_paramspec=True
+        )
     if variance is Variance.CONTRAVARIANT:
-        return _has_relation_for_generic_arg_pair(right, left, relation_ctx)
+        return _has_relation_for_generic_arg_pair(
+            right, left, relation_ctx, reverse_paramspec=True
+        )
 
     forward = _has_relation_for_generic_arg_pair(left, right, relation_ctx)
     if isinstance(forward, CanAssignError):
@@ -2280,8 +2302,7 @@ def _has_relation_typeddict(
         )
         if isinstance(can_assign, CanAssignError):
             return CanAssignError(
-                f"Type for key {key!r} is incompatible with extra keys type"
-                f" {left.extra_keys}",
+                f"Type for key {key!r} is incompatible with extra keys type {left.extra_keys}",
                 children=[can_assign],
             )
         bounds_maps.append(can_assign)
@@ -2331,8 +2352,7 @@ def _has_relation_typeddict_dict(
                 if key_type.val not in left.items:
                     if left.extra_keys is NO_RETURN_VALUE:
                         return CanAssignError(
-                            f"Key {key_type.val!r} is not allowed in closed"
-                            f" TypedDict {left}"
+                            f"Key {key_type.val!r} is not allowed in closed TypedDict {left}"
                         )
                     elif left.extra_keys is not None:
                         can_assign = relation_ctx.has_relation(
@@ -2340,7 +2360,7 @@ def _has_relation_typeddict_dict(
                         )
                         if isinstance(can_assign, CanAssignError):
                             return CanAssignError(
-                                f"Type for extra key {pair.key} is" " incompatible",
+                                f"Type for extra key {pair.key} is incompatible",
                                 children=[can_assign],
                             )
                         bounds_maps.append(can_assign)
@@ -2357,7 +2377,7 @@ def _has_relation_typeddict_dict(
                     )
                 if left.extra_keys is NO_RETURN_VALUE:
                     return CanAssignError(
-                        f"Key {pair.key} is not allowed in closed TypedDict" f" {left}"
+                        f"Key {pair.key} is not allowed in closed TypedDict {left}"
                     )
                 elif left.extra_keys is not None:
                     can_assign = relation_ctx.has_relation(left.extra_keys, pair.value)

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -136,6 +136,10 @@ class RelationContext:
     original_left: GradualType | None = None
     original_right: GradualType | None = None
     relation_goals: tuple[object, ...] = ()
+    inference_mode: bool = False
+
+    def should_infer_type_params(self) -> bool:
+        return self.inference_mode or self.inferables is not None
 
     def with_relation(
         self, relation: Literal[Relation.SUBTYPE, Relation.ASSIGNABLE]
@@ -191,10 +195,17 @@ def _make_relation_cache_key(
     right: Value,
     relation: Relation,
     inferables: tuple[TypeParam, ...] | None = None,
+    inference_mode: bool = False,
 ) -> tuple[
-    tuple[str, object], tuple[str, object], Relation, tuple[TypeParam, ...] | None
+    tuple[str, object], tuple[str, object], Relation, tuple[TypeParam, ...] | None, bool
 ]:
-    return (_relation_key_piece(left), _relation_key_piece(right), relation, inferables)
+    return (
+        _relation_key_piece(left),
+        _relation_key_piece(right),
+        relation,
+        inferables,
+        inference_mode,
+    )
 
 
 def _get_cached_relation_result(
@@ -312,7 +323,11 @@ def _has_relation(
     left = gradualize(left)
     right = gradualize(right)
     key = _make_relation_cache_key(
-        left, right, relation_ctx.relation, relation_ctx.inferables
+        left,
+        right,
+        relation_ctx.relation,
+        relation_ctx.inferables,
+        relation_ctx.inference_mode,
     )
     if key in relation_ctx.relation_goals:
         return {}
@@ -1300,7 +1315,11 @@ def _has_relation_for_generic_arg_pair(
             right.input_sig,
             relation_ctx.relation,
             relation_ctx.ctx,
-            relation_ctx.inferables if relation_ctx.inferables is not None else (),
+            (
+                relation_ctx.inferables
+                if relation_ctx.should_infer_type_params()
+                else ()
+            ),
         )
     if isinstance(left, pycroscope.input_sig.InputSigValue) or isinstance(
         right, pycroscope.input_sig.InputSigValue
@@ -2178,6 +2197,8 @@ def _unpack_fixed_tuple_generic_arg(value: Value) -> list[Value] | None:
         if all(not is_many for is_many, _ in value.binding):
             return [member for _, member in value.binding]
         return None
+    if isinstance(value, pycroscope.input_sig.InputSigValue):
+        return None
     normalized = replace_known_sequence_value(value)
     if isinstance(normalized, SequenceValue) and normalized.typ is tuple:
         members = normalized.get_member_sequence()
@@ -2401,7 +2422,7 @@ def get_tv_map(
     ctx: CanAssignContext,
     inferables: tuple[TypeParam, ...] | None = None,
 ) -> TypeVarMap | CanAssignError:
-    relation_ctx = RelationContext(relation, ctx, inferables)
+    relation_ctx = RelationContext(relation, ctx, inferables, inference_mode=True)
     return get_tv_map_from_ctx(left, right, relation_ctx)
 
 

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -2402,11 +2402,7 @@ class Signature:
             return None
         if self_annotation_value is not None:
             tv_map = relations.get_tv_map(
-                self_annotation,
-                self_annotation_value,
-                Relation.ASSIGNABLE,
-                ctx,
-                inferables=tuple(iter_type_params_in_value(self_annotation)),
+                self_annotation, self_annotation_value, Relation.ASSIGNABLE, ctx
             )
             if isinstance(tv_map, CanAssignError):
                 return None

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -2402,7 +2402,11 @@ class Signature:
             return None
         if self_annotation_value is not None:
             tv_map = relations.get_tv_map(
-                self_annotation, self_annotation_value, Relation.ASSIGNABLE, ctx
+                self_annotation,
+                self_annotation_value,
+                Relation.ASSIGNABLE,
+                ctx,
+                inferables=tuple(iter_type_params_in_value(self_annotation)),
             )
             if isinstance(tv_map, CanAssignError):
                 return None

--- a/pycroscope/test_annotations.py
+++ b/pycroscope/test_annotations.py
@@ -514,8 +514,9 @@ class TestAnnotations(TestNameCheckVisitorBase):
         assert type_from_value(KnownValue(Array[()])) == GenericValue(Array, [])
 
     @skip_before((3, 12))
-    def test_type_from_runtime_preserves_runtime_paramspec_specialization(self):
+    def test_type_from_runtime_canonicalizes_runtime_paramspec_specialization(self):
         from .annotations import Context, type_from_runtime
+        from .input_sig import coerce_paramspec_specialization_to_input_sig
 
         namespace: dict[str, object] = {}
         exec("class Callback[**P]:\n    pass", namespace)
@@ -526,8 +527,10 @@ class TestAnnotations(TestNameCheckVisitorBase):
         ) == GenericValue(
             Callback,
             [
-                SequenceValue(
-                    tuple, [(False, TypedValue(int)), (False, TypedValue(str))]
+                coerce_paramspec_specialization_to_input_sig(
+                    SequenceValue(
+                        tuple, [(False, TypedValue(int)), (False, TypedValue(str))]
+                    )
                 )
             ],
         )

--- a/pycroscope/test_arg_spec.py
+++ b/pycroscope/test_arg_spec.py
@@ -29,7 +29,6 @@ from .value import (
     KnownValue,
     NewTypeValue,
     ParamSpecParam,
-    SequenceValue,
     TypedValue,
     TypeVarParam,
     TypeVarTupleBindingValue,
@@ -154,7 +153,7 @@ def test_specialize_generic_type_params_preserves_suffix_with_default_prefix() -
             TypeVarParam(u, owner=None),
         ],
         [TypedValue(str)],
-    ) == [TypedValue(int), SequenceValue(tuple, []), TypedValue(str)]
+    ) == [TypedValue(int), TypeVarTupleBindingValue(()), TypedValue(str)]
 
 
 def test_collapse_constructor_overloads_to_single_generic() -> None:

--- a/pycroscope/test_name_check_visitor.py
+++ b/pycroscope/test_name_check_visitor.py
@@ -3186,7 +3186,7 @@ class TestTaxonomyDistilledRegressions(TestNameCheckVisitorBase):
     def test_paramspec_callable_protocol_assignment_does_not_internal_error(self):
         from typing import Any, ParamSpec, Protocol
 
-        P = ParamSpec("P")
+        P = ParamSpec("P", contravariant=True)
 
         class Proto3(Protocol):
             def __call__(self, a: int, *args: Any, **kwargs: Any) -> None: ...

--- a/pycroscope/test_pep673.py
+++ b/pycroscope/test_pep673.py
@@ -282,6 +282,9 @@ class TestPEP673(TestNameCheckVisitorBase):
         T = TypeVar("T", bound="Model")
 
         class Getter(Generic[T]):
+            def __call__(self, key: str) -> T | None:
+                raise NotImplementedError
+
             def get_one(self) -> T | None:
                 raise NotImplementedError
 
@@ -296,6 +299,7 @@ class TestPEP673(TestNameCheckVisitorBase):
                 assert_type(getter, Getter[Self])
                 result = getter.get_one()
                 assert_type(result, Self | None)
+                assert_type(getter("key"), Self | None)
                 return result
 
         class SubModel(Model):

--- a/pycroscope/test_protocol.py
+++ b/pycroscope/test_protocol.py
@@ -49,7 +49,7 @@ class TestProtocol(TestNameCheckVisitorBase):
     def test_unknown_attribute_assignment_on_protocol_typed_callable(self):
         from typing import Callable, ParamSpec, Protocol, TypeVar, cast
 
-        P = ParamSpec("P")
+        P = ParamSpec("P", contravariant=True)
         R = TypeVar("R", covariant=True)
 
         class CallableWithAttr(Protocol[P, R]):

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -1348,7 +1348,7 @@ class TestSyntheticType(TestNameCheckVisitorBase):
     def test_paramspec_callable_protocol_equivalence(self):
         from typing import Callable, ParamSpec, Protocol, TypeAlias
 
-        P = ParamSpec("P")
+        P = ParamSpec("P", contravariant=True)
 
         class ProtocolWithP(Protocol[P]):
             def __call__(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
@@ -1364,10 +1364,11 @@ class TestSyntheticType(TestNameCheckVisitorBase):
     def test_protocol_receiver_constraints_with_typevartuple(self):
         self.assert_passes(
             """
-            from typing import Generic, Protocol, TypeVar, TypeVarTuple
+            from typing import Generic, Protocol, TypeVar
+            from typing_extensions import TypeVarTuple
 
             T_co = TypeVar("T_co", covariant=True)
-            Ts = TypeVarTuple("Ts")
+            Ts = TypeVarTuple("Ts", covariant=True)
 
             class Box(Generic[T_co, *Ts]):
                 def head(self) -> T_co:
@@ -1397,7 +1398,7 @@ class TestSyntheticType(TestNameCheckVisitorBase):
         from typing import Any, Callable, ParamSpec, Protocol, TypeVar
 
         T_contra = TypeVar("T_contra", contravariant=True)
-        P = ParamSpec("P")
+        P = ParamSpec("P", contravariant=True)
 
         class ProtoAnyTail(Protocol):
             def __call__(self, *args: Any, **kwargs: Any) -> None: ...

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -471,14 +471,42 @@ class TestTypeVar(TestNameCheckVisitorBase):
             def __init__(self, value: T_co) -> None: ...
 
     @assert_passes(run_in_both_module_modes=True)
-    def test_protocol_paramspec_is_ignored_for_variance_check(self):
+    def test_protocol_paramspec_variance_is_checked(self):
         from typing import ParamSpec, Protocol, TypeVar
 
         P = ParamSpec("P")
+        P_contra = ParamSpec("P_contra", contravariant=True)
         R = TypeVar("R", covariant=True)
 
-        class Callback(Protocol[P, R]):
+        class BadCallback(Protocol[P, R]):  # E: invalid_protocol
             def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
+
+        class Callback(Protocol[P_contra, R]):
+            def __call__(
+                self, *args: P_contra.args, **kwargs: P_contra.kwargs
+            ) -> R: ...
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_protocol_variance_with_variadic_parameters(self):
+        from typing import Protocol, TypeVar
+
+        T_contra = TypeVar("T_contra", contravariant=True)
+
+        class Callback(Protocol[T_contra]):
+            def __call__(self, *args: T_contra, **kwargs: T_contra) -> None: ...
+
+    @assert_passes(run_in_both_module_modes=True)
+    def test_recursive_protocol_classmethod_receiver_does_not_affect_variance(self):
+        from typing import Protocol, TypeVar
+
+        T_co = TypeVar("T_co", covariant=True)
+        T_contra = TypeVar("T_contra", contravariant=True)
+
+        class Proto(Protocol[T_co, T_contra]):
+            def recurse(self) -> "Proto[T_co, T_contra]": ...
+
+            @classmethod
+            def consume(cls, value: T_contra) -> None: ...
 
     @assert_passes(run_in_both_module_modes=True)
     def test_protocol_output_only_covariant_typevar_is_valid(self):
@@ -1810,6 +1838,75 @@ class TestGenericClasses(TestNameCheckVisitorBase):
                 def f(self, x: [T]) -> None:  # E: invalid_annotation
                     raise NotImplementedError
         """)
+
+    @skip_before((3, 12))
+    def test_infer_paramspec_variance(self):
+        self.assert_passes(
+            """
+            from typing import Callable
+
+            class Invariant[**P]:
+                callback: Callable[P, None]
+
+            class Contravariant[**P]:
+                def call(self, *args: P.args, **kwargs: P.kwargs) -> None:
+                    raise NotImplementedError
+
+            class Covariant[**P]:
+                def accept(self, callback: Callable[P, None]) -> None:
+                    raise NotImplementedError
+
+            invariant_bad1: Invariant[object] = Invariant[int]()  # E: incompatible_assignment
+            invariant_bad2: Invariant[int] = Invariant[object]()  # E: incompatible_assignment
+            contra_ok: Contravariant[int] = Contravariant[object]()
+            contra_bad: Contravariant[object] = Contravariant[int]()  # E: incompatible_assignment
+            co_ok: Covariant[object] = Covariant[int]()
+            co_bad: Covariant[int] = Covariant[object]()  # E: incompatible_assignment
+            """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 12))
+    def test_infer_typevartuple_variance(self):
+        self.assert_passes(
+            """
+            class Contravariant[*Ts]:
+                def accept(self, value: tuple[*Ts]) -> None:
+                    raise NotImplementedError
+
+            class Covariant[*Ts]:
+                def produce(self) -> tuple[*Ts]:
+                    raise NotImplementedError
+
+            contra_ok: Contravariant[int] = Contravariant[object]()
+            contra_bad: Contravariant[object] = Contravariant[int]()  # E: incompatible_assignment
+            co_ok: Covariant[int, int] = Covariant[bool, bool]()
+            co_bad: Covariant[int, int] = Covariant[bool, object]()  # E: incompatible_assignment
+            unbounded_ok: Covariant[*tuple[object, ...]] = Covariant[*tuple[int, ...]]()
+            fixed_ok: Covariant[*tuple[int, ...]] = Covariant[int]()
+            """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 12))
+    def test_infer_mixed_type_parameter_variance(self):
+        self.assert_passes(
+            """
+            class Mixed[T, *Ts, **P]:
+                def call(
+                    self, value: T, /, *args: P.args, **kwargs: P.kwargs
+                ) -> tuple[*Ts]:
+                    raise NotImplementedError
+
+            t_ok: Mixed[int, []] = Mixed[object, []]()
+            t_bad: Mixed[int, []] = Mixed[bool, []]()  # E: incompatible_assignment
+            ts_ok: Mixed[int, int, []] = Mixed[int, bool, []]()
+            ts_bad: Mixed[int, int, []] = Mixed[int, object, []]()  # E: incompatible_assignment
+            p_ok: Mixed[int, [int]] = Mixed[int, [object]]()
+            p_bad: Mixed[int, [int]] = Mixed[int, [bool]]()  # E: incompatible_assignment
+            """,
+            run_in_both_module_modes=True,
+        )
 
     @skip_before((3, 12))
     def test_reject_legacy_typevar_in_generic_class_bases(self):

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -189,8 +189,7 @@ def infer_type_param_variances_from_class_api(
     inferable_type_params = tuple(
         type_param
         for type_param in type_params
-        if isinstance(type_param, TypeVarParam)
-        and (not infer_variance_only or _type_param_uses_infer_variance(type_param))
+        if not infer_variance_only or _type_param_uses_infer_variance(type_param)
     )
     if not inferable_type_params:
         return None
@@ -222,9 +221,34 @@ def infer_type_param_variances_from_class_api(
     )
 
 
+def find_incompatible_callable_type_param_variances(
+    type_params: Sequence[TypeParam],
+    parameter_annotations: Sequence[Value],
+    return_annotation: Value | None,
+    ctx: CanAssignContext,
+) -> tuple[TypeParam, ...]:
+    explicit_type_params = tuple(
+        type_param
+        for type_param in type_params
+        if isinstance(type_param, (ParamSpecParam, TypeVarTupleParam))
+        if type_param.variance in (Variance.COVARIANT, Variance.CONTRAVARIANT)
+    )
+    if not explicit_type_params:
+        return ()
+    collector = _PolarityCollector(explicit_type_params, ctx)
+    for annotation in parameter_annotations:
+        collector.collect(annotation, _Polarity.CONTRAVARIANT)
+    if return_annotation is not None:
+        collector.collect(return_annotation, _Polarity.COVARIANT)
+    return tuple(
+        type_param
+        for type_param in explicit_type_params
+        if (observed := collector.polarities.get(type_param)) is not None
+        and observed is not _polarity_from_variance(type_param.variance)
+    )
+
+
 def _type_param_uses_infer_variance(type_param: TypeParam) -> bool:
-    if not is_instance_of_typing_name(type_param.typevar, "TypeVar"):
-        return False
     if type_param.variance is Variance.INFERRED:
         return True
     return bool(safe_getattr(type_param.typevar, "__infer_variance__", False))
@@ -253,14 +277,12 @@ def _is_type_parameter_declaration_base(value: Value) -> bool:
 class _PolarityCollector:
     def __init__(self, type_params: Sequence[TypeParam], ctx: CanAssignContext) -> None:
         self._type_params_by_identity = {
-            type_param.typevar: type_param
-            for type_param in type_params
-            if isinstance(type_param, TypeVarParam)
+            type_param.typevar: type_param for type_param in type_params
         }
         self._ctx = ctx
         self.polarities: dict[TypeParam, _Polarity] = {}
 
-    def record(self, type_param: TypeVarParam, polarity: _Polarity) -> None:
+    def record(self, type_param: TypeParam, polarity: _Polarity) -> None:
         target = self._type_params_by_identity.get(type_param.typevar)
         if target is None:
             return
@@ -274,12 +296,16 @@ class _PolarityCollector:
             self.record(value.typevar_param, polarity)
             return
         if isinstance(value, (ParamSpecArgsValue, ParamSpecKwargsValue)):
+            target = self._type_params_by_identity.get(value.param_spec)
+            if target is not None:
+                self.record(target, polarity)
             return
         if isinstance(value, TypeVarTupleBindingValue):
             for _, member in value.binding:
                 self.collect(member, polarity)
             return
         if isinstance(value, TypeVarTupleValue):
+            self.record(value.typevar_tuple_param, polarity)
             return
         if isinstance(value, TypeFormValue):
             self.collect(value.inner_type, polarity)
@@ -289,6 +315,9 @@ class _PolarityCollector:
             return
         input_sig_value = _input_sig_value(value)
         if input_sig_value is not None:
+            if isinstance(input_sig_value.input_sig, ParamSpecParam):
+                self.record(input_sig_value.input_sig, polarity)
+                return
             for member in input_sig_value.input_sig.walk_values():
                 if member is not input_sig_value:
                     self.collect(member, polarity)
@@ -323,13 +352,17 @@ class _PolarityCollector:
         match value:
             case TypeVarValue(typevar_param=typevar_param):
                 self.record(typevar_param, polarity)
-            case ParamSpecArgsValue() | ParamSpecKwargsValue():
-                return
+            case ParamSpecArgsValue(param_spec=param_spec) | ParamSpecKwargsValue(
+                param_spec=param_spec
+            ):
+                target = self._type_params_by_identity.get(param_spec)
+                if target is not None:
+                    self.record(target, polarity)
             case TypeVarTupleBindingValue(binding=binding):
                 for _, member in binding:
                     self.collect(member, polarity)
-            case TypeVarTupleValue():
-                return
+            case TypeVarTupleValue(typevar_tuple_param=typevar_tuple_param):
+                self.record(typevar_tuple_param, polarity)
             case TypeFormValue(inner_type=inner_type):
                 self.collect(inner_type, polarity)
             case NotValue(value=inner_type):
@@ -387,7 +420,12 @@ class _PolarityCollector:
     def collect_signature(
         self, signature: object, polarity: _Polarity, *, skip_first_parameter: bool
     ) -> None:
-        from .signature import BoundMethodSignature, OverloadedSignature, Signature
+        from .signature import (
+            BoundMethodSignature,
+            OverloadedSignature,
+            ParameterKind,
+            Signature,
+        )
 
         if isinstance(signature, BoundMethodSignature):
             signature = signature.signature
@@ -402,7 +440,22 @@ class _PolarityCollector:
         for index, param in enumerate(signature.parameters.values()):
             if skip_first_parameter and index == 0:
                 continue
-            self.collect(param.annotation, polarity.compose(_Polarity.CONTRAVARIANT))
+            annotation = param.annotation
+            if (
+                param.kind is ParameterKind.VAR_POSITIONAL
+                and isinstance(annotation, GenericValue)
+                and annotation.typ is tuple
+                and len(annotation.args) == 1
+            ):
+                annotation = annotation.args[0]
+            elif (
+                param.kind is ParameterKind.VAR_KEYWORD
+                and isinstance(annotation, GenericValue)
+                and annotation.typ is dict
+                and len(annotation.args) == 2
+            ):
+                annotation = annotation.args[1]
+            self.collect(annotation, polarity.compose(_Polarity.CONTRAVARIANT))
         self.collect(signature.return_value, polarity)
 
     def collect_class_symbol(
@@ -428,6 +481,10 @@ class _PolarityCollector:
             if name in {"__init__", "__new__"}:
                 return
             if symbol.initializer is not None:
+                if symbol.is_classmethod and self._collect_classmethod_wrapper(
+                    symbol.initializer, _Polarity.COVARIANT
+                ):
+                    return
                 signature = self._ctx.signature_from_value(symbol.initializer)
                 if signature is None:
                     self.collect(symbol.initializer, _Polarity.COVARIANT)
@@ -446,6 +503,26 @@ class _PolarityCollector:
             else _Polarity.INVARIANT
         )
         self.collect(symbol.annotation, attribute_polarity)
+
+    def _collect_classmethod_wrapper(self, value: Value, polarity: _Polarity) -> bool:
+        if (
+            not isinstance(value, GenericValue)
+            or value.typ is not classmethod
+            or len(value.args) != 3
+        ):
+            return False
+        input_sig_value = _input_sig_value(value.args[1])
+        if input_sig_value is None:
+            return False
+        from pycroscope.input_sig import FullSignature
+
+        if not isinstance(input_sig_value.input_sig, FullSignature):
+            return False
+        self.collect_signature(
+            input_sig_value.input_sig.sig, polarity, skip_first_parameter=False
+        )
+        self.collect(value.args[2], polarity)
+        return True
 
 
 def _is_type_param_declaration_node(node: ast.AST) -> bool:
@@ -967,10 +1044,8 @@ class ActiveTypeParams:
         type_param = visitor.get_type_param_from_value(value)
         if type_param is not None:
             self._check_direct_type_param_usage(node, type_param)
-            if (
-                isinstance(type_param, TypeVarParam)
-                and self._variance_collections
-                and (visitor.in_annotation or self._variance_outside_annotations > 0)
+            if self._variance_collections and (
+                visitor.in_annotation or self._variance_outside_annotations > 0
             ):
                 for context in self._variance_collections:
                     used_polarities = context.type_param_polarities.get(

--- a/pycroscope/typeshed.py
+++ b/pycroscope/typeshed.py
@@ -237,6 +237,14 @@ _RUNTIME_TO_TYPESHED_ALIASES = {
 }
 
 
+def _resolved_name(info: typeshed_client.resolver.ResolvedName) -> str | None:
+    while isinstance(info, typeshed_client.ImportedInfo):
+        info = info.info
+    if isinstance(info, typeshed_client.NameInfo):
+        return info.name
+    return None
+
+
 @dataclass
 class TypeshedFinder:
     ctx: CanAssignContext = field(repr=False)
@@ -1664,6 +1672,19 @@ class TypeshedFinder:
     def _value_from_info_inner(
         self, info: typeshed_client.resolver.ResolvedName, module: str
     ) -> Value:
+        if isinstance(info, typeshed_client.ImportedInfo) and module in {
+            "typing",
+            "typing_extensions",
+        }:
+            runtime_name = _resolved_name(info)
+            if runtime_name is not None:
+                try:
+                    runtime_module = __import__(module)
+                    runtime_value = getattr(runtime_module, runtime_name)
+                except (AttributeError, ImportError):
+                    pass
+                else:
+                    return KnownValue(runtime_value)
         if isinstance(info, typeshed_client.ImportedInfo):
             return self._value_from_info(info.info, ".".join(info.source_module))
         elif isinstance(info, typeshed_client.NameInfo):

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -347,7 +347,8 @@ def pack_typevartuple_binding(values: Iterable["Value"]) -> SequenceMembers:
     return tuple(members)
 
 
-def typevartuple_value_to_members(value: "Value") -> SequenceMembers:
+def get_typevartuple_members(value: "Value") -> SequenceMembers | None:
+    """Return canonical pack members if value can represent a TypeVarTuple."""
     if isinstance(value, TypeVarTupleValue):
         return ((True, value),)
     if isinstance(value, TypeVarTupleBindingValue):
@@ -363,6 +364,14 @@ def typevartuple_value_to_members(value: "Value") -> SequenceMembers:
         and len(normalized.args) == 1
     ):
         return ((True, normalized.args[0]),)
+    return None
+
+
+def typevartuple_value_to_members(value: "Value") -> SequenceMembers:
+    """Return canonical pack members, raising for an invalid substitution."""
+    members = get_typevartuple_members(value)
+    if members is not None:
+        return members
     raise TypeError(
         f"TypeVarTuple substitutions must be tuple-like values, not {value}"
     )
@@ -495,21 +504,26 @@ class Variance(enum.Enum):
     CONTRAVARIANT = 2
     INVARIANT = 3
     INFERRED = 4
+    UNSPECIFIED = 5
 
     def display_name(self) -> str:
         return self.name.lower()
 
 
-def get_typevar_variance(typevar: TypeVarLike) -> Variance:
-    if not is_instance_of_typing_name(typevar, "TypeVar"):
-        return Variance.INVARIANT
-    is_covariant = bool(getattr(typevar, "__covariant__", False))
-    is_contravariant = bool(getattr(typevar, "__contravariant__", False))
+def get_type_param_variance(type_param: TypeVarLike) -> Variance:
+    is_covariant = bool(safe_getattr(type_param, "__covariant__", False))
+    is_contravariant = bool(safe_getattr(type_param, "__contravariant__", False))
     if is_covariant and not is_contravariant:
         return Variance.COVARIANT
     if is_contravariant and not is_covariant:
         return Variance.CONTRAVARIANT
     return Variance.INVARIANT
+
+
+# Keep "derive this from the runtime object" distinct from an explicitly supplied
+# invariant variance. This matters when dataclasses.replace() stores an inferred
+# invariant result on a parameter whose runtime object has __infer_variance__ set.
+_DEFAULT_TYPE_PARAM_VARIANCE = Variance.UNSPECIFIED
 
 
 class Value:
@@ -1161,7 +1175,7 @@ class TypeVarParam:
     bound: Value | None = None
     default: Value | None = None
     constraints: Sequence[Value] = ()
-    variance: Variance = Variance.INVARIANT
+    variance: Variance = _DEFAULT_TYPE_PARAM_VARIANCE
     is_self: bool = False
     """Whether this TypeVar represents typing.Self."""
 
@@ -1196,8 +1210,8 @@ class TypeVarParam:
                     "default",
                     _value_from_runtime_type_param_component(runtime_default),
                 )
-        if self.variance is Variance.INVARIANT:
-            object.__setattr__(self, "variance", get_typevar_variance(self.typevar))
+        if self.variance is _DEFAULT_TYPE_PARAM_VARIANCE:
+            object.__setattr__(self, "variance", get_type_param_variance(self.typevar))
 
     def substitute_typevars(self, typevars: TypeVarMap) -> Value:
         substituted = typevars.get_typevar(self)
@@ -1238,7 +1252,13 @@ class ParamSpecParam:
     param_spec: ParamSpecLike
     owner: TypeParamOwner | None
     default: Value | None = None
-    variance: Variance = Variance.INVARIANT
+    variance: Variance = _DEFAULT_TYPE_PARAM_VARIANCE
+
+    def __post_init__(self) -> None:
+        if self.variance is _DEFAULT_TYPE_PARAM_VARIANCE:
+            object.__setattr__(
+                self, "variance", get_type_param_variance(self.param_spec)
+            )
 
     @property
     def typevar(self) -> ParamSpecLike:
@@ -1265,7 +1285,13 @@ class TypeVarTupleParam:
     typevar_tuple: TypeVarTupleLike
     owner: TypeParamOwner | None
     default: Value | None = None
-    variance: Variance = Variance.INVARIANT
+    variance: Variance = _DEFAULT_TYPE_PARAM_VARIANCE
+
+    def __post_init__(self) -> None:
+        if self.variance is _DEFAULT_TYPE_PARAM_VARIANCE:
+            object.__setattr__(
+                self, "variance", get_type_param_variance(self.typevar_tuple)
+            )
 
     @property
     def typevar(self) -> TypeVarTupleLike:
@@ -1425,6 +1451,16 @@ class TypeAlias:
 
 def default_value_for_type_param(type_param: "TypeParam") -> Value:
     if type_param.default is not None:
+        if isinstance(type_param, ParamSpecParam):
+            from pycroscope.input_sig import (
+                coerce_paramspec_specialization_to_input_sig,
+            )
+
+            return coerce_paramspec_specialization_to_input_sig(type_param.default)
+        if isinstance(type_param, TypeVarTupleParam):
+            return TypeVarTupleBindingValue(
+                typevartuple_value_to_members(type_param.default)
+            )
         return type_param.default
     return AnyValue(AnySource.generic_argument)
 
@@ -4780,8 +4816,7 @@ def _unpack_sequence_value(
         while len(tail) < post_starred_length:
             if len(tail) >= len(value.members) - len(head):
                 return CanAssignError(
-                    f"{value} must have at least"
-                    f" {target_length + post_starred_length} elements"
+                    f"{value} must have at least {target_length + post_starred_length} elements"
                 )
             is_many, val = value.members[-len(tail) - 1]
             if is_many:
@@ -4796,8 +4831,7 @@ def _unpack_sequence_value(
         if remaining_target_length != 0 or remaining_post_starred_length != 0:
             if not remaining_members:
                 return CanAssignError(
-                    f"{value} must have at least"
-                    f" {target_length + post_starred_length} elements"
+                    f"{value} must have at least {target_length + post_starred_length} elements"
                 )
             else:
                 fallback_value = unite_values(*[val for _, val in remaining_members])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
   "typeshed_client>=2.1.0",
-  "typing_extensions>=4.14.0",
+  "typing_extensions>=4.16.0",
   "tomli>=1.1.0; python_version < '3.11'",
 ]
 

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -55,7 +55,4 @@ directives_disjoint_base
 # cases changed because they now use PEP 695 ParamSpec syntax.
 classes_classvar
 classes_override
-generics_mixed_variance_inference
-generics_paramspec_variance
 generics_typevartuple_basic
-generics_typevartuple_variance

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ requires-dist = [
     { name = "qcore", marker = "extra == 'full'", specifier = ">=0.5.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1.0" },
     { name = "typeshed-client", specifier = ">=2.1.0" },
-    { name = "typing-extensions", specifier = ">=4.14.0" },
+    { name = "typing-extensions", specifier = ">=4.16.0" },
     { name = "typing-extensions", marker = "extra == 'tests'", specifier = "==4.16.0" },
 ]
 provides-extras = ["tests", "asynq", "codemod", "full"]


### PR DESCRIPTION
## Summary

- infer variance for `ParamSpec` and `TypeVarTuple` in PEP 695 generic classes
- support explicit and inferred variance for traditional variadic type parameters
- use canonical parameter-signature and tuple-pack representations throughout specialization and relation checks
- enforce variadic parameter variance in protocols and method annotations
- enable the mixed, `ParamSpec`, and `TypeVarTuple` variance conformance cases

## Design

Variance is stored on the common type-parameter wrappers rather than synthetic runtime objects. Generic argument parsing now produces one canonical value per declared parameter: `InputSigValue` for `ParamSpec` and `TypeVarTupleBindingValue` for `TypeVarTuple`. Variance collection and generic relation checks operate on those representations for all three type-parameter kinds.

This removes the previous representation splits that made mixed type parameters, defaults, import-failure mode, and fixed versus unbounded tuple packs fragile.
