### PR TITLE
Apply defaults to generic class objects

### DIFF
--- a/changelog.d/20260814_060321_jelle.zijlstra_default_specialized_class_objects.md
+++ b/changelog.d/20260814_060321_jelle.zijlstra_default_specialized_class_objects.md
@@ -1,0 +1,1 @@
+- Apply type parameter defaults when checking the type of a bare generic class object.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -164,6 +164,7 @@ from .value import (
     annotate_value,
     bound_self_type_from_class_key,
     class_owner_from_key,
+    generic_value_from_type_param_defaults,
     get_single_typevartuple_param,
     get_type_param_variance,
     iter_type_params_in_value,
@@ -172,7 +173,6 @@ from .value import (
     replace_known_sequence_value,
     stringify_object,
     type_param_to_value,
-    typevar_map_from_type_param_defaults,
     typevartuple_binding_to_generic_args,
     typevartuple_value_to_members,
     unite_values,
@@ -3916,13 +3916,7 @@ def _type_from_bare_runtime_class(val: type, ctx: Context) -> Value:
 def _type_from_bare_class(typ: ClassKey, type_params: Sequence[TypeParam]) -> Value:
     if not type_params or not any(param.default is not None for param in type_params):
         return _maybe_typed_value(typ)
-    substitutions = typevar_map_from_type_param_defaults(type_params)
-    args = []
-    for param in type_params:
-        arg = substitutions.get_value(param)
-        assert arg is not None
-        args.append(arg)
-    return GenericValue(typ, _canonicalize_generic_args_for_value(args))
+    return generic_value_from_type_param_defaults(typ, type_params)
 
 
 def _make_sequence_value(

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -81,9 +81,9 @@ from pycroscope.value import (
     Value,
     VariableNameValue,
     Variance,
-    default_value_for_type_param,
     flatten_values,
     freshen_typevars_for_inference,
+    generic_value_from_type_param_defaults,
     get_type_params_by_typevar,
     gradualize,
     intersect_bounds_maps,
@@ -912,6 +912,9 @@ def _has_relation_impl(
         elif isinstance(right, KnownValue):
             if not safe_isinstance(right.val, type):
                 return CanAssignError(f"{right} is not a type")
+            right_instance_type = _specialize_class_type_with_defaults(right.val, ctx)
+            if isinstance(right_instance_type, GenericValue):
+                return _has_relation(left.typ, right_instance_type, relation_ctx)
             if isinstance(left.typ, InferenceVarValue):
                 return {
                     left.typ.typevar_param: [
@@ -954,6 +957,10 @@ def _has_relation_impl(
             return CanAssignError(f"{right} is not {relation.description} {left}")
     if isinstance(right, SubclassValue):
         if isinstance(left, KnownValue):
+            if safe_isinstance(left.val, type):
+                left_instance_type = _specialize_class_type_with_defaults(left.val, ctx)
+                if isinstance(left_instance_type, GenericValue):
+                    return _has_relation(left_instance_type, right.typ, relation_ctx)
             return CanAssignError(f"{right} is not {relation.description} {left}")
         elif isinstance(left, TypedValue):
             left_tobj = left.get_type_object(ctx)
@@ -1275,17 +1282,18 @@ def _specialized_synthetic_class_type(
     class_typ = synthetic_class.class_type.typ
     tobj = synthetic_class.get_type_object(ctx)
     declared = tobj.get_declared_type_params()
-    if declared:
-        substitutions = TypeVarMap()
-        specialized_args: list[Value] = []
-        for param in declared:
-            specialized_arg = default_value_for_type_param(param).substitute_typevars(
-                substitutions
-            )
-            substitutions = substitutions.with_value(param, specialized_arg)
-            specialized_args.append(specialized_arg)
-        return GenericValue(class_typ, specialized_args)
+    if declared and any(param.default is not None for param in declared):
+        return generic_value_from_type_param_defaults(class_typ, declared)
     return synthetic_class.class_type
+
+
+def _specialize_class_type_with_defaults(
+    class_typ: type, ctx: CanAssignContext
+) -> TypedValue:
+    declared = ctx.make_type_object(class_typ).get_declared_type_params()
+    if declared and any(param.default is not None for param in declared):
+        return generic_value_from_type_param_defaults(class_typ, declared)
+    return TypedValue(class_typ)
 
 
 def _coerce_paramspec_generic_arg_for_relation(arg: Value, *, other: Value) -> Value:

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -2077,6 +2077,36 @@ class TestSyntheticType(TestNameCheckVisitorBase):
         ) -> None:
             assert_type(typevartuple.elements, tuple[str, int])
 
+    @assert_passes(run_in_both_module_modes=True)
+    def test_bare_generic_class_object_uses_defaults(self):
+        from typing import Any, Callable, Generic
+
+        from typing_extensions import ParamSpec, TypeVar, assert_type
+
+        StartT = TypeVar("StartT", default=int)
+        StopT = TypeVar("StopT", default=StartT)
+        StepT = TypeVar("StepT", default=int | None)
+
+        class Slice(Generic[StartT, StopT, StepT]):
+            pass
+
+        assert_type(Slice, type[Slice[int, int, int | None]])
+
+        T = TypeVar("T")
+        DefaultListT = TypeVar("DefaultListT", default=list[T])
+
+        class Box(Generic[T, DefaultListT]):
+            pass
+
+        assert_type(Box, type[Box[Any, list[Any]]])
+
+        P = ParamSpec("P", default=[str, int])
+
+        class WithParamSpec(Generic[P]):
+            callback: Callable[P, None]
+
+        assert_type(WithParamSpec, type[WithParamSpec[str, int]])
+
     @assert_passes()
     def test_protocol_hash_method_accepts_class_object_metaclass_hash(self):
         from typing import Protocol

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -2061,21 +2061,25 @@ class TestSyntheticType(TestNameCheckVisitorBase):
             assert_type(paramspec.callback, Callable[[str, int], None])
 
     @skip_before((3, 11))
-    @assert_passes(run_in_both_module_modes=True)
     def test_bare_generic_typevartuple_attribute_uses_default(self):
-        from typing import Generic
+        self.assert_passes(
+            """
+            from typing import Generic
 
-        from typing_extensions import TypeVarTuple, Unpack, assert_type
+            from typing_extensions import TypeVarTuple, Unpack, assert_type
 
-        Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
+            Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
 
-        class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
-            elements: tuple[Unpack[Ts]]
+            class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
+                elements: tuple[Unpack[Ts]]
 
-        def check(
-            typevartuple: WithTypeVarTupleDefault,  # E: missing_generic_parameters
-        ) -> None:
-            assert_type(typevartuple.elements, tuple[str, int])
+            def check(
+                typevartuple: WithTypeVarTupleDefault,  # E: missing_generic_parameters
+            ) -> None:
+                assert_type(typevartuple.elements, tuple[str, int])
+            """,
+            run_in_both_module_modes=True,
+        )
 
     @assert_passes(run_in_both_module_modes=True)
     def test_bare_generic_class_object_uses_defaults(self):

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -1475,6 +1475,23 @@ def typevar_map_from_type_param_defaults(
     return substitutions
 
 
+def generic_value_from_type_param_defaults(
+    typ: ClassKey, type_params: Sequence["TypeParam"]
+) -> "GenericValue":
+    substitutions = typevar_map_from_type_param_defaults(type_params)
+    args: list[Value] = []
+    for param in type_params:
+        arg = substitutions.get_value(param)
+        assert arg is not None
+        if isinstance(arg, TypeVarTupleBindingValue) and not any(
+            is_many for is_many, _ in arg.binding
+        ):
+            args.extend(typevartuple_binding_to_generic_args(arg.binding))
+        else:
+            args.append(arg)
+    return GenericValue(typ, args)
+
+
 def _split_variadic_type_arguments(
     type_params: Sequence["TypeParam"],
     type_arguments: Sequence[Value],

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -5,9 +5,8 @@
 # Doesn't detect when you use a TypeVar in the wrong place
 generics_syntax_scoping
 
-# Various issues, defaults not correctly implemented
+# Variadic arguments do not yet account for defaulted trailing ParamSpecs
 generics_defaults
-generics_defaults_referential
 
 # Fails to reject "x" | int annotations that fail at runtime
 # Does not correctly pick up forward refs in unimportable module


### PR DESCRIPTION
## Summary

- Apply PEP 696 defaults when comparing bare generic class objects.
- Share sequential default specialization between annotations and class-object relations.
- Enable the `generics_defaults_referential` conformance case.

## Rationale

Bare generic instance annotations already applied defaults, but a runtime class object still compared as `type[Class]`. This made a class such as `Slice` differ from `type[Slice[int, int, int | None]]`, even though constructing `Slice()` used those defaults. The relation now specializes both runtime and synthetic class-object representations through the same helper, including defaults that refer to earlier parameters.
