### PR TITLE
Match defaulted ParamSpec after TypeVarTuple

### DIFF
--- a/changelog.d/20260814_061742_jelle.zijlstra_variadic_defaulted_paramspec.md
+++ b/changelog.d/20260814_061742_jelle.zijlstra_variadic_defaulted_paramspec.md
@@ -1,0 +1,1 @@
+- Apply a trailing ParamSpec default when preceding type arguments belong to a TypeVarTuple.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1769,7 +1769,13 @@ def type_generic_args_from_members(
             for type_param, member in zip(type_params, members)
         ]
         members_are_typed = True
-    matched = match_typevar_arguments(type_params, members_for_matching)
+    matched = match_typevar_arguments(
+        type_params,
+        members_for_matching,
+        argument_matches_type_param=lambda type_param, argument: (
+            _argument_can_specialize_type_param(type_param, argument, ctx)
+        ),
+    )
     if matched is None:
         return [_type_from_value(member, ctx) for member in members]
     if members_are_typed:
@@ -1865,6 +1871,33 @@ def _normalize_paramspec_generic_arg_in_context(
     return AnyValue(AnySource.error)
 
 
+def _argument_can_specialize_type_param(
+    type_param: TypeParam, argument: Value, ctx: Context
+) -> bool:
+    if not isinstance(type_param, ParamSpecParam):
+        return True
+    if isinstance(argument, KnownValue):
+        argument = replace_known_sequence_value(argument)
+    if isinstance(argument, (InputSigValue, AnyValue)):
+        return True
+    if isinstance(argument, SequenceValue) and argument.typ in (list, tuple):
+        return True
+    if argument == KnownValue(Ellipsis):
+        return True
+    if (
+        isinstance(argument, PartialValue)
+        and argument.operation is PartialValueOperation.SUBSCRIPT
+        and isinstance(argument.root, KnownValue)
+        and is_typing_name(argument.root.val, "Concatenate")
+    ):
+        return True
+    if isinstance(argument, KnownValue) and is_typing_name(
+        get_origin(argument.val), "Concatenate"
+    ):
+        return True
+    return isinstance(make_type_param_from_value(argument, ctx=ctx), ParamSpecParam)
+
+
 def normalize_paramspec_generic_args_in_context(
     type_params: Sequence[TypeParam], args: Sequence[Value], ctx: Context
 ) -> list[Value]:
@@ -1940,11 +1973,25 @@ def _canonicalize_generic_args_for_value(args: Sequence[Value]) -> list[Value]:
 def _canonicalize_generic_args_for_type_params(
     type_params: Sequence[TypeParam], args: Sequence[Value], ctx: Context
 ) -> list[Value]:
-    normalized = normalize_paramspec_generic_args(type_params, args, ctx)
-    matched = match_typevar_arguments(type_params, normalized)
-    if matched is not None:
-        normalized = [argument for _, argument in matched]
-    return list(normalized)
+    matched = match_typevar_arguments(
+        type_params,
+        args,
+        argument_matches_type_param=lambda type_param, argument: (
+            _argument_can_specialize_type_param(type_param, argument, ctx)
+        ),
+    )
+    if matched is None:
+        return normalize_paramspec_generic_args(type_params, args, ctx)
+    return [
+        (
+            _normalize_paramspec_generic_arg_in_context(
+                argument, allow_flat_form=False, ctx=ctx
+            )
+            if isinstance(type_param, ParamSpecParam)
+            else argument
+        )
+        for type_param, argument in matched
+    ]
 
 
 def _normalize_generic_unpack_members(

--- a/pycroscope/arg_spec.py
+++ b/pycroscope/arg_spec.py
@@ -113,6 +113,7 @@ from .value import (
     iter_type_params_in_value,
     make_coro_type,
     pack_typevartuple_binding,
+    split_variadic_type_arguments,
     type_param_to_value,
     with_type_param_owner,
 )
@@ -144,6 +145,17 @@ def _substitute_generic_base_args(
             continue
         specialized = specialized.with_value(type_param, transform(value))
     return specialized
+
+
+def _specialization_argument_matches_type_param(
+    type_param: TypeParam, argument: Value
+) -> bool:
+    if not isinstance(type_param, ParamSpecParam):
+        return True
+    if argument == KnownValue(Ellipsis):
+        return True
+    normalized = coerce_paramspec_specialization_to_input_sig(argument)
+    return isinstance(normalized, (InputSigValue, AnyValue))
 
 
 # types.MethodWrapperType in 3.7+
@@ -1664,8 +1676,12 @@ class ArgSpecCache:
             variadic_arg = generic_args[variadic_index]
             if isinstance(variadic_arg, (TypeVarTupleValue, TypeVarTupleBindingValue)):
                 return list(generic_args)
-        split = self._split_variadic_generic_args(
-            type_params, generic_args, variadic_index
+        split = split_variadic_type_arguments(
+            type_params,
+            generic_args,
+            variadic_index,
+            param_has_default=self._specialization_param_has_default,
+            argument_matches_type_param=_specialization_argument_matches_type_param,
         )
         if split is None:
             return list(generic_args)
@@ -1721,34 +1737,6 @@ class ArgSpecCache:
                 type_params[i], value
             )
         return specialized
-
-    def _split_variadic_generic_args(
-        self,
-        type_params: Sequence[TypeParam],
-        generic_args: Sequence[Value],
-        variadic_index: int,
-    ) -> tuple[int, int] | None:
-        suffix_params = type_params[variadic_index + 1 :]
-        prefix_explicit_count = min(variadic_index, len(generic_args))
-        while prefix_explicit_count >= 0:
-            if any(
-                not self._specialization_param_has_default(type_param)
-                for type_param in type_params[prefix_explicit_count:variadic_index]
-            ):
-                prefix_explicit_count -= 1
-                continue
-            suffix_explicit_count = min(
-                len(suffix_params), len(generic_args) - prefix_explicit_count
-            )
-            omitted_suffix_count = len(suffix_params) - suffix_explicit_count
-            if any(
-                not self._specialization_param_has_default(type_param)
-                for type_param in suffix_params[:omitted_suffix_count]
-            ):
-                prefix_explicit_count -= 1
-                continue
-            return prefix_explicit_count, suffix_explicit_count
-        return None
 
     def _specialization_param_has_default(self, type_param: TypeParam) -> bool:
         if type_param.default is not None:

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -2061,21 +2061,25 @@ class TestSyntheticType(TestNameCheckVisitorBase):
             assert_type(paramspec.callback, Callable[[str, int], None])
 
     @skip_before((3, 11))
-    @assert_passes(run_in_both_module_modes=True)
     def test_bare_generic_typevartuple_attribute_uses_default(self):
-        from typing import Generic
+        self.assert_passes(
+            """
+            from typing import Generic
 
-        from typing_extensions import TypeVarTuple, Unpack, assert_type
+            from typing_extensions import TypeVarTuple, Unpack, assert_type
 
-        Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
+            Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
 
-        class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
-            elements: tuple[Unpack[Ts]]
+            class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
+                elements: tuple[Unpack[Ts]]
 
-        def check(
-            typevartuple: WithTypeVarTupleDefault,  # E: missing_generic_parameters
-        ) -> None:
-            assert_type(typevartuple.elements, tuple[str, int])
+            def check(
+                typevartuple: WithTypeVarTupleDefault,  # E: missing_generic_parameters
+            ) -> None:
+                assert_type(typevartuple.elements, tuple[str, int])
+            """,
+            run_in_both_module_modes=True,
+        )
 
     @assert_passes()
     def test_protocol_hash_method_accepts_class_object_metaclass_hash(self):

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -673,6 +673,29 @@ class TestTypeVar(TestNameCheckVisitorBase):
         """)
 
     @skip_before((3, 11))
+    @assert_passes(allow_import_failures=True)
+    def test_defaulted_paramspec_after_typevartuple(self):
+        from typing import Callable, Generic
+
+        from typing_extensions import ParamSpec, TypeVarTuple, Unpack, assert_type
+
+        Ts = TypeVarTuple("Ts")
+        P = ParamSpec("P", default=[float, bool])
+
+        class WithVariadics(Generic[Unpack[Ts], P]):
+            elements: tuple[Unpack[Ts]]
+            callback: Callable[P, None]
+
+        def check(
+            defaulted: WithVariadics[int, str],
+            explicit: WithVariadics[int, str, [bytes]],
+        ) -> None:
+            assert_type(defaulted.elements, tuple[int, str])
+            assert_type(defaulted.callback, Callable[[float, bool], None])
+            assert_type(explicit.elements, tuple[int, str])
+            assert_type(explicit.callback, Callable[[bytes], None])
+
+    @skip_before((3, 11))
     def test_typevartuple_unpack_assignability(self):
         self.assert_passes("""
             from typing import Any, Generic, NewType, TypeVarTuple

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -673,35 +673,39 @@ class TestTypeVar(TestNameCheckVisitorBase):
         """)
 
     @skip_before((3, 11))
-    @assert_passes(allow_import_failures=True)
     def test_defaulted_paramspec_after_typevartuple(self):
-        from typing import Callable, Generic
+        self.assert_passes(
+            """
+            from typing import Callable, Generic
 
-        from typing_extensions import ParamSpec, TypeVarTuple, Unpack, assert_type
+            from typing_extensions import ParamSpec, TypeVarTuple, Unpack, assert_type
 
-        Ts = TypeVarTuple("Ts")
-        DefaultTs = TypeVarTuple("DefaultTs", default=Unpack[tuple[int, str]])
-        P = ParamSpec("P", default=[float, bool])
+            Ts = TypeVarTuple("Ts")
+            DefaultTs = TypeVarTuple("DefaultTs", default=Unpack[tuple[int, str]])
+            P = ParamSpec("P", default=[float, bool])
 
-        class WithVariadics(Generic[Unpack[Ts], P]):
-            elements: tuple[Unpack[Ts]]
-            callback: Callable[P, None]
+            class WithVariadics(Generic[Unpack[Ts], P]):
+                elements: tuple[Unpack[Ts]]
+                callback: Callable[P, None]
 
-        class WithVariadicDefaults(Generic[Unpack[DefaultTs], P]):
-            elements: tuple[Unpack[DefaultTs]]
-            callback: Callable[P, None]
+            class WithVariadicDefaults(Generic[Unpack[DefaultTs], P]):
+                elements: tuple[Unpack[DefaultTs]]
+                callback: Callable[P, None]
 
-        def check(
-            defaulted: WithVariadics[int, str],
-            explicit: WithVariadics[int, str, [bytes]],
-            defaulted_pack: WithVariadicDefaults[[bytes]],
-        ) -> None:
-            assert_type(defaulted.elements, tuple[int, str])
-            assert_type(defaulted.callback, Callable[[float, bool], None])
-            assert_type(explicit.elements, tuple[int, str])
-            assert_type(explicit.callback, Callable[[bytes], None])
-            assert_type(defaulted_pack.elements, tuple[int, str])
-            assert_type(defaulted_pack.callback, Callable[[bytes], None])
+            def check(
+                defaulted: WithVariadics[int, str],
+                explicit: WithVariadics[int, str, [bytes]],
+                defaulted_pack: WithVariadicDefaults[[bytes]],
+            ) -> None:
+                assert_type(defaulted.elements, tuple[int, str])
+                assert_type(defaulted.callback, Callable[[float, bool], None])
+                assert_type(explicit.elements, tuple[int, str])
+                assert_type(explicit.callback, Callable[[bytes], None])
+                assert_type(defaulted_pack.elements, tuple[int, str])
+                assert_type(defaulted_pack.callback, Callable[[bytes], None])
+            """,
+            allow_import_failures=True,
+        )
 
     @skip_before((3, 11))
     def test_typevartuple_unpack_assignability(self):

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -680,20 +680,28 @@ class TestTypeVar(TestNameCheckVisitorBase):
         from typing_extensions import ParamSpec, TypeVarTuple, Unpack, assert_type
 
         Ts = TypeVarTuple("Ts")
+        DefaultTs = TypeVarTuple("DefaultTs", default=Unpack[tuple[int, str]])
         P = ParamSpec("P", default=[float, bool])
 
         class WithVariadics(Generic[Unpack[Ts], P]):
             elements: tuple[Unpack[Ts]]
             callback: Callable[P, None]
 
+        class WithVariadicDefaults(Generic[Unpack[DefaultTs], P]):
+            elements: tuple[Unpack[DefaultTs]]
+            callback: Callable[P, None]
+
         def check(
             defaulted: WithVariadics[int, str],
             explicit: WithVariadics[int, str, [bytes]],
+            defaulted_pack: WithVariadicDefaults[[bytes]],
         ) -> None:
             assert_type(defaulted.elements, tuple[int, str])
             assert_type(defaulted.callback, Callable[[float, bool], None])
             assert_type(explicit.elements, tuple[int, str])
             assert_type(explicit.callback, Callable[[bytes], None])
+            assert_type(defaulted_pack.elements, tuple[int, str])
+            assert_type(defaulted_pack.callback, Callable[[bytes], None])
 
     @skip_before((3, 11))
     def test_typevartuple_unpack_assignability(self):

--- a/pycroscope/test_value.py
+++ b/pycroscope/test_value.py
@@ -49,7 +49,6 @@ from .value import (
     Value,
     class_owner_from_key,
     concrete_values_from_iterable,
-    match_typevar_arguments,
     unite_and_simplify,
     unpack_values,
 )
@@ -298,16 +297,6 @@ def test_typevarmap_preserves_open_typevartuple_bindings() -> None:
     assert tv_map.get_value(param) == TypeVarTupleBindingValue(
         ((True, TypedValue(str)),)
     )
-
-
-def test_match_typevartuple_uses_default_when_omitted() -> None:
-    Ts = TypeVarTuple("Ts")
-    default = TypeVarTupleBindingValue(
-        ((False, TypedValue(str)), (False, TypedValue(int)))
-    )
-    param = TypeVarTupleParam(Ts, owner=None, default=default)
-
-    assert match_typevar_arguments([param], []) == [(param, default)]
 
 
 def test_get_generic_args_for_type_with_super() -> None:

--- a/pycroscope/test_value.py
+++ b/pycroscope/test_value.py
@@ -49,6 +49,7 @@ from .value import (
     Value,
     class_owner_from_key,
     concrete_values_from_iterable,
+    match_typevar_arguments,
     unite_and_simplify,
     unpack_values,
 )
@@ -297,6 +298,16 @@ def test_typevarmap_preserves_open_typevartuple_bindings() -> None:
     assert tv_map.get_value(param) == TypeVarTupleBindingValue(
         ((True, TypedValue(str)),)
     )
+
+
+def test_match_typevartuple_uses_default_when_omitted() -> None:
+    Ts = TypeVarTuple("Ts")
+    default = TypeVarTupleBindingValue(
+        ((False, TypedValue(str)), (False, TypedValue(int)))
+    )
+    param = TypeVarTupleParam(Ts, owner=None, default=default)
+
+    assert match_typevar_arguments([param], []) == [(param, default)]
 
 
 def test_get_generic_args_for_type_with_super() -> None:

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -1475,31 +1475,64 @@ def typevar_map_from_type_param_defaults(
     return substitutions
 
 
-def _split_variadic_type_arguments(
+def _type_param_has_default(type_param: "TypeParam") -> bool:
+    return type_param.default is not None
+
+
+def _argument_matches_any_type_param(type_param: "TypeParam", argument: Value) -> bool:
+    return True
+
+
+def split_variadic_type_arguments(
     type_params: Sequence["TypeParam"],
     type_arguments: Sequence[Value],
     variadic_index: int,
+    *,
+    param_has_default: Callable[["TypeParam"], bool] | None = None,
+    argument_matches_type_param: Callable[["TypeParam", Value], bool] | None = None,
 ) -> tuple[int, int] | None:
+    if param_has_default is None:
+        param_has_default = _type_param_has_default
+    if argument_matches_type_param is None:
+        argument_matches_type_param = _argument_matches_any_type_param
     suffix_params = type_params[variadic_index + 1 :]
     prefix_explicit_count = min(variadic_index, len(type_arguments))
     while prefix_explicit_count >= 0:
         if any(
-            type_param.default is None
+            not param_has_default(type_param)
             for type_param in type_params[prefix_explicit_count:variadic_index]
         ):
             prefix_explicit_count -= 1
             continue
-        suffix_explicit_count = min(
-            len(suffix_params), len(type_arguments) - prefix_explicit_count
-        )
-        omitted_suffix_count = len(suffix_params) - suffix_explicit_count
-        if any(
-            type_param.default is None
-            for type_param in suffix_params[:omitted_suffix_count]
+        if not all(
+            argument_matches_type_param(type_param, argument)
+            for type_param, argument in zip(
+                type_params[:prefix_explicit_count],
+                type_arguments[:prefix_explicit_count],
+            )
         ):
             prefix_explicit_count -= 1
             continue
-        return prefix_explicit_count, suffix_explicit_count
+        maximum_suffix_explicit_count = min(
+            len(suffix_params), len(type_arguments) - prefix_explicit_count
+        )
+        for suffix_explicit_count in range(maximum_suffix_explicit_count, -1, -1):
+            omitted_suffix_count = len(suffix_params) - suffix_explicit_count
+            if any(
+                not param_has_default(type_param)
+                for type_param in suffix_params[:omitted_suffix_count]
+            ):
+                continue
+            if suffix_explicit_count and not all(
+                argument_matches_type_param(type_param, argument)
+                for type_param, argument in zip(
+                    suffix_params[omitted_suffix_count:],
+                    type_arguments[-suffix_explicit_count:],
+                )
+            ):
+                continue
+            return prefix_explicit_count, suffix_explicit_count
+        prefix_explicit_count -= 1
     return None
 
 
@@ -1508,6 +1541,7 @@ def match_typevar_arguments(
     type_arguments: Sequence[Value],
     *,
     type_arguments_are_packed: bool = False,
+    argument_matches_type_param: Callable[["TypeParam", Value], bool] | None = None,
 ) -> Sequence[tuple["TypeParam", Value]] | None:
     if type_arguments_are_packed:
         if len(type_params) != len(type_arguments):
@@ -1557,6 +1591,11 @@ def match_typevar_arguments(
         )
         if len(type_arguments) < minimum_required:
             return None
+        if argument_matches_type_param is not None and not all(
+            argument_matches_type_param(type_param, argument)
+            for type_param, argument in zip(type_params, type_arguments)
+        ):
+            return None
         for i, type_param in enumerate(type_params):
             argument = (
                 type_arguments[i]
@@ -1574,7 +1613,12 @@ def match_typevar_arguments(
     )
     if len(type_arguments) < minimum_required:
         return None
-    split = _split_variadic_type_arguments(type_params, type_arguments, variadic_index)
+    split = split_variadic_type_arguments(
+        type_params,
+        type_arguments,
+        variadic_index,
+        argument_matches_type_param=argument_matches_type_param,
+    )
     if split is None:
         return None
     prefix_explicit_count, suffix_explicit_count = split
@@ -1591,9 +1635,13 @@ def match_typevar_arguments(
                 else _default_argument(type_param)
             )
         elif i == variadic_index:
-            argument = TypeVarTupleBindingValue(
-                pack_typevartuple_binding(type_arguments[variadic_start:variadic_end])
-            )
+            variadic_arguments = type_arguments[variadic_start:variadic_end]
+            if not variadic_arguments and type_param.default is not None:
+                argument = _default_argument(type_param)
+            else:
+                argument = TypeVarTupleBindingValue(
+                    pack_typevartuple_binding(variadic_arguments)
+                )
         else:
             suffix_index = i - variadic_index - 1
             argument = (

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -5,8 +5,7 @@
 # Doesn't detect when you use a TypeVar in the wrong place
 generics_syntax_scoping
 
-# Various issues, defaults not correctly implemented
-generics_defaults
+# Bare generic class objects do not apply defaults
 generics_defaults_referential
 
 # Fails to reject "x" | int annotations that fail at runtime

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -5,9 +5,6 @@
 # Doesn't detect when you use a TypeVar in the wrong place
 generics_syntax_scoping
 
-# Bare generic class objects do not apply defaults
-generics_defaults_referential
-
 # Fails to reject "x" | int annotations that fail at runtime
 # Does not correctly pick up forward refs in unimportable module
 annotations_forward_refs


### PR DESCRIPTION
## Summary

- Match variadic generic arguments using the kinds of trailing type parameters.
- Apply a trailing `ParamSpec` default when ordinary type arguments belong to the preceding `TypeVarTuple`.
- Share the variadic argument splitter between annotation and runtime specialization paths.
- Preserve a `TypeVarTuple` default when its pack is omitted.

## Rationale

The existing splitter always assigned as many arguments as possible to parameters after a `TypeVarTuple`. For `Generic[*Ts, P]` with a default for `P`, this incorrectly treated the last ordinary type as an explicit `ParamSpec` argument rather than part of `Ts`. Matching now considers whether an argument is valid for the trailing parameter before consuming it, and falls back to the default otherwise.

The branch also keeps the recently added Python 3.11-only `TypeVarTuple` default sample out of Python 3.10's self-check. Pytest skipped the sample there, but the self-check still scanned its function body.
