### PR TITLE
Check explicit constructor overrides

### DIFF
--- a/changelog.d/20260813_143851_jelle.zijlstra_conformance_override_constructors.md
+++ b/changelog.d/20260813_143851_jelle.zijlstra_conformance_override_constructors.md
@@ -1,1 +1,1 @@
-- Check constructor signature compatibility when **init** or **new** is marked with @override.
+- Check constructor signature compatibility when `__init__` or `__new__` is marked with `@override`.

--- a/changelog.d/20260813_143851_jelle.zijlstra_conformance_override_constructors.md
+++ b/changelog.d/20260813_143851_jelle.zijlstra_conformance_override_constructors.md
@@ -1,0 +1,1 @@
+- Check constructor signature compatibility when **init** or **new** is marked with @override.

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -951,7 +951,7 @@ class IgnoredForIncompatibleOverride(StringSequenceOption):
     """These attributes are not checked for incompatible overrides."""
 
     name = "ignored_for_incompatible_overrides"
-    default_value = ["__init__", "__eq__", "__ne__"]
+    default_value = ["__eq__", "__ne__"]
 
 
 _IGNORED_OVERRIDE_METADATA_ATTRIBUTES = {
@@ -3232,8 +3232,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return
         if varname in self.options.get_value_for(IgnoredForIncompatibleOverride):
             return
-        if varname in _IGNORED_OVERRIDE_METADATA_ATTRIBUTES:
-            return
         if varname.startswith("__") and not varname.endswith("__"):
             return
         policy = AttributePolicy(
@@ -3245,6 +3243,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         with self.catch_errors():
             child_attr = self.current_tobj.get_attribute(varname, policy)
         if child_attr is None:
+            return
+        if (
+            varname in _IGNORED_OVERRIDE_METADATA_ATTRIBUTES
+            and FunctionDecorator.override not in child_attr.symbol.function_decorators
+        ):
             return
 
         for base_value in self.current_tobj.get_direct_bases():

--- a/pycroscope/test_override.py
+++ b/pycroscope/test_override.py
@@ -26,6 +26,39 @@ class TestOverride(TestNameCheckVisitorBase):
             def method(self):
                 pass
 
+    @assert_passes()
+    def test_constructor_compatibility_is_checked_for_explicit_override(self):
+        from typing_extensions import override
+
+        class Parent:
+            def __init__(self, x: int) -> None: ...
+
+            def __new__(cls, x: int) -> "Parent":
+                raise NotImplementedError
+
+        class GoodChild(Parent):
+            @override
+            def __init__(self, x: int) -> None: ...
+
+            @override
+            def __new__(cls, x: int) -> "GoodChild":
+                raise NotImplementedError
+
+        class BadChild(Parent):
+            @override
+            def __init__(self, x: str) -> None:  # E: incompatible_override
+                pass
+
+            @override
+            def __new__(cls, x: str) -> "BadChild":  # E: incompatible_override
+                raise NotImplementedError
+
+        class UndecoratedChild(Parent):
+            def __init__(self, x: str) -> None: ...
+
+            def __new__(cls, x: str) -> "UndecoratedChild":
+                raise NotImplementedError
+
     @assert_fails(ErrorCode.override_does_not_override)
     def test_invalid_method(self):
         from typing_extensions import override

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -54,5 +54,4 @@ directives_disjoint_base
 # ParamSpec and TypeVarTuple variance is not fully implemented yet; the other
 # cases changed because they now use PEP 695 ParamSpec syntax.
 classes_classvar
-classes_override
 generics_typevartuple_basic


### PR DESCRIPTION
## Summary

- check `__init__` and `__new__` signature compatibility when they are marked with `@override`
- preserve the normal constructor exemption when `@override` is absent
- add regression coverage and remove the corresponding conformance known failure

## Why

Constructors are normally exempt from Liskov-style override checks, but the typing specification requires the assignability check when a constructor is explicitly marked with `@override`.