### PR TITLE
Reject ClassVar fields in NamedTuples

### DIFF
--- a/changelog.d/20260813_143545_jelle.zijlstra_conformance_namedtuple_classvar.md
+++ b/changelog.d/20260813_143545_jelle.zijlstra_conformance_namedtuple_classvar.md
@@ -1,0 +1,1 @@
+- Report an error when ClassVar is used for a NamedTuple field.

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -11916,13 +11916,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if self.scopes.scope_type() is ScopeType.class_scope:
             self._record_namedtuple_class_field(node)
 
-        # TODO: handle TypeAlias and ClassVar
         is_final = Qualifier.Final in qualifiers
         has_classvar = Qualifier.ClassVar in qualifiers
         if has_classvar and self.scopes.scope_type() != ScopeType.class_scope:
             self._show_error_if_checking(
                 node.annotation,
                 "ClassVar can only be used for assignments in class body",
+                error_code=ErrorCode.invalid_qualifier,
+            )
+        if (
+            has_classvar
+            and self.current_tobj is not None
+            and self.current_tobj.is_direct_namedtuple()
+        ):
+            self._show_error_if_checking(
+                node.annotation,
+                "ClassVar cannot be used for NamedTuple fields",
                 error_code=ErrorCode.invalid_qualifier,
             )
         if (

--- a/pycroscope/test_namedtuple.py
+++ b/pycroscope/test_namedtuple.py
@@ -6,7 +6,7 @@ from .test_node_visitor import assert_passes
 class TestNamedTuple(TestNameCheckVisitorBase):
     @assert_passes(allow_import_failures=True)
     def test_namedtuple_after_import_failure(self):
-        from typing import Generic, NamedTuple, TypeVar
+        from typing import ClassVar, Generic, NamedTuple, TypeVar
 
         from typing_extensions import assert_type
 
@@ -53,6 +53,9 @@ class TestNamedTuple(TestNameCheckVisitorBase):
 
         class Point3(NamedTuple):
             _y: int  # E: invalid_namedtuple
+
+        class Point4(NamedTuple):
+            x: ClassVar[int]  # E: invalid_qualifier
 
         class Location(NamedTuple):
             altitude: float = 0.0

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -53,6 +53,5 @@ directives_disjoint_base
 # Added or changed by https://github.com/python/typing/pull/2215.
 # ParamSpec and TypeVarTuple variance is not fully implemented yet; the other
 # cases changed because they now use PEP 695 ParamSpec syntax.
-classes_classvar
 classes_override
 generics_typevartuple_basic


### PR DESCRIPTION
## Summary

- report an invalid qualifier when `ClassVar` is used for a `NamedTuple` field
- add a regression test and remove the corresponding conformance known failure

## Why

`ClassVar` is not permitted for `NamedTuple` fields, but pycroscope previously accepted it even though the equivalent `TypedDict` usage was already rejected.