### PR TITLE
Fix dependent generic defaults

### DIFF
--- a/changelog.d/20260813_224917_jelle.zijlstra_dependent_generic_defaults.md
+++ b/changelog.d/20260813_224917_jelle.zijlstra_dependent_generic_defaults.md
@@ -1,0 +1,1 @@
+- Apply dependent type parameter defaults correctly when specializing a generic with some type arguments omitted.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1739,9 +1739,21 @@ def type_generic_args_from_members(
             _type_from_value_type_alias_arg(member, type_param, ctx)
             for type_param, member in zip(type_params, members)
         ]
-    matched = match_typevar_arguments(type_params, members)
+    members_for_matching = members
+    members_are_typed = False
+    if len(members) < len(type_params) and not any(
+        isinstance(type_param, TypeVarTupleParam) for type_param in type_params
+    ):
+        members_for_matching = [
+            _type_from_value_type_alias_arg(member, type_param, ctx)
+            for type_param, member in zip(type_params, members)
+        ]
+        members_are_typed = True
+    matched = match_typevar_arguments(type_params, members_for_matching)
     if matched is None:
         return [_type_from_value(member, ctx) for member in members]
+    if members_are_typed:
+        return [argument for _, argument in matched]
     typed_members: list[Value] = []
     for type_param, argument in matched:
         if isinstance(type_param, TypeVarTupleParam):

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -866,6 +866,26 @@ class TestTypeVar(TestNameCheckVisitorBase):
         value: Baz[int, str] = Spam()
         assert_type(value, Baz[int, str])
 
+    @assert_passes(run_in_both_module_modes=True)
+    def test_dependent_generic_default_specialization(self):
+        from typing import Generic
+
+        from typing_extensions import TypeVar, assert_type
+
+        T = TypeVar("T")
+        DefaultListT = TypeVar("DefaultListT", default=list[T])
+
+        class Box(Generic[T, DefaultListT]):
+            value: DefaultListT
+
+            def __init__(self, value: DefaultListT) -> None:
+                self.value = value
+
+        def capybara(box: Box[int]) -> None:
+            assert_type(box.value, list[int])
+
+        assert_type(Box[int]([]), Box[int, list[int]])
+
 
 class TestSolve(TestNameCheckVisitorBase):
     @assert_passes()


### PR DESCRIPTION
## Summary

- Normalize supplied generic arguments before substituting dependent defaults.
- Keep the existing TypeVarTuple matching path unchanged.
- Cover dependent defaults in annotations and specialized constructor calls in both module modes.

## Rationale

When a generic was specialized with some arguments omitted, explicit arguments were still represented as runtime values while defaults were substituted. A default such as `list[T]` therefore became the malformed internal equivalent of `list[type 'int']` for `Box[int]`. Converting the supplied arguments to their canonical type representation first allows the existing substitution logic to produce `list[int]`.
