### PR TITLE
Accept referential TypeVarTuple defaults

### DIFF
--- a/changelog.d/20260813_225105_jelle.zijlstra_typevartuple_referential_default.md
+++ b/changelog.d/20260813_225105_jelle.zijlstra_typevartuple_referential_default.md
@@ -1,0 +1,1 @@
+- Allow `TypeVarTuple` defaults to refer to another unpacked `TypeVarTuple` and report invalid non-unpacked defaults.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1407,6 +1407,10 @@ def make_type_param(
         default = _type_param_component_from_runtime(runtime_default, ctx)
     else:
         default = None
+    if is_instance_of_typing_name(tv, "TypeVarTuple"):
+        return TypeVarTupleParam(
+            tv, owner=owner, default=default, variance=get_type_param_variance(tv)
+        )
     if isinstance(tv, (TypeVar, typing_extensions.TypeVar)):
         if getattr(tv, "__bound__", None) is not None:
             bound = _type_from_runtime(tv.__bound__, ctx)
@@ -1428,10 +1432,6 @@ def make_type_param(
         )
     if is_instance_of_typing_name(tv, "ParamSpec"):
         return ParamSpecParam(
-            tv, owner=owner, default=default, variance=get_type_param_variance(tv)
-        )
-    if is_instance_of_typing_name(tv, "TypeVarTuple"):
-        return TypeVarTupleParam(
             tv, owner=owner, default=default, variance=get_type_param_variance(tv)
         )
     raise TypeError(f"Unsupported type parameter: {tv!r}")

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1010,9 +1010,14 @@ def make_type_param_from_value(
                     variance=variance,
                 )
             elif is_typing_name(runtime_val.typ, "TypeVarTuple"):
-                name, default = _extract_common_type_param_args(value, ctx)
+                name = _extract_type_param_name_arg(value)
                 if name is None:
                     return None
+                default_val = value.arguments.get("default", NO_ARG_SENTINEL)
+                if default_val is NO_ARG_SENTINEL:
+                    default = None
+                else:
+                    default = _typevartuple_default_from_value(default_val, ctx)
                 variance = _extract_partial_type_param_variance(value, ctx)
                 if variance is None:
                     return None
@@ -1145,6 +1150,20 @@ def _paramspec_default_from_value(value: Value, ctx: Context) -> Value:
             value.typ, [(False, type_from_value(member, ctx=ctx)) for member in members]
         )
     return type_from_value(value, ctx=ctx)
+
+
+def _typevartuple_default_from_value(value: Value, ctx: Context) -> Value:
+    expr = _annotation_expr_from_value(value, ctx)
+    unpacked, qualifiers = expr.unqualify({Qualifier.Unpack})
+    members = _unpack_value(unpacked) if Qualifier.Unpack in qualifiers else None
+    if members is None:
+        ctx.show_error(
+            "TypeVarTuple default must be an unpacked tuple or TypeVarTuple",
+            error_code=ErrorCode.incompatible_argument,
+            node=ctx.get_error_node(),
+        )
+        return AnyValue(AnySource.error)
+    return TypeVarTupleBindingValue(tuple(members))
 
 
 def _show_type_param_call_error(

--- a/pycroscope/implementation.py
+++ b/pycroscope/implementation.py
@@ -4056,7 +4056,7 @@ def get_default_argspecs() -> dict[object, ConcreteSignature]:
             tvt_params = [name_param]
             if sys.version_info >= (3, 12) or mod is typing_extensions:
                 tvt_params.append(
-                    replace(default_param, annotation=TypeFormValue(TypedValue(object)))
+                    replace(default_param, annotation=AnyValue(AnySource.explicit))
                 )
             if sys.version_info >= (3, 15) or mod is typing_extensions:
                 tvt_params.append(

--- a/pycroscope/test_implementation.py
+++ b/pycroscope/test_implementation.py
@@ -2175,6 +2175,21 @@ class TestTypeParameterConstructs(TestNameCheckVisitorBase):
             )
             print(BadTypeVarTuple)
 
+    @assert_passes(run_in_both_module_modes=True)
+    def test_typevartuple_impl_validates_default(self):
+        from typing_extensions import TypeVarTuple, Unpack
+
+        DefaultTs = TypeVarTuple("DefaultTs", default=Unpack[tuple[str, int]])
+        AnotherDefaultTs = TypeVarTuple("AnotherDefaultTs", default=Unpack[DefaultTs])
+        BadTuple = TypeVarTuple(
+            "BadTuple", default=tuple[str, int]  # E: incompatible_argument
+        )
+        BadType = TypeVarTuple("BadType", default=int)  # E: incompatible_argument
+        BadUnpack = TypeVarTuple(
+            "BadUnpack", default=Unpack[list[int]]  # E: incompatible_argument
+        )
+        print(DefaultTs, AnotherDefaultTs, BadTuple, BadType, BadUnpack)
+
 
 @skip_if(not hasattr(typing_extensions, "Sentinel"))
 class TestSentinelImplementation(TestNameCheckVisitorBase):


### PR DESCRIPTION
## Summary

- accept unpacked tuple and referential `TypeVarTuple` defaults
- diagnose defaults that are not an unpacked tuple or `TypeVarTuple`

## Rationale

The runtime `TypeVarTuple` signature required `default` to be a `TypeForm`, so a valid default such as `Unpack[OtherTs]` was rejected before the type-parameter parser could interpret it. The signature now delegates the argument to the parser, which validates the TypeVarTuple-specific syntax and stores a canonical pack binding.
