### PR TITLE
Fix remaining generic default bugs

### DIFF
--- a/changelog.d/20260814_081509_jelle.zijlstra_defaults_immediate_fixes.md
+++ b/changelog.d/20260814_081509_jelle.zijlstra_defaults_immediate_fixes.md
@@ -1,1 +1,1 @@
-- Support `ParamSpec` and `TypeVarTuple` defaults in type parameter syntax, substitute referential `ParamSpec` defaults, and reject defaults of the wrong type parameter kind.
+- Support `ParamSpec` and `TypeVarTuple` defaults in type parameter syntax, substitute referential `ParamSpec` defaults, and report invalid defaults with the new `invalid_type_parameter_default` error code.

--- a/changelog.d/20260814_081509_jelle.zijlstra_defaults_immediate_fixes.md
+++ b/changelog.d/20260814_081509_jelle.zijlstra_defaults_immediate_fixes.md
@@ -1,0 +1,1 @@
+- Support `ParamSpec` and `TypeVarTuple` defaults in type parameter syntax, substitute referential `ParamSpec` defaults, and reject defaults of the wrong type parameter kind.

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1129,7 +1129,20 @@ def _type_param_default_from_value(
             error_code=ErrorCode.incompatible_argument,
             node=partial.node,
         )
+    elif has_invalid_typevar_default_kind(typed):
+        ctx.show_error(
+            "TypeVar default must be a type or TypeVar",
+            error_code=ErrorCode.incompatible_argument,
+            node=getattr(value, "node", partial.node),
+        )
+        return AnyValue(AnySource.error)
     return typed
+
+
+def has_invalid_typevar_default_kind(value: Value) -> bool:
+    return isinstance(
+        value, (InputSigValue, TypeVarTupleBindingValue, TypeVarTupleValue)
+    )
 
 
 def _value_contains_type_params(value: Value, ctx: Context) -> bool:

--- a/pycroscope/annotations.py
+++ b/pycroscope/annotations.py
@@ -1126,13 +1126,13 @@ def _type_param_default_from_value(
     if isinstance(typed, AnyValue) and typed.source is AnySource.error:
         ctx.show_error(
             f"Invalid type parameter default {value}",
-            error_code=ErrorCode.incompatible_argument,
+            error_code=ErrorCode.invalid_type_parameter_default,
             node=partial.node,
         )
     elif has_invalid_typevar_default_kind(typed):
         ctx.show_error(
             "TypeVar default must be a type or TypeVar",
-            error_code=ErrorCode.incompatible_argument,
+            error_code=ErrorCode.invalid_type_parameter_default,
             node=getattr(value, "node", partial.node),
         )
         return AnyValue(AnySource.error)
@@ -1172,7 +1172,7 @@ def _paramspec_default_from_value(value: Value, ctx: Context) -> Value:
 def _invalid_paramspec_default(ctx: Context) -> AnyValue:
     ctx.show_error(
         "ParamSpec default must be a list of types, ellipsis, or ParamSpec",
-        error_code=ErrorCode.incompatible_argument,
+        error_code=ErrorCode.invalid_type_parameter_default,
         node=ctx.get_error_node(),
     )
     return AnyValue(AnySource.error)
@@ -1185,7 +1185,7 @@ def _typevartuple_default_from_value(value: Value, ctx: Context) -> Value:
     if members is None:
         ctx.show_error(
             "TypeVarTuple default must be an unpacked tuple or TypeVarTuple",
-            error_code=ErrorCode.incompatible_argument,
+            error_code=ErrorCode.invalid_type_parameter_default,
             node=ctx.get_error_node(),
         )
         return AnyValue(AnySource.error)
@@ -1193,12 +1193,15 @@ def _typevartuple_default_from_value(value: Value, ctx: Context) -> Value:
 
 
 def _show_type_param_call_error(
-    ctx: Context, message: str, *, value: PartialCallValue, node: ast.AST | None = None
+    ctx: Context,
+    message: str,
+    *,
+    value: PartialCallValue,
+    node: ast.AST | None = None,
+    error_code: Error = ErrorCode.incompatible_call,
 ) -> None:
     ctx.show_error(
-        message,
-        error_code=ErrorCode.incompatible_call,
-        node=node if node is not None else value.node,
+        message, error_code=error_code, node=node if node is not None else value.node
     )
 
 
@@ -1239,6 +1242,7 @@ def _validate_partial_typevar_defaults(
             "TypeVar default must be assignable to its bound",
             value=value,
             node=ctx.get_error_node(),
+            error_code=ErrorCode.invalid_type_parameter_default,
         )
         return
     if not type_param.constraints:
@@ -1263,6 +1267,7 @@ def _validate_partial_typevar_defaults(
         "TypeVar default must be one of its constraints",
         value=value,
         node=ctx.get_error_node(),
+        error_code=ErrorCode.invalid_type_parameter_default,
     )
 
 

--- a/pycroscope/error_code.py
+++ b/pycroscope/error_code.py
@@ -143,6 +143,7 @@ ErrorCode = ErrorRegistry(
         Error("invalid_protocol", "Invalid Protocol definition"),
         Error("invalid_disjoint_base", "Invalid use of @disjoint_base"),
         Error("invalid_type_parameter", "Invalid type parameter declaration"),
+        Error("invalid_type_parameter_default", "Invalid type parameter default"),
         Error("invalid_dataclass", "Invalid dataclass definition"),
         Error(
             "classvar_type_parameters",

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -5738,21 +5738,21 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         node,
                         "Type parameter defaults can reference only earlier type"
                         " parameters from the same class",
-                        error_code=ErrorCode.invalid_type_parameter,
+                        error_code=ErrorCode.invalid_type_parameter_default,
                     )
                     return
             if seen_default and not has_default:
                 self._show_error_if_checking(
                     node,
                     "non-default TypeVars cannot follow ones with defaults",
-                    error_code=ErrorCode.invalid_type_parameter,
+                    error_code=ErrorCode.invalid_type_parameter_default,
                 )
                 return
             if previous_was_typevartuple and has_default and is_typevar:
                 self._show_error_if_checking(
                     node,
                     "TypeVars with defaults cannot follow TypeVarTuples",
-                    error_code=ErrorCode.invalid_type_parameter,
+                    error_code=ErrorCode.invalid_type_parameter_default,
                 )
                 return
             seen_default = seen_default or has_default
@@ -12881,7 +12881,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             resolved, _ = self.resolve_name(root, error_node=root, suppress_errors=True)
             return isinstance(resolved, AnyValue) and resolved.source is AnySource.error
 
-        def _type_from_pep695_type_param_expr(self, node: ast.expr) -> Value:
+        def _type_from_pep695_type_param_expr(
+            self, node: ast.expr, *, suppress_errors: bool = False
+        ) -> Value:
             if isinstance(node, ast.Constant) and isinstance(node.value, str):
                 return type_from_value(
                     KnownValue(node.value), self, node, suppress_errors=True
@@ -12890,7 +12892,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 return type_from_value(
                     KnownValue(ast.unparse(node)), self, node, suppress_errors=True
                 )
-            return type_from_value(self.visit(node), self, node)
+            return type_from_value(
+                self.visit(node), self, node, suppress_errors=suppress_errors
+            )
 
         def _paramspec_default_from_pep695_expr(self, node: ast.expr) -> Value:
             if isinstance(node, ast.Constant) and node.value is Ellipsis:
@@ -12898,17 +12902,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             if isinstance(node, ast.List):
                 members: list[tuple[bool, Value]] = []
                 for member_node in node.elts:
-                    member = self._type_from_pep695_type_param_expr(member_node)
-                    if has_invalid_typevar_default_kind(member):
+                    member = self._type_from_pep695_type_param_expr(
+                        member_node, suppress_errors=True
+                    )
+                    if (
+                        isinstance(member, AnyValue)
+                        and member.source is AnySource.error
+                    ) or has_invalid_typevar_default_kind(member):
                         self._show_error_if_checking(
                             member_node,
                             "Invalid type in ParamSpec default",
-                            error_code=ErrorCode.invalid_annotation,
+                            error_code=ErrorCode.invalid_type_parameter_default,
                         )
                         member = AnyValue(AnySource.error)
                     members.append((False, member))
                 return SequenceValue(list, members)
-            default = self._type_from_pep695_type_param_expr(node)
+            default = self._type_from_pep695_type_param_expr(node, suppress_errors=True)
             if isinstance(default, InputSigValue) and isinstance(
                 default.input_sig, ParamSpecParam
             ):
@@ -12916,7 +12925,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             self._show_error_if_checking(
                 node,
                 "ParamSpec default must be a list of types, ellipsis, or ParamSpec",
-                error_code=ErrorCode.invalid_annotation,
+                error_code=ErrorCode.invalid_type_parameter_default,
             )
             return AnyValue(AnySource.error)
 
@@ -12925,16 +12934,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 self._show_error_if_checking(
                     node,
                     "TypeVarTuple default must be an unpacked tuple or TypeVarTuple",
-                    error_code=ErrorCode.invalid_annotation,
+                    error_code=ErrorCode.invalid_type_parameter_default,
                 )
                 return AnyValue(AnySource.error)
-            unpacked = self._type_from_pep695_type_param_expr(node.value)
-            members = get_typevartuple_members(unpacked)
+            unpacked = self._type_from_pep695_type_param_expr(
+                node.value, suppress_errors=True
+            )
+            members = (
+                None
+                if isinstance(unpacked, AnyValue) and unpacked.source is AnySource.error
+                else get_typevartuple_members(unpacked)
+            )
             if members is None:
                 self._show_error_if_checking(
                     node,
                     "TypeVarTuple default must be an unpacked tuple or TypeVarTuple",
-                    error_code=ErrorCode.invalid_annotation,
+                    error_code=ErrorCode.invalid_type_parameter_default,
                 )
                 return AnyValue(AnySource.error)
             return TypeVarTupleBindingValue(tuple(members))
@@ -13095,12 +13110,17 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         )
             if sys.version_info >= (3, 13):
                 if node.default_value is not None:
-                    default = self._type_from_pep695_type_param_expr(node.default_value)
-                    if has_invalid_typevar_default_kind(default):
+                    default = self._type_from_pep695_type_param_expr(
+                        node.default_value, suppress_errors=True
+                    )
+                    if (
+                        isinstance(default, AnyValue)
+                        and default.source is AnySource.error
+                    ) or has_invalid_typevar_default_kind(default):
                         self._show_error_if_checking(
                             node.default_value,
                             "TypeVar default must be a type or TypeVar",
-                            error_code=ErrorCode.invalid_annotation,
+                            error_code=ErrorCode.invalid_type_parameter_default,
                         )
                         default = AnyValue(AnySource.error)
             maybe_runtime_typevar = self._get_runtime_type_param_for_current_scope(
@@ -15348,7 +15368,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 self._show_error_if_checking(
                     node,
                     "the bound and default are incompatible",
-                    error_code=ErrorCode.invalid_annotation,
+                    error_code=ErrorCode.invalid_type_parameter_default,
                 )
                 return
         if typevar.typevar_param.constraints:
@@ -15409,7 +15429,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             self._show_error_if_checking(
                 node,
                 "TypeVar default must be one of its constraints",
-                error_code=ErrorCode.invalid_annotation,
+                error_code=ErrorCode.invalid_type_parameter_default,
             )
 
     def get_call_result(

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -79,7 +79,6 @@ from .annotations import (
     annotation_expr_from_runtime,
     annotation_expr_from_value,
     has_invalid_paramspec_usage,
-    has_invalid_typevar_default_kind,
     is_context_manager_type,
     is_instance_of_typing_name,
     is_typevarlike,
@@ -92,6 +91,9 @@ from .annotations import (
     type_generic_args_from_members,
     value_from_ast,
 )
+
+if sys.version_info >= (3, 12):
+    from .annotations import has_invalid_typevar_default_kind
 from .arg_spec import ArgSpecCache, IgnoredCallees, UnwrapClass, is_dot_asynq_function
 from .asynq_checker import AsynqChecker
 from .boolability import Boolability, get_boolability

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -79,6 +79,7 @@ from .annotations import (
     annotation_expr_from_runtime,
     annotation_expr_from_value,
     has_invalid_paramspec_usage,
+    has_invalid_typevar_default_kind,
     is_context_manager_type,
     is_instance_of_typing_name,
     is_typevarlike,
@@ -12889,6 +12890,53 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 )
             return type_from_value(self.visit(node), self, node)
 
+        def _paramspec_default_from_pep695_expr(self, node: ast.expr) -> Value:
+            if isinstance(node, ast.Constant) and node.value is Ellipsis:
+                return KnownValue(Ellipsis)
+            if isinstance(node, ast.List):
+                members: list[tuple[bool, Value]] = []
+                for member_node in node.elts:
+                    member = self._type_from_pep695_type_param_expr(member_node)
+                    if has_invalid_typevar_default_kind(member):
+                        self._show_error_if_checking(
+                            member_node,
+                            "Invalid type in ParamSpec default",
+                            error_code=ErrorCode.invalid_annotation,
+                        )
+                        member = AnyValue(AnySource.error)
+                    members.append((False, member))
+                return SequenceValue(list, members)
+            default = self._type_from_pep695_type_param_expr(node)
+            if isinstance(default, InputSigValue) and isinstance(
+                default.input_sig, ParamSpecParam
+            ):
+                return default
+            self._show_error_if_checking(
+                node,
+                "ParamSpec default must be a list of types, ellipsis, or ParamSpec",
+                error_code=ErrorCode.invalid_annotation,
+            )
+            return AnyValue(AnySource.error)
+
+        def _typevartuple_default_from_pep695_expr(self, node: ast.expr) -> Value:
+            if not isinstance(node, ast.Starred):
+                self._show_error_if_checking(
+                    node,
+                    "TypeVarTuple default must be an unpacked tuple or TypeVarTuple",
+                    error_code=ErrorCode.invalid_annotation,
+                )
+                return AnyValue(AnySource.error)
+            unpacked = self._type_from_pep695_type_param_expr(node.value)
+            members = get_typevartuple_members(unpacked)
+            if members is None:
+                self._show_error_if_checking(
+                    node,
+                    "TypeVarTuple default must be an unpacked tuple or TypeVarTuple",
+                    error_code=ErrorCode.invalid_annotation,
+                )
+                return AnyValue(AnySource.error)
+            return TypeVarTupleBindingValue(tuple(members))
+
         def _pep695_type_param_expr_contains_type_param(self, node: ast.AST) -> bool:
             for subnode, _ in _iter_loaded_name_nodes(node):
                 resolved, _ = self.resolve_name(
@@ -13046,6 +13094,13 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             if sys.version_info >= (3, 13):
                 if node.default_value is not None:
                     default = self._type_from_pep695_type_param_expr(node.default_value)
+                    if has_invalid_typevar_default_kind(default):
+                        self._show_error_if_checking(
+                            node.default_value,
+                            "TypeVar default must be a type or TypeVar",
+                            error_code=ErrorCode.invalid_annotation,
+                        )
+                        default = AnyValue(AnySource.error)
             maybe_runtime_typevar = self._get_runtime_type_param_for_current_scope(
                 node.name, expected_kind="TypeVar"
             )
@@ -13069,6 +13124,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
         def visit_ParamSpec(self, node: ast.ParamSpec) -> Value:
             owner = self.active_type_params.current_owner()
+            default = None
+            if sys.version_info >= (3, 13) and node.default_value is not None:
+                default = self._paramspec_default_from_pep695_expr(node.default_value)
             maybe_runtime_param_spec = self._get_runtime_type_param_for_current_scope(
                 node.name, expected_kind="ParamSpec"
             )
@@ -13077,13 +13135,20 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             else:
                 ps = typing.cast(Any, maybe_runtime_param_spec)
             typevar = InputSigValue(
-                ParamSpecParam(ps, owner=owner, variance=Variance.INFERRED)
+                ParamSpecParam(
+                    ps, owner=owner, default=default, variance=Variance.INFERRED
+                )
             )
             self._set_name_in_scope(node.name, node, typevar)
             return typevar
 
         def visit_TypeVarTuple(self, node: ast.TypeVarTuple) -> Value:
             owner = self.active_type_params.current_owner()
+            default = None
+            if sys.version_info >= (3, 13) and node.default_value is not None:
+                default = self._typevartuple_default_from_pep695_expr(
+                    node.default_value
+                )
             maybe_runtime_typevar_tuple = (
                 self._get_runtime_type_param_for_current_scope(
                     node.name, expected_kind="TypeVarTuple"
@@ -13094,7 +13159,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             else:
                 tv = typing.cast(Any, maybe_runtime_typevar_tuple)
             typevar = TypeVarTupleValue(
-                TypeVarTupleParam(tv, owner=owner, variance=Variance.INFERRED)
+                TypeVarTupleParam(
+                    tv, owner=owner, default=default, variance=Variance.INFERRED
+                )
             )
             self._set_name_in_scope(node.name, node, typevar)
             return typevar

--- a/pycroscope/test_implementation.py
+++ b/pycroscope/test_implementation.py
@@ -2182,11 +2182,13 @@ class TestTypeParameterConstructs(TestNameCheckVisitorBase):
         DefaultTs = TypeVarTuple("DefaultTs", default=Unpack[tuple[str, int]])
         AnotherDefaultTs = TypeVarTuple("AnotherDefaultTs", default=Unpack[DefaultTs])
         BadTuple = TypeVarTuple(
-            "BadTuple", default=tuple[str, int]  # E: incompatible_argument
+            "BadTuple", default=tuple[str, int]  # E: invalid_type_parameter_default
         )
-        BadType = TypeVarTuple("BadType", default=int)  # E: incompatible_argument
+        BadType = TypeVarTuple(
+            "BadType", default=int  # E: invalid_type_parameter_default
+        )
         BadUnpack = TypeVarTuple(
-            "BadUnpack", default=Unpack[list[int]]  # E: incompatible_argument
+            "BadUnpack", default=Unpack[list[int]]  # E: invalid_type_parameter_default
         )
         print(DefaultTs, AnotherDefaultTs, BadTuple, BadType, BadUnpack)
 

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -643,6 +643,91 @@ class TestTypeVar(TestNameCheckVisitorBase):
         )
 
     @skip_before((3, 11))
+    def test_type_parameter_default_kinds(self):
+        self.assert_passes(
+            """
+            from typing_extensions import ParamSpec, TypeVar, TypeVarTuple, Unpack
+
+            P = ParamSpec("P")
+            Ts = TypeVarTuple("Ts")
+
+            TypeVar("FromParamSpec", default=P)  # E: incompatible_argument
+            TypeVar(  # E: incompatible_argument
+                "FromTypeVarTuple", default=Unpack[Ts]
+            )
+            """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 11))
+    def test_referential_paramspec_default(self):
+        self.assert_passes(
+            """
+            from typing import Callable, Generic
+            from typing_extensions import ParamSpec, assert_type
+
+            P = ParamSpec("P")
+            Q = ParamSpec("Q", default=P)
+
+            class Callbacks(Generic[P, Q]):
+                first: Callable[P, None]
+                second: Callable[Q, None]
+
+            def check(value: Callbacks[[int]]) -> None:
+                assert_type(value.first, Callable[[int], None])
+                assert_type(value.second, Callable[[int], None])
+            """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 14))
+    def test_pep696_paramspec_and_typevartuple_defaults(self):
+        self.assert_passes(
+            """
+            from typing import Callable
+            from typing_extensions import assert_type
+
+            class CallbackBox[**P = [str, int]]:
+                callback: Callable[P, None]
+
+            class TupleBox[*Ts = *tuple[Later, int]]:
+                elements: tuple[*Ts]
+
+            class NativeCallbacks[**P, **Q = P]:
+                first: Callable[P, None]
+                second: Callable[Q, None]
+
+            class Later: ...
+
+            def check(
+                callback: CallbackBox,
+                packed: TupleBox,
+                native: NativeCallbacks[[bytes]],
+            ) -> None:
+                assert_type(callback.callback, Callable[[str, int], None])
+                assert_type(packed.elements, tuple[Later, int])
+                assert_type(native.first, Callable[[bytes], None])
+                assert_type(native.second, Callable[[bytes], None])
+
+            class TypeVarFromParamSpec[**P, T = P]:  # E: invalid_annotation
+                ...
+
+            class ParamSpecFromTypeVar[T, **P = T]:  # E: invalid_annotation
+                ...
+
+            class TypeVarTupleFromTypeVar[T, *Ts = *T]:  # E: invalid_annotation
+                ...
+
+            class InvalidParamSpecDefault[**P = int]:  # E: invalid_annotation
+                ...
+
+            class InvalidTypeVarTupleDefault[*Ts = tuple[int]]:  # E: invalid_annotation
+                ...
+            """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 11))
     @assert_passes(run_in_both_module_modes=True)
     def test_paramspec_default_must_be_parameter_list_ellipsis_or_paramspec(self):
         from typing_extensions import ParamSpec, TypeVar

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -634,12 +634,20 @@ class TestTypeVar(TestNameCheckVisitorBase):
         from typing_extensions import TypeVar
 
         TypeVar("GoodBound", bound=float, default=int)
-        TypeVar("BadBound", bound=str, default=int)  # E: incompatible_call
-        TypeVar("BadConstraint", float, str, default=int)  # E: incompatible_call
+        TypeVar("BadBound", bound=str, default=int)  # E: invalid_type_parameter_default
+        TypeVar(
+            "BadConstraint",
+            float,
+            str,
+            default=int,  # E: invalid_type_parameter_default
+        )
         Base = TypeVar("Base", int, str)
         TypeVar("GoodConstraint", int, str, bool, default=Base)
         TypeVar(
-            "BadConstraintTypeVar", bool, complex, default=Base  # E: incompatible_call
+            "BadConstraintTypeVar",
+            bool,
+            complex,
+            default=Base,  # E: invalid_type_parameter_default
         )
 
     @skip_before((3, 11))
@@ -651,8 +659,8 @@ class TestTypeVar(TestNameCheckVisitorBase):
             P = ParamSpec("P")
             Ts = TypeVarTuple("Ts")
 
-            TypeVar("FromParamSpec", default=P)  # E: incompatible_argument
-            TypeVar(  # E: incompatible_argument
+            TypeVar("FromParamSpec", default=P)  # E: invalid_type_parameter_default
+            TypeVar(  # E: invalid_type_parameter_default
                 "FromTypeVarTuple", default=Unpack[Ts]
             )
             """,
@@ -709,19 +717,22 @@ class TestTypeVar(TestNameCheckVisitorBase):
                 assert_type(native.first, Callable[[bytes], None])
                 assert_type(native.second, Callable[[bytes], None])
 
-            class TypeVarFromParamSpec[**P, T = P]:  # E: invalid_annotation
+            class TypeVarFromParamSpec[**P, T = P]:  # E: invalid_type_parameter_default
                 ...
 
-            class ParamSpecFromTypeVar[T, **P = T]:  # E: invalid_annotation
+            class ParamSpecFromTypeVar[T, **P = T]:  # E: invalid_type_parameter_default
                 ...
 
-            class TypeVarTupleFromTypeVar[T, *Ts = *T]:  # E: invalid_annotation
+            class TypeVarTupleFromTypeVar[T, *Ts = *T]:  # E: invalid_type_parameter_default
                 ...
 
-            class InvalidParamSpecDefault[**P = int]:  # E: invalid_annotation
+            class InvalidParamSpecDefault[**P = int]:  # E: invalid_type_parameter_default
                 ...
 
-            class InvalidTypeVarTupleDefault[*Ts = tuple[int]]:  # E: invalid_annotation
+            class InvalidTypeVarTupleDefault[*Ts = tuple[int]]:  # E: invalid_type_parameter_default
+                ...
+
+            class InvalidTypeVarDefault[T = 42]:  # E: invalid_type_parameter_default
                 ...
             """,
             run_in_both_module_modes=True,
@@ -738,9 +749,11 @@ class TestTypeVar(TestNameCheckVisitorBase):
         ParamSpec("ListDefault", default=[str, int])
         ParamSpec("EllipsisDefault", default=...)
         ParamSpec("ParamSpecDefault", default=P)
-        ParamSpec("TypeDefault", default=int)  # E: incompatible_argument
-        ParamSpec("TupleDefault", default=(str, int))  # E: incompatible_argument
-        ParamSpec("TypeVarDefault", default=T)  # E: incompatible_argument
+        ParamSpec("TypeDefault", default=int)  # E: invalid_type_parameter_default
+        ParamSpec(
+            "TupleDefault", default=(str, int)  # E: invalid_type_parameter_default
+        )
+        ParamSpec("TypeVarDefault", default=T)  # E: invalid_type_parameter_default
 
     @assert_passes()
     def test_typevar_default_is_not_used_as_fallback(self):
@@ -888,7 +901,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
         DefaultAfterVariadic = TypeVar("DefaultAfterVariadic", default=bool)
         P = ParamSpec("P", default=[str])
 
-        class BadOrder(Generic[DefaultT, T]): ...  # E: invalid_type_parameter
+        class BadOrder(Generic[DefaultT, T]): ...  # E: invalid_type_parameter_default
 
         class GoodAfterVariadic(Generic[Unpack[Ts], P]): ...
 
@@ -902,7 +915,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
         Ts = TypeVarTuple("Ts")
         DefaultAfterVariadic = TypeVar("DefaultAfterVariadic", default=bool)
 
-        class BadAfterVariadic(  # E: invalid_type_parameter
+        class BadAfterVariadic(  # E: invalid_type_parameter_default
             Generic[Unpack[Ts], DefaultAfterVariadic]
         ): ...
 
@@ -916,7 +929,9 @@ class TestTypeVar(TestNameCheckVisitorBase):
         LaterT = TypeVar("LaterT")
         EarlierDefaultT = TypeVar("EarlierDefaultT", default=list[LaterT])
 
-        class Bad(Generic[EarlierDefaultT, LaterT]): ...  # E: invalid_type_parameter
+        class Bad(  # E: invalid_type_parameter_default
+            Generic[EarlierDefaultT, LaterT]
+        ): ...
 
     @skip_before((3, 13))
     def test_pep696_class_type_param_defaults_cannot_reference_later_params(self):
@@ -925,7 +940,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
             class Good[T, U = tuple[T]]:
                 ...
 
-            class Bad[T = tuple[U], U]:  # E: undefined_name  # E: invalid_type_parameter
+            class Bad[T = tuple[U], U]:  # E: undefined_name  # E: invalid_type_parameter_default
                 ...
         """,
             allow_import_failures=True,
@@ -1572,7 +1587,7 @@ class TestGenericClasses(TestNameCheckVisitorBase):
             T = TypeVar("T", default=tuple[U])
 
             def capybara() -> None:
-                class Bad(Generic[T, U]):  # E: invalid_type_parameter
+                class Bad(Generic[T, U]):  # E: invalid_type_parameter_default
                     ...
         """,
             run_in_both_module_modes=True,
@@ -1584,20 +1599,20 @@ class TestGenericClasses(TestNameCheckVisitorBase):
             class GoodBound[T: float = int]:
                 ...
 
-            class BadBound[T: str = int]:  # E: invalid_annotation
+            class BadBound[T: str = int]:  # E: invalid_type_parameter_default
                 ...
 
             class GoodConstraint[T: (int, str) = int]:
                 ...
 
-            class BadConstraint[T: (float, str) = int]:  # E: invalid_annotation
+            class BadConstraint[T: (float, str) = int]:  # E: invalid_type_parameter_default
                 ...
 
             class GoodConstraintTypeVar[Base: (int, str), T: (int, str, bool) = Base]:
                 ...
 
             class BadConstraintTypeVar[
-                # E: invalid_annotation
+                # E: invalid_type_parameter_default
                 Base: (int, str), T: (bool, complex) = Base
             ]:
                 ...
@@ -1609,7 +1624,8 @@ class TestGenericClasses(TestNameCheckVisitorBase):
             class AcceptsBoundTypeVar[Base: int, T: (int, str) = Base]:
                 ...
 
-            class RejectsBoundTypeVar[Base: bytes, T: (int, str) = Base]:  # E: invalid_annotation
+            # E: invalid_type_parameter_default
+            class RejectsBoundTypeVar[Base: bytes, T: (int, str) = Base]:
                 ...
         """)
 
@@ -1626,14 +1642,20 @@ class TestGenericClasses(TestNameCheckVisitorBase):
             "LiteralBad",
             Literal[1],
             Literal[2],
-            default=Literal[3],  # E: incompatible_call
+            default=Literal[3],  # E: invalid_type_parameter_default
         )
         BoundInt = TypeVar("BoundInt", bound=int)
         BoundDefaultOk = TypeVar(
-            "BoundDefaultOk", int, str, default=BoundInt  # E: incompatible_call
+            "BoundDefaultOk",
+            int,
+            str,
+            default=BoundInt,  # E: invalid_type_parameter_default
         )
         BoundDefaultBad = TypeVar(
-            "BoundDefaultBad", str, bytes, default=BoundInt  # E: incompatible_call
+            "BoundDefaultBad",
+            str,
+            bytes,
+            default=BoundInt,  # E: invalid_type_parameter_default
         )
 
         print(LiteralOk, LiteralBad, BoundDefaultOk, BoundDefaultBad)
@@ -2198,6 +2220,6 @@ class TestIntegration(TestNameCheckVisitorBase):
         from typing_extensions import TypeVar
 
         T = TypeVar("T")
-        U = TypeVar("U", default=42)  # E: incompatible_argument
-        V = TypeVar("V", bound=int, default=str)  # E: incompatible_call
-        W = TypeVar("W", int, str, default=bool)  # E: incompatible_call
+        U = TypeVar("U", default=42)  # E: invalid_type_parameter_default
+        V = TypeVar("V", bound=int, default=str)  # E: invalid_type_parameter_default
+        W = TypeVar("W", int, str, default=bool)  # E: invalid_type_parameter_default

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -1279,6 +1279,14 @@ class ParamSpecParam:
     def __str__(self) -> str:
         return _type_param_to_string("**", self.param_spec.__name__, self.owner)
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ParamSpecParam):
+            return NotImplemented
+        return self.param_spec == other.param_spec
+
+    def __hash__(self) -> int:
+        return hash(self.param_spec)
+
 
 @dataclass(frozen=True)
 class TypeVarTupleParam:


### PR DESCRIPTION
## Summary

- interpret native `ParamSpec` and `TypeVarTuple` defaults from PEP 695/696 syntax
- substitute `ParamSpec` defaults that refer to an earlier parameter
- reject defaults that use an incompatible type-parameter kind

## Details

Native source defaults are normalized from their AST representation in the existing annotation scope. Runtime `__default__` handling is unchanged, so this does not introduce eager evaluation of imported forward references.