### PR TITLE
Allow bare generics when all parameters default

### DIFF
--- a/changelog.d/20260814_064804_jelle.zijlstra_defaulted_bare_generic_diagnostic.md
+++ b/changelog.d/20260814_064804_jelle.zijlstra_defaulted_bare_generic_diagnostic.md
@@ -1,0 +1,1 @@
+- Do not report missing generic parameters when every type parameter has a default.

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -8881,7 +8881,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         else:
             return
         generic_params = self.checker.get_type_parameters(val)
-        if not generic_params:
+        if not generic_params or all(
+            type_param.default is not None for type_param in generic_params
+        ):
             return
         self.show_error(
             node,

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -2067,19 +2067,23 @@ class TestSyntheticType(TestNameCheckVisitorBase):
             assert_type(paramspec.callback, Callable[[str, int], None])
 
     @skip_before((3, 11))
-    @assert_passes(run_in_both_module_modes=True)
     def test_bare_generic_typevartuple_attribute_uses_default(self):
-        from typing import Generic
+        self.assert_passes(
+            """
+            from typing import Generic
 
-        from typing_extensions import TypeVarTuple, Unpack, assert_type
+            from typing_extensions import TypeVarTuple, Unpack, assert_type
 
-        Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
+            Ts = TypeVarTuple("Ts", default=Unpack[tuple[str, int]])
 
-        class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
-            elements: tuple[Unpack[Ts]]
+            class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
+                elements: tuple[Unpack[Ts]]
 
-        def check(typevartuple: WithTypeVarTupleDefault) -> None:
-            assert_type(typevartuple.elements, tuple[str, int])
+            def check(typevartuple: WithTypeVarTupleDefault) -> None:
+                assert_type(typevartuple.elements, tuple[str, int])
+            """,
+            run_in_both_module_modes=True,
+        )
 
     @assert_passes()
     def test_protocol_hash_method_accepts_class_object_metaclass_hash(self):

--- a/pycroscope/test_type_object.py
+++ b/pycroscope/test_type_object.py
@@ -2036,6 +2036,7 @@ class TestSyntheticType(TestNameCheckVisitorBase):
 
         T = TypeVar("T")
         NestedDefaultT = TypeVar("NestedDefaultT", default=list[T])
+        DefaultT = TypeVar("DefaultT", default=int)
 
         class WithNestedDefault(Generic[T, NestedDefaultT]):
             required: T
@@ -2043,6 +2044,9 @@ class TestSyntheticType(TestNameCheckVisitorBase):
 
         class BareSubclass(WithNestedDefault):
             pass
+
+        class WithTypeVarDefault(Generic[DefaultT]):
+            value: DefaultT
 
         P = ParamSpec("P", default=[str, int])
 
@@ -2052,12 +2056,14 @@ class TestSyntheticType(TestNameCheckVisitorBase):
         def check(
             nested: WithNestedDefault,  # E: missing_generic_parameters
             child: BareSubclass,
-            paramspec: WithParamSpecDefault,  # E: missing_generic_parameters
+            typevar: WithTypeVarDefault,
+            paramspec: WithParamSpecDefault,
         ) -> None:
             assert_type(nested.required, Any)
             assert_type(nested.nested, list[Any])
             assert_type(child.required, Any)
             assert_type(child.nested, list[Any])
+            assert_type(typevar.value, int)
             assert_type(paramspec.callback, Callable[[str, int], None])
 
     @skip_before((3, 11))
@@ -2072,9 +2078,7 @@ class TestSyntheticType(TestNameCheckVisitorBase):
         class WithTypeVarTupleDefault(Generic[Unpack[Ts]]):
             elements: tuple[Unpack[Ts]]
 
-        def check(
-            typevartuple: WithTypeVarTupleDefault,  # E: missing_generic_parameters
-        ) -> None:
+        def check(typevartuple: WithTypeVarTupleDefault) -> None:
             assert_type(typevartuple.elements, tuple[str, int])
 
     @assert_passes()

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -5,9 +5,8 @@
 # Doesn't detect when you use a TypeVar in the wrong place
 generics_syntax_scoping
 
-# Various issues, defaults not correctly implemented
+# Variadic arguments do not yet account for defaulted trailing ParamSpecs
 generics_defaults
-generics_defaults_referential
 
 # Fails to reject "x" | int annotations that fail at runtime
 # Does not correctly pick up forward refs in unimportable module


### PR DESCRIPTION
## Summary

- Do not report `missing_generic_parameters` for a bare generic when every declared type parameter has a default.
- Cover all-default `TypeVar`, `ParamSpec`, and `TypeVarTuple` classes while retaining the diagnostic for mixed required/defaulted parameters.

## Rationale

Bare generic annotations now specialize defaulted parameters correctly, but the separate missing-parameters diagnostic only checked whether the class declared any type parameters. As a result, fully defaulted generics produced correct attribute types and an incorrect diagnostic at the same time. The diagnostic now requires at least one parameter without a default.
