### PR TITLE
Simplify disjoint fixed tuple intersections

### DIFF
--- a/changelog.d/20260813_164231_jelle.zijlstra_fixed_tuple_negative_narrowing.md
+++ b/changelog.d/20260813_164231_jelle.zijlstra_fixed_tuple_negative_narrowing.md
@@ -1,0 +1,1 @@
+- Simplify negative narrowing when fixed-length tuple types have different lengths.

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -2904,6 +2904,21 @@ def _intersect_simple_types(
 def _intersect_typed(
     left: TypedValue, right: TypedValue, ctx: CanAssignContext
 ) -> TypeOrIrreducible:
+    if (
+        isinstance(left, SequenceValue)
+        and left.typ is tuple
+        and isinstance(right, SequenceValue)
+        and right.typ is tuple
+    ):
+        left_members = left.get_member_sequence()
+        right_members = right.get_member_sequence()
+        if (
+            left_members is not None
+            and right_members is not None
+            and len(left_members) != len(right_members)
+        ):
+            return NO_RETURN_VALUE
+
     if isinstance(left, TypedDictValue) and isinstance(right, TypedDictValue):
         return _intersect_typeddict(left, right, ctx)
 
@@ -2930,8 +2945,8 @@ def _intersect_typed(
     # TODO: Consider more options for reducing the intersection:
     # - Certain cases involving incompatible metaclasses can return to Never
     # - Possibly some cases with attributes of incompatible types (possibly debatable)
-    # - Cases involving SequenceValue, DictIncompleteValue, and other concrete subclasses of
-    #   TypedValue
+    # - Cases involving compatible SequenceValues, DictIncompleteValue, and other concrete
+    #   subclasses of TypedValue
     return Irreducible
 
 

--- a/pycroscope/test_typeis.py
+++ b/pycroscope/test_typeis.py
@@ -679,6 +679,23 @@ class TestTypeIs(TestNameCheckVisitorBase):
             assert not is_source(x)
             assert_type(x, Intersection[int, Not[Source[object]]])
 
+    @assert_passes(run_in_both_module_modes=True)
+    def testTypeIsNegativeNarrowingFixedTuples(self):
+        from typing import TypeVar
+
+        from typing_extensions import TypeIs, assert_type
+
+        T = TypeVar("T")
+
+        def is_two_element_tuple(val: tuple[T, ...]) -> TypeIs[tuple[T, T]]:
+            return len(val) == 2
+
+        def capybara(names: tuple[str, str] | tuple[str, str, str]) -> None:
+            if is_two_element_tuple(names):
+                assert_type(names, tuple[str, str])
+            else:
+                assert_type(names, tuple[str, str, str])
+
     @assert_passes()
     def testTypeIsMultipleCondition(self):
         from typing_extensions import TypeIs, assert_type

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -2,9 +2,6 @@
 # If a listed case starts passing, or an unlisted case starts failing,
 # the conformance CI workflow should fail and this file should be updated.
 
-# https://github.com/python/typing/pull/2298
-narrowing_typeis
-
 # Doesn't detect when you use a TypeVar in the wrong place
 generics_syntax_scoping
 


### PR DESCRIPTION
## Summary

- recognize that fixed-length tuple types with different lengths cannot overlap
- remove redundant negative tuple constraints after TypeIs narrowing
- mark the corresponding typing conformance case as passing

## Root cause

Tuple intersections fell through to nominal tuple compatibility even when both shapes had known, unequal lengths. The negative narrowing path therefore retained an impossible `Not[...]` constraint.
