### PR TITLE
Implement disjoint base validation

### DIFF
--- a/changelog.d/20260813_163533_jelle.zijlstra_disjoint_base_conformance.md
+++ b/changelog.d/20260813_163533_jelle.zijlstra_disjoint_base_conformance.md
@@ -1,0 +1,1 @@
+- Enforce the disjoint-base rules for multiple inheritance, nonempty slots, and invalid decorator targets.

--- a/changelog.d/20260813_163533_jelle.zijlstra_disjoint_base_conformance.md
+++ b/changelog.d/20260813_163533_jelle.zijlstra_disjoint_base_conformance.md
@@ -1,1 +1,1 @@
-- Enforce the disjoint-base rules for multiple inheritance, nonempty slots, and invalid decorator targets.
+- Enforce the disjoint-base rules for multiple inheritance and nonempty slots, and report invalid decorator targets with the new `invalid_disjoint_base` error code.

--- a/pycroscope/error_code.py
+++ b/pycroscope/error_code.py
@@ -141,6 +141,7 @@ ErrorCode = ErrorRegistry(
         Error("invalid_overload", "Invalid overload definition"),
         Error("invalid_type_alias", "Invalid type alias definition"),
         Error("invalid_protocol", "Invalid Protocol definition"),
+        Error("invalid_disjoint_base", "Invalid use of @disjoint_base"),
         Error("invalid_type_parameter", "Invalid type parameter declaration"),
         Error("invalid_dataclass", "Invalid dataclass definition"),
         Error(

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -3786,7 +3786,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 self._show_error_if_checking(
                     disjoint_base_decorators[0],
                     f"disjoint_base cannot be applied to a {target_kind}",
-                    error_code=ErrorCode.invalid_base,
+                    error_code=ErrorCode.invalid_disjoint_base,
                 )
             effective_type_param_values = (
                 type_param_values
@@ -7182,15 +7182,29 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     node, error_code=ErrorCode.missing_return_annotation
                 )
 
-            info_for_computed_value = info
-            if FunctionDecorator.overload in info.decorator_kinds:
-                decorators = [
-                    decorator
-                    for decorator in info.decorators
-                    if not self._is_overload_decorator(decorator[0])
-                ]
-                if len(decorators) != len(info.decorators):
-                    info_for_computed_value = replace(info, decorators=decorators)
+            disjoint_base_decorators = [
+                decorator
+                for value, _, decorator in info.decorators
+                if self._is_disjoint_base_decorator_value(value)
+            ]
+            if disjoint_base_decorators:
+                self._show_error_if_checking(
+                    disjoint_base_decorators[0],
+                    "disjoint_base cannot be applied to a function",
+                    error_code=ErrorCode.invalid_disjoint_base,
+                )
+
+            decorators = [
+                decorator
+                for decorator in info.decorators
+                if not self._is_overload_decorator(decorator[0])
+                and not self._is_disjoint_base_decorator_value(decorator[0])
+            ]
+            info_for_computed_value = (
+                replace(info, decorators=decorators)
+                if len(decorators) != len(info.decorators)
+                else info
+            )
             computed_function = compute_value_of_function(info_for_computed_value, self)
             static_overload_signature: OverloadedSignature | None = None
             overload_dataclass_transform_info: DataclassTransformInfo | None = None

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -3586,10 +3586,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             self._is_final_decorator_value(value) for _, value, _ in decorator_values
         ):
             self.final_class_keys.add(class_key)
-        if any(
-            self._is_disjoint_base_decorator_value(value)
-            for _, value, _ in decorator_values
-        ):
+        disjoint_base_decorators = [
+            decorator
+            for _, value, decorator in decorator_values
+            if self._is_disjoint_base_decorator_value(value)
+        ]
+        if disjoint_base_decorators:
             tobj.set_is_disjoint_base(True)
         is_pep695_generic = sys.version_info >= (3, 12) and node.type_params
 
@@ -3775,6 +3777,17 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 class_scope_object if isinstance(class_scope_object, type) else None
             )
             is_protocol_class = self._is_protocol_class(base_values, class_scope_object)
+            if disjoint_base_decorators and (
+                synthetic_typeddict is not None or is_protocol_class
+            ):
+                target_kind = (
+                    "TypedDict" if synthetic_typeddict is not None else "Protocol"
+                )
+                self._show_error_if_checking(
+                    disjoint_base_decorators[0],
+                    f"disjoint_base cannot be applied to a {target_kind}",
+                    error_code=ErrorCode.invalid_base,
+                )
             effective_type_param_values = (
                 type_param_values
                 if type_param_values
@@ -4093,6 +4106,16 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         self._finalize_synthetic_abstract_members(
             node, class_key, is_protocol_class=is_protocol_class
         )
+        if (
+            self._is_checking()
+            and synthetic_typeddict is None
+            and tobj.get_inherited_disjoint_base() is None
+        ):
+            self._show_error_if_checking(
+                node,
+                "Class has incompatible disjoint bases",
+                error_code=ErrorCode.invalid_base,
+            )
         self._check_for_uninitialized_final_members(class_key)
         return value
 

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -2995,11 +2995,7 @@ def _solid_base(
         return tobj
     typ = tobj.typ
     if not isinstance(typ, type):
-        # TODO: this is not entirely correct in the presence of multiple inheritance.
-        # I think the right approach is to get the solid base for all direct bases, and pick
-        # the one that is a subclass of all others.
-        direct_bases = tuple(tobj.get_direct_base_type_objects())
-        return _solid_base(direct_bases[0], ctx)
+        return tobj.get_disjoint_base() or tobj
     base = typ.__base__
     assert base is not None, f"Type {typ} has no base"
     if _shape_differs(typ, base):

--- a/pycroscope/test_typeis.py
+++ b/pycroscope/test_typeis.py
@@ -654,13 +654,17 @@ class TestTypeIs(TestNameCheckVisitorBase):
             class IncompatibleSlots(SlotBase1, SlotBase2):  # E: invalid_base
                 pass
 
-            @disjoint_base  # E: invalid_base
+            @disjoint_base  # E: invalid_disjoint_base
             class Movie(TypedDict):
                 name: str
 
-            @disjoint_base  # E: invalid_base
+            @disjoint_base  # E: invalid_disjoint_base
             class SupportsClose(Protocol):
                 def close(self) -> None: ...
+
+            @disjoint_base  # E: invalid_disjoint_base
+            def func() -> None:
+                pass
 
     @assert_passes()
     def testTypeIsComprehensionSubtype(self):

--- a/pycroscope/test_typeis.py
+++ b/pycroscope/test_typeis.py
@@ -591,6 +591,77 @@ class TestTypeIs(TestNameCheckVisitorBase):
             if is_left(x) and is_right(x):
                 assert_type(x, Never)
 
+    @assert_passes(run_in_both_module_modes=True)
+    def testDisjointBaseDefinitions(self):
+        from typing import TYPE_CHECKING, NamedTuple, Protocol, TypedDict
+
+        from typing_extensions import disjoint_base
+
+        if TYPE_CHECKING:
+
+            @disjoint_base
+            class Left:
+                pass
+
+            @disjoint_base
+            class Right:
+                pass
+
+            @disjoint_base
+            class LeftChild(Left):
+                pass
+
+            @disjoint_base
+            class Record(NamedTuple):
+                value: int
+
+            class Plain:
+                pass
+
+            class LeftAndPlain(Left, Plain):
+                pass
+
+            class LeftChildAndLeft(LeftChild, Left):
+                pass
+
+            class PlainRecord(Plain, Record):
+                pass
+
+            class LeftAndRight(Left, Right):  # E: invalid_base
+                pass
+
+            class LeftChildAndRight(LeftChild, Right):  # E: invalid_base
+                pass
+
+            class LeftAndRightViaChild(LeftAndPlain, Right):  # E: invalid_base
+                pass
+
+            class LeftRecord(Left, Record):  # E: invalid_base
+                pass
+
+            class SlotBase1:
+                __slots__ = ("x",)
+
+            class SlotBase2:
+                __slots__ = ("y",)
+
+            class EmptySlots:
+                __slots__ = ()
+
+            class SlotAndEmptySlots(SlotBase1, EmptySlots):
+                pass
+
+            class IncompatibleSlots(SlotBase1, SlotBase2):  # E: invalid_base
+                pass
+
+            @disjoint_base  # E: invalid_base
+            class Movie(TypedDict):
+                name: str
+
+            @disjoint_base  # E: invalid_base
+            class SupportsClose(Protocol):
+                def close(self) -> None: ...
+
     @assert_passes()
     def testTypeIsComprehensionSubtype(self):
         from typing import List

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -692,12 +692,32 @@ class TypeObject:
         ) or safe_getattr(self.typ, "__final__", False)
 
     def _compute_is_disjoint_base(self) -> bool:
+        if self.typ is object:
+            return True
+        runtime_disjoint = False
         if isinstance(self.typ, type):
             class_dict = safe_getattr(self.typ, "__dict__", None)
-            return isinstance(class_dict, Mapping) and bool(
-                class_dict.get("__disjoint_base__", False)
-            )
-        return bool(self._directly_disjoint_base)
+            if isinstance(class_dict, Mapping):
+                runtime_disjoint = bool(class_dict.get("__disjoint_base__", False)) or (
+                    "__slots__" in class_dict and bool(class_dict["__slots__"])
+                )
+        if runtime_disjoint or self._directly_disjoint_base:
+            return True
+        dataclass_info = self.get_direct_dataclass_info()
+        if dataclass_info is not None and dataclass_info.slots:
+            return True
+        slots_symbol = self.get_declared_symbol("__slots__")
+        if slots_symbol is None or slots_symbol.initializer is None:
+            return False
+        slots_value = replace_known_sequence_value(slots_symbol.initializer)
+        if isinstance(slots_value, SequenceValue):
+            members = slots_value.get_member_sequence()
+            return members is not None and bool(members)
+        return (
+            isinstance(slots_value, KnownValue)
+            and isinstance(slots_value.val, str)
+            and bool(slots_value.val)
+        )
 
     def _compute_is_protocol(self) -> bool:
         if isinstance(self.typ, ClassOwner):
@@ -1263,6 +1283,29 @@ class TypeObject:
         if self._is_disjoint_base is None:
             self._is_disjoint_base = self._compute_is_disjoint_base()
         return self._is_disjoint_base
+
+    def get_inherited_disjoint_base(self) -> "TypeObject | None":
+        candidates: dict[ClassKey, TypeObject] = {}
+        for base_tobj in self.get_direct_base_type_objects():
+            candidate = base_tobj.get_disjoint_base()
+            if candidate is None:
+                return None
+            candidates[candidate.typ] = candidate
+        if not candidates:
+            return self._checker.make_type_object(object)
+        return next(
+            (
+                candidate
+                for candidate in candidates.values()
+                if all(candidate.is_in_mro(other.typ) for other in candidates.values())
+            ),
+            None,
+        )
+
+    def get_disjoint_base(self) -> "TypeObject | None":
+        if self.is_disjoint_base():
+            return self
+        return self.get_inherited_disjoint_base()
 
     def is_protocol(self) -> bool:
         if self._is_protocol is None:

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -43,6 +43,3 @@ typeddicts_type_consistency
 
 # https://github.com/python/typing/issues/2259
 dataclasses_descriptors
-
-# Newly added on typing; pycroscope doesn't fully implement disjoint_base yet
-directives_disjoint_base


### PR DESCRIPTION
## Summary

- compute inherited disjoint bases across multiple inheritance
- treat explicit markers, nonempty slots, and slotted dataclasses as disjoint bases
- reject incompatible disjoint bases and invalid uses on TypedDicts and Protocols
- use effective disjoint bases when deciding whether synthetic nominal types can intersect

## Root cause

Pycroscope recognized `@disjoint_base` only as a direct marker for intersection checks. It did not compute the effective inherited base or validate class definitions as required by PEP 800.
