### PR TITLE
Apply defaults to bare generic annotations

### DIFF
--- a/changelog.d/20260813_225412_jelle.zijlstra_bare_generic_defaults.md
+++ b/changelog.d/20260813_225412_jelle.zijlstra_bare_generic_defaults.md
@@ -1,0 +1,1 @@
+- Apply PEP 696 type parameter defaults when a generic class is used without explicit type arguments.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -172,6 +172,7 @@ from .value import (
     replace_known_sequence_value,
     stringify_object,
     type_param_to_value,
+    typevar_map_from_type_param_defaults,
     typevartuple_binding_to_generic_args,
     typevartuple_value_to_members,
     unite_values,
@@ -869,7 +870,7 @@ def _type_from_runtime(val: Any, ctx: Context) -> Value:
         # Bare TypeForm is equivalent to TypeForm[Any].
         return TypeFormValue(AnyValue(AnySource.explicit))
     elif isinstance(val, type):
-        return _maybe_typed_value(val)
+        return _type_from_bare_runtime_class(val, ctx)
     elif val is None:
         return KnownValue(None)
     elif is_typing_name(val, "NoReturn") or is_typing_name(val, "Never"):
@@ -2451,6 +2452,15 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
     elif isinstance(value, TypedDictValue):
         return value
     elif isinstance(value, SyntheticClassObjectValue):
+        if type(value.class_type) is TypedValue:
+            return _type_from_bare_class(
+                value.class_type.typ,
+                (
+                    ctx.can_assign_ctx.get_type_parameters(value.class_type.typ)
+                    if ctx.can_assign_ctx is not None
+                    else ()
+                ),
+            )
         return value.class_type
     elif isinstance(value, (TypeVarValue, TypeVarTupleValue, TypeAliasValue)):
         return value
@@ -3864,6 +3874,24 @@ def _maybe_typed_value(val: ClassKey) -> Value:
     elif val is complex:
         return TypedValue(complex) | TypedValue(float) | TypedValue(int)
     return TypedValue(val)
+
+
+def _type_from_bare_runtime_class(val: type, ctx: Context) -> Value:
+    return _type_from_bare_class(
+        val, _get_generic_type_parameters_for_annotation(val, ctx)
+    )
+
+
+def _type_from_bare_class(typ: ClassKey, type_params: Sequence[TypeParam]) -> Value:
+    if not type_params or not any(param.default is not None for param in type_params):
+        return _maybe_typed_value(typ)
+    substitutions = typevar_map_from_type_param_defaults(type_params)
+    args = []
+    for param in type_params:
+        arg = substitutions.get_value(param)
+        assert arg is not None
+        args.append(arg)
+    return GenericValue(typ, _canonicalize_generic_args_for_value(args))
 
 
 def _make_sequence_value(

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -2032,13 +2032,7 @@ class TestSyntheticType(TestNameCheckVisitorBase):
     def test_bare_generic_instance_attributes_use_defaults(self):
         from typing import Any, Callable, Generic
 
-        from typing_extensions import (
-            ParamSpec,
-            TypeVar,
-            TypeVarTuple,
-            Unpack,
-            assert_type,
-        )
+        from typing_extensions import ParamSpec, TypeVar, assert_type
 
         T = TypeVar("T")
         NestedDefaultT = TypeVar("NestedDefaultT", default=list[T])
@@ -2055,22 +2049,32 @@ class TestSyntheticType(TestNameCheckVisitorBase):
         class WithParamSpecDefault(Generic[P]):
             callback: Callable[P, None]
 
-        Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
-
-        class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
-            elements: tuple[Unpack[Ts]]
-
         def check(
             nested: WithNestedDefault,  # E: missing_generic_parameters
             child: BareSubclass,
             paramspec: WithParamSpecDefault,  # E: missing_generic_parameters
-            typevartuple: WithTypeVarTupleDefault,  # E: missing_generic_parameters
         ) -> None:
             assert_type(nested.required, Any)
             assert_type(nested.nested, list[Any])
             assert_type(child.required, Any)
             assert_type(child.nested, list[Any])
             assert_type(paramspec.callback, Callable[[str, int], None])
+
+    @skip_before((3, 11))
+    @assert_passes(run_in_both_module_modes=True)
+    def test_bare_generic_typevartuple_attribute_uses_default(self):
+        from typing import Generic
+
+        from typing_extensions import TypeVarTuple, Unpack, assert_type
+
+        Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
+
+        class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
+            elements: tuple[Unpack[Ts]]
+
+        def check(
+            typevartuple: WithTypeVarTupleDefault,  # E: missing_generic_parameters
+        ) -> None:
             assert_type(typevartuple.elements, tuple[str, int])
 
     @assert_passes()

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -2028,6 +2028,51 @@ class TestSyntheticType(TestNameCheckVisitorBase):
         assert_type(Box[bool](True, s).first, bool)
         assert_type(Box[bool](True, s).second, str)
 
+    @assert_passes(run_in_both_module_modes=True)
+    def test_bare_generic_instance_attributes_use_defaults(self):
+        from typing import Any, Callable, Generic
+
+        from typing_extensions import (
+            ParamSpec,
+            TypeVar,
+            TypeVarTuple,
+            Unpack,
+            assert_type,
+        )
+
+        T = TypeVar("T")
+        NestedDefaultT = TypeVar("NestedDefaultT", default=list[T])
+
+        class WithNestedDefault(Generic[T, NestedDefaultT]):
+            required: T
+            nested: NestedDefaultT
+
+        class BareSubclass(WithNestedDefault):
+            pass
+
+        P = ParamSpec("P", default=[str, int])
+
+        class WithParamSpecDefault(Generic[P]):
+            callback: Callable[P, None]
+
+        Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
+
+        class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
+            elements: tuple[Unpack[Ts]]
+
+        def check(
+            nested: WithNestedDefault,  # E: missing_generic_parameters
+            child: BareSubclass,
+            paramspec: WithParamSpecDefault,  # E: missing_generic_parameters
+            typevartuple: WithTypeVarTupleDefault,  # E: missing_generic_parameters
+        ) -> None:
+            assert_type(nested.required, Any)
+            assert_type(nested.nested, list[Any])
+            assert_type(child.required, Any)
+            assert_type(child.nested, list[Any])
+            assert_type(paramspec.callback, Callable[[str, int], None])
+            assert_type(typevartuple.elements, tuple[str, int])
+
     @assert_passes()
     def test_protocol_hash_method_accepts_class_object_metaclass_hash(self):
         from typing import Protocol

--- a/pycroscope/type_object.py
+++ b/pycroscope/type_object.py
@@ -120,6 +120,7 @@ from .value import (
     substitute_typevartuple_binding,
     tuple_members_from_value,
     type_param_to_value,
+    typevar_map_from_type_param_defaults,
     typevar_map_from_varlike_pairs,
     typevartuple_binding_to_generic_args,
     typevartuple_binding_to_tuple_value,
@@ -3365,12 +3366,7 @@ def _get_tv_map_for_mro(
                 )
             return substituted
         else:
-            substitutions = TypeVarMap()
-            for param in params:
-                substitutions = substitutions.with_value(
-                    param, AnyValue(AnySource.generic_argument)
-                )
-            return substitutions
+            return typevar_map_from_type_param_defaults(params)
     else:
         return TypeVarMap()
 
@@ -3414,12 +3410,7 @@ def _match_up_generic_params(
     returning a mapping of type variables to values."""
     seq = match_typevar_arguments(type_params, generic_args)
     if seq is None:
-        substitutions = TypeVarMap()
-        for param in type_params:
-            substitutions = substitutions.with_value(
-                param, default_value_for_type_param(param)
-            )
-        return substitutions
+        return typevar_map_from_type_param_defaults(type_params)
     return typevar_map_from_varlike_pairs(seq)
 
 

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -1465,6 +1465,16 @@ def default_value_for_type_param(type_param: "TypeParam") -> Value:
     return AnyValue(AnySource.generic_argument)
 
 
+def typevar_map_from_type_param_defaults(
+    type_params: Sequence["TypeParam"],
+) -> TypeVarMap:
+    substitutions = TypeVarMap()
+    for param in type_params:
+        default = default_value_for_type_param(param).substitute_typevars(substitutions)
+        substitutions = substitutions.with_value(param, default)
+    return substitutions
+
+
 def _split_variadic_type_arguments(
     type_params: Sequence["TypeParam"],
     type_arguments: Sequence[Value],


### PR DESCRIPTION
Bare generic annotations currently remain unspecialized, so attribute lookup exposes unresolved type parameters instead of applying PEP 696 defaults. Bare generic bases and invalid-specialization recovery also construct their fallback substitutions independently.

This change centralizes sequential construction of default substitutions and uses it when parsing bare generic class annotations, resolving bare generic bases, and recovering a generic parameter map. Required parameters still become generic-argument `Any`, while later defaults can reference the substitutions selected for earlier parameters. Bare generic classes with no declared defaults keep their existing representation.

Regression coverage exercises TypeVar, ParamSpec, TypeVarTuple, nested referential defaults, and bare generic inheritance in both module modes.