### PR TITLE
Fix TypedDict mapping consistency

### DIFF
--- a/changelog.d/20260813_220609_jelle.zijlstra_typeddict_mapping_relations.md
+++ b/changelog.d/20260813_220609_jelle.zijlstra_typeddict_mapping_relations.md
@@ -1,0 +1,1 @@
+- Enforce TypedDict consistency rules for assignments to Mapping and mutable dict types.

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -1091,6 +1091,12 @@ def _has_relation_impl(
         return CanAssignError(f"{right} is not {relation.description} {left}")
 
     if isinstance(left, GenericValue):
+        if isinstance(right, TypedDictValue) and left.typ in {
+            dict,
+            collections.abc.Mapping,
+            collections.abc.MutableMapping,
+        }:
+            return _has_relation_typed_dict_mapping(left, right, relation_ctx)
         if (
             isinstance(right, SequenceValue)
             and left.typ is tuple
@@ -1705,21 +1711,6 @@ def _maybe_specify_error_for_generic(
                     return CanAssignError(
                         f"In value of key-value pair {pair}", [can_assign]
                     )
-    elif isinstance(right, TypedDictValue) and left.typ in {
-        dict,
-        collections.abc.Mapping,
-        collections.abc.MutableMapping,
-    }:
-        if i == 0:
-            for key in right.items:
-                can_assign = relation_ctx.has_relation(expected, KnownValue(key))
-                if isinstance(can_assign, CanAssignError):
-                    return CanAssignError(f"In TypedDict key {key!r}", [can_assign])
-        elif i == 1:
-            for key, entry in right.items.items():
-                can_assign = relation_ctx.has_relation(expected, entry.typ)
-                if isinstance(can_assign, CanAssignError):
-                    return CanAssignError(f"In TypedDict key {key!r}", [can_assign])
     elif isinstance(right, SequenceValue) and left.typ in {
         list,
         set,
@@ -1738,6 +1729,37 @@ def _maybe_specify_error_for_generic(
     return CanAssignError(
         f"In {variance.display_name()} generic parameter {i} to {left}", [error]
     )
+
+
+def _has_relation_typed_dict_mapping(
+    left: GenericValue, right: TypedDictValue, relation_ctx: RelationContext
+) -> CanAssign:
+    if relation_ctx.relation is Relation.EQUIVALENT:
+        return CanAssignError(f"{right} is not equivalent to {left}")
+
+    if left.typ in {dict, collections.abc.MutableMapping}:
+        if right.extra_keys is None or right.extra_keys is NO_RETURN_VALUE:
+            return CanAssignError(
+                f"{right} does not allow mutable extra items required by {left}"
+            )
+        if right.extra_keys_readonly:
+            return CanAssignError(f"Extra items in {right} are read-only")
+        for key, entry in right.items.items():
+            if entry.required:
+                return CanAssignError(
+                    f"TypedDict key {key!r} is required and cannot be deleted"
+                )
+            if entry.readonly:
+                return CanAssignError(f"TypedDict key {key!r} is read-only")
+
+    value_types = [entry.typ for entry in right.items.values()]
+    if right.extra_keys is None:
+        value_types.append(TypedValue(object))
+    elif right.extra_keys is not NO_RETURN_VALUE:
+        value_types.append(right.extra_keys)
+    value_type = unite_values(*value_types)
+    mapping_view = GenericValue(left.typ, [TypedValue(str), value_type])
+    return _has_relation(left, mapping_view, relation_ctx)
 
 
 @dataclass(frozen=True)

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -14,7 +14,7 @@ import itertools
 import warnings
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field, replace
-from types import FunctionType, MethodType
+from types import FunctionType, MethodDescriptorType, MethodType
 from typing import Any, ClassVar, NamedTuple, TypeVar, get_args, get_origin
 
 from typing_extensions import Self, Sentinel, assert_never
@@ -737,6 +737,19 @@ def _has_decomposable_argument(args: Sequence[Argument]) -> bool:
     return False
 
 
+def _typed_dict_as_mapping_receiver(value: TypedDictValue) -> DictIncompleteValue:
+    kv_pairs = [
+        KVPair(KnownValue(key), entry.typ, is_required=entry.required)
+        for key, entry in value.items.items()
+        if not (not entry.required and entry.typ is NO_RETURN_VALUE)
+    ]
+    if value.extra_keys is not None and value.extra_keys is not NO_RETURN_VALUE:
+        kv_pairs.append(
+            KVPair(TypedValue(str), value.extra_keys, is_many=True, is_required=False)
+        )
+    return DictIncompleteValue(dict, kv_pairs)
+
+
 @dataclass(frozen=True)
 class Signature:
     """Represents the signature of a Python callable.
@@ -984,7 +997,8 @@ class Signature:
                 value_to_check = composite.value
                 first_parameter = next(iter(self.parameters.values()), None)
                 is_receiver_parameter = (
-                    first_parameter is param
+                    first_parameter is not None
+                    and first_parameter.name == param.name
                     and param.kind
                     in (
                         ParameterKind.POSITIONAL_ONLY,
@@ -1003,24 +1017,7 @@ class Signature:
                     # bound receiver argument, keep that behavior instead of applying
                     # TypedDict-vs-dict assignment restrictions intended for user-facing
                     # assignment/compatibility checks.
-                    kv_pairs = [
-                        KVPair(KnownValue(key), entry.typ, is_required=entry.required)
-                        for key, entry in composite.value.items.items()
-                        if not (not entry.required and entry.typ is NO_RETURN_VALUE)
-                    ]
-                    if (
-                        composite.value.extra_keys is not None
-                        and composite.value.extra_keys is not NO_RETURN_VALUE
-                    ):
-                        kv_pairs.append(
-                            KVPair(
-                                TypedValue(str),
-                                composite.value.extra_keys,
-                                is_many=True,
-                                is_required=False,
-                            )
-                        )
-                    value_to_check = DictIncompleteValue(dict, kv_pairs)
+                    value_to_check = _typed_dict_as_mapping_receiver(composite.value)
                 tv_tuple_map = _try_match_typevartuple_var_positional(
                     param, param_typ, value_to_check, ctx.can_assign_ctx
                 )
@@ -1178,7 +1175,7 @@ class Signature:
         return None
 
     def _is_method_like_typeguard_callable(self) -> bool:
-        if isinstance(self.callable, MethodType):
+        if isinstance(self.callable, (MethodType, MethodDescriptorType)):
             return True
         if not isinstance(self.callable, FunctionType):
             return False

--- a/pycroscope/signature.py
+++ b/pycroscope/signature.py
@@ -14,7 +14,7 @@ import itertools
 import warnings
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field, replace
-from types import FunctionType, MethodDescriptorType, MethodType
+from types import FunctionType, MethodDescriptorType, MethodType, WrapperDescriptorType
 from typing import Any, ClassVar, NamedTuple, TypeVar, get_args, get_origin
 
 from typing_extensions import Self, Sentinel, assert_never
@@ -1175,7 +1175,9 @@ class Signature:
         return None
 
     def _is_method_like_typeguard_callable(self) -> bool:
-        if isinstance(self.callable, (MethodType, MethodDescriptorType)):
+        if isinstance(
+            self.callable, (MethodType, MethodDescriptorType, WrapperDescriptorType)
+        ):
             return True
         if not isinstance(self.callable, FunctionType):
             return False

--- a/pycroscope/test_typeddict.py
+++ b/pycroscope/test_typeddict.py
@@ -254,9 +254,9 @@ class TestExtraKeys(TestNameCheckVisitorBase):
 class TestTypedDict(TestNameCheckVisitorBase):
     @assert_passes(run_in_both_module_modes=True)
     def test_mapping_consistency(self):
-        from typing import Any, Mapping, MutableMapping, assert_type
+        from typing import Any, Mapping, MutableMapping
 
-        from typing_extensions import NotRequired, ReadOnly, TypedDict
+        from typing_extensions import NotRequired, ReadOnly, TypedDict, assert_type
 
         class DefaultOpen(TypedDict):
             x: int

--- a/pycroscope/test_typeddict.py
+++ b/pycroscope/test_typeddict.py
@@ -252,6 +252,65 @@ class TestExtraKeys(TestNameCheckVisitorBase):
 
 
 class TestTypedDict(TestNameCheckVisitorBase):
+    @assert_passes(run_in_both_module_modes=True)
+    def test_mapping_consistency(self):
+        from typing import Any, Mapping, MutableMapping, assert_type
+
+        from typing_extensions import NotRequired, ReadOnly, TypedDict
+
+        class DefaultOpen(TypedDict):
+            x: int
+            y: int
+
+        class ExtraInt(TypedDict, extra_items=int):
+            x: NotRequired[int]
+
+        class ReadOnlyExtraInt(TypedDict, extra_items=ReadOnly[int]):
+            x: NotRequired[int]
+
+        class RequiredExtraInt(TypedDict, extra_items=int):
+            x: int
+
+        def check(
+            default_open: DefaultOpen,
+            extra_int: ExtraInt,
+            readonly_extra_int: ReadOnlyExtraInt,
+            required_extra_int: RequiredExtraInt,
+        ) -> None:
+            assert_type(default_open["x"], int)
+            assert_type(default_open.get("x"), int)
+            mapping_object: Mapping[str, object] = default_open
+            mapping_any: Mapping[str, Any] = default_open
+            mapping_int: Mapping[str, int] = default_open  # E: incompatible_assignment
+            dict_int: dict[str, int] = default_open  # E: incompatible_assignment
+            dict_object: dict[str, object] = default_open  # E: incompatible_assignment
+            dict_any: dict[Any, Any] = default_open  # E: incompatible_assignment
+
+            precise_mapping: Mapping[str, int] = extra_int
+            precise_dict: dict[str, int] = extra_int
+            precise_mutable_mapping: MutableMapping[str, int] = extra_int
+
+            readonly_dict: dict[str, int] = (  # E: incompatible_assignment
+                readonly_extra_int
+            )
+
+            required_dict: dict[str, int] = (  # E: incompatible_assignment
+                required_extra_int
+            )
+            print(
+                mapping_object,
+                mapping_any,
+                mapping_int,
+                dict_int,
+                dict_object,
+                dict_any,
+                precise_mapping,
+                precise_dict,
+                precise_mutable_mapping,
+                readonly_dict,
+                required_dict,
+            )
+
     def test_recursive_gradual_typeddict_materializations(self):
         self.assert_passes("""
             from __future__ import annotations

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -2563,11 +2563,6 @@ class DictIncompleteValue(GenericValue):
             value = AnyValue(AnySource.unreachable)
         return GenericValue(self.typ, [key, value], weak=True)
 
-    @property
-    def items(self) -> Sequence[tuple[Value, Value]]:
-        """Sequence of pairs representing the keys and values of the dict."""
-        return [(pair.key, pair.value) for pair in self.kv_pairs]
-
     def get_value(self, key: Value, ctx: CanAssignContext) -> Value:
         """Return the :class:`Value` for a specific key."""
         possible_values = []

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -34,8 +34,5 @@ typeforms_typeform
 literals_parameterizations
 qualifiers_annotated
 
-# pycroscope doesn't handle relations between TypedDict and dict etc. correctly
-typeddicts_type_consistency
-
 # https://github.com/python/typing/issues/2259
 dataclasses_descriptors


### PR DESCRIPTION
## Summary

- model default-open TypedDicts as `Mapping[str, object]`
- enforce mutable mapping compatibility using extra-item, required-key, and read-only rules
- preserve precise inherited dict method behavior for TypedDict receivers
- mark `typeddicts_type_consistency` conformant

## Root cause

TypedDict relations previously considered only the union of declared value types through the nominal `dict` base. That made default-open TypedDicts appear compatible with overly precise `Mapping` value types and allowed assignments to mutable dict types without checking whether keys could be added, removed, or updated.
