### PR TITLE
Infer precise NamedTuple slices

### DIFF
--- a/changelog.d/20260813_144042_jelle.zijlstra_conformance_namedtuple_slices.md
+++ b/changelog.d/20260813_144042_jelle.zijlstra_conformance_namedtuple_slices.md
@@ -1,0 +1,1 @@
+- Infer precise tuple types when slicing NamedTuple instances with literal slices.

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -1143,12 +1143,9 @@ def _sequence_common_getitem_impl(ctx: CallContext, typ: type) -> ImplReturn:
             tuple_members = tuple_members_from_value(self_value, ctx.visitor)
             if tuple_members is not None:
                 generated_tuple_sequence = True
-                if not (
-                    isinstance(original_self_value, TypedValue)
-                    and original_self_value.typ is tuple
-                ):
+                if self_value.typ is not tuple:
                     from_tuple_subtype = not ctx.visitor.checker.make_type_object(
-                        original_self_value.typ
+                        self_value.typ
                     ).is_namedtuple_like()
                 self_value = SequenceValue(tuple, tuple_members)
         type_arg = self_value.get_generic_arg_for_type(typ, ctx.visitor, 0)

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -1147,7 +1147,9 @@ def _sequence_common_getitem_impl(ctx: CallContext, typ: type) -> ImplReturn:
                     isinstance(original_self_value, TypedValue)
                     and original_self_value.typ is tuple
                 ):
-                    from_tuple_subtype = True
+                    from_tuple_subtype = not ctx.visitor.checker.make_type_object(
+                        original_self_value.typ
+                    ).is_namedtuple_like()
                 self_value = SequenceValue(tuple, tuple_members)
         type_arg = self_value.get_generic_arg_for_type(typ, ctx.visitor, 0)
         key = replace_known_sequence_value(key)

--- a/pycroscope/test_namedtuple.py
+++ b/pycroscope/test_namedtuple.py
@@ -261,6 +261,8 @@ class TestNamedTuple(TestNameCheckVisitorBase):
             assert_type(p[-1], str)
             assert_type(p[-2], int)
             assert_type(p[-3], int)
+            assert_type(p[0:2], tuple[int, int])
+            assert_type(p[0:], tuple[int, int, str])
 
             p[3]  # E: incompatible_call
             p[-4]  # E: incompatible_call

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -41,9 +41,6 @@ qualifiers_annotated
 # pycroscope doesn't handle relations between TypedDict and dict etc. correctly
 typeddicts_type_consistency
 
-# pycroscope uses Literal[] over float
-namedtuples_define_class
-
 # https://github.com/python/typing/issues/2259
 dataclasses_descriptors
 


### PR DESCRIPTION
## Summary

- preserve exact NamedTuple field types when evaluating literal tuple slices
- continue widening slices of arbitrary tuple subclasses to plain `tuple`
- add regression coverage and remove the corresponding conformance known failure

## Why

Pycroscope already modeled each NamedTuple field precisely for integer indexing, but the generic tuple-subclass fallback discarded that information for slices.