### PR TITLE
Reject multiple PEP 695 TypeVarTuples

### DIFF
--- a/changelog.d/20260813_143306_jelle.zijlstra_conformance_single_typevartuple.md
+++ b/changelog.d/20260813_143306_jelle.zijlstra_conformance_single_typevartuple.md
@@ -1,0 +1,1 @@
+- Report an error when a PEP 695 type parameter list contains multiple TypeVarTuples.

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -12335,12 +12335,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         legacy_allowed_identities: set[object] | None = None,
     ) -> Sequence[TypeParam]:
         type_param_values = []
+        first_typevartuple: TypeVarTupleParam | None = None
         for param in type_params:
             value = self.visit(param)
             extracted = _type_param_value_from_value(value, self)
             if extracted is None:
                 assert False, f"unexpected type parameter value: {value!r}"
             type_param_values.append(extracted)
+            if isinstance(extracted, TypeVarTupleParam):
+                if first_typevartuple is None:
+                    first_typevartuple = extracted
+                else:
+                    self._show_error_if_checking(
+                        param,
+                        "Only one TypeVarTuple may appear in a type parameter list",
+                        error_code=ErrorCode.invalid_type_parameter,
+                    )
             if legacy_allowed_identities is not None:
                 legacy_allowed_identities.add(extracted.typevar)
         return type_param_values

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -1493,6 +1493,9 @@ class TestGenericClasses(TestNameCheckVisitorBase):
                 def pack(self, *args: *Ts) -> tuple[*Ts]:
                     return args
 
+            class Bad[*Ts1, *Ts2]:  # E: invalid_type_parameter
+                pass
+
             def capybara() -> None:
                 assert_type(Array[int, str]().pack(1, "x"), tuple[int, str])
         """,

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -50,9 +50,6 @@ dataclasses_descriptors
 # Newly added on typing; pycroscope doesn't fully implement disjoint_base yet
 directives_disjoint_base
 
-# Added or changed by https://github.com/python/typing/pull/2215.
-# ParamSpec and TypeVarTuple variance is not fully implemented yet; the other
-# cases changed because they now use PEP 695 ParamSpec syntax.
+# Recently added conformance cases.
 classes_classvar
 classes_override
-generics_typevartuple_basic


### PR DESCRIPTION
## Summary

- report an error when a PEP 695 type parameter list contains more than one `TypeVarTuple`
- add a regression test and remove the corresponding conformance known failure

## Why

The typing specification permits only one type variable tuple in a type parameter list, but pycroscope previously accepted multiple PEP 695 `TypeVarTuple` parameters.