### PR TITLE
Fix PEP 695 type parameter scoping

### DIFF
--- a/changelog.d/20260814_095032_jelle.zijlstra_type_parameter_scoping.md
+++ b/changelog.d/20260814_095032_jelle.zijlstra_type_parameter_scoping.md
@@ -1,0 +1,1 @@
+- Follow PEP 695 scoping rules for native type parameters, including nested scopes and references from class and function headers.

--- a/pycroscope/name_check_visitor.py
+++ b/pycroscope/name_check_visitor.py
@@ -1865,6 +1865,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     expected_return_value: Value | None
     future_imports: set[str]
     in_annotation: bool
+    _treat_type_param_names_as_types: bool
     in_comprehension_body: bool
     in_union_decomposition: bool
     import_name_to_node: dict[str, ast.Import | ast.ImportFrom]
@@ -1985,6 +1986,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         self.current_enum_members = None
         self.is_async_def = False
         self.in_annotation = False
+        self._treat_type_param_names_as_types = False
         self.in_union_decomposition = False
         self.collector = collector
         self.import_name_to_node = {}
@@ -3374,6 +3376,20 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 )
             return AnyValue(AnySource.error), origin
         self.active_type_params.observe_value(error_node, value)
+        if (
+            defining_scope is not None
+            and defining_scope.scope_type is ScopeType.annotation_scope
+            and not self.in_annotation
+            and not self._treat_type_param_names_as_types
+            and not self.active_type_params.has_variance_collection()
+        ):
+            type_param = self.get_type_param_from_value(value)
+            if type_param is not None:
+                value = SyntheticTypeFormValue(
+                    type_param_to_value(type_param),
+                    TypedValue(type(type_param.typevar)),
+                    node,
+                )
         assert not isinstance(value, (TypeVarParam, ParamSpecParam, TypeVarTupleParam))
         if isinstance(value, (InputSigValue, TypeVarTupleBindingValue)):
             # ParamSpecs are stored as InputSigValues and cannot be converted to a
@@ -3629,6 +3645,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
                 disallowed_type_params = (
                     self.active_type_params.current_annotation_identities()
+                    - self.active_type_params.current_native_pep695_identities()
                 )
                 with self.active_type_params.disallow(disallowed_type_params):
                     (
@@ -3919,7 +3936,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 class_annotation_identities.update(alias_identities)
             with (
                 self.active_type_params.push_pep695_scope(
-                    class_scope_type_params, aliases=type_param_alias_identities
+                    class_scope_type_params,
+                    aliases=type_param_alias_identities,
+                    is_native=is_pep695_generic,
                 ),
                 self.active_type_params.allow_in_annotations(
                     class_annotation_identities
@@ -7297,12 +7316,18 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         val,
                         [DataclassTransformExtension(merged_dataclass_transform_info)],
                     )
-                self._set_name_in_scope(
-                    node.name, node, val, record_synthetic_symbol=False
+                name_scope_ctx = (
+                    self.scopes.ignore_topmost_scope()
+                    if sys.version_info >= (3, 12) and node.type_params
+                    else contextlib.nullcontext()
                 )
-                self._record_complete_synthetic_function_symbol(
-                    node, info, synthetic_function_value
-                )
+                with name_scope_ctx:
+                    self._set_name_in_scope(
+                        node.name, node, val, record_synthetic_symbol=False
+                    )
+                    self._record_complete_synthetic_function_symbol(
+                        node, info, synthetic_function_value
+                    )
 
             if (
                 node.name in METHODS_ALLOWING_NOTIMPLEMENTED
@@ -7327,7 +7352,14 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     is_classmethod=FunctionDecorator.classmethod
                     in info.decorator_kinds,
                 ),
-                self.active_type_params.push_pep695_scope(info.type_params),
+                self.active_type_params.push_pep695_scope(
+                    info.type_params,
+                    is_native=(
+                        sys.version_info >= (3, 12)
+                        and not isinstance(node, ast.Lambda)
+                        and bool(node.type_params)
+                    ),
+                ),
                 self.active_type_params.allow_in_annotations(
                     function_annotation_identities
                 ),
@@ -12411,8 +12443,40 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     ) -> Sequence[TypeParam]:
         type_param_values = []
         first_typevartuple: TypeVarTupleParam | None = None
-        for param in type_params:
-            value = self.visit(param)
+        for index, param in enumerate(type_params):
+            name = getattr(param, "name", None)
+            if (
+                isinstance(name, str)
+                and self.active_type_params.get_type_param_by_name(name) is not None
+            ):
+                self._show_error_if_checking(
+                    param,
+                    f"Type parameter {name!r} is already in use by an outer scope",
+                    error_code=ErrorCode.invalid_type_parameter,
+                )
+
+            later_names = {
+                later_name
+                for later_param in type_params[index + 1 :]
+                if isinstance((later_name := getattr(later_param, "name", None)), str)
+            }
+            bound = getattr(param, "bound", None)
+            references_later_param = bound is not None and any(
+                name_node.id in later_names
+                for name_node, _ in _iter_loaded_name_nodes(
+                    bound, allow_string_parse=True
+                )
+            )
+            if references_later_param:
+                self._show_error_if_checking(
+                    param,
+                    "Type parameter bound cannot reference a later type parameter",
+                    error_code=ErrorCode.invalid_type_parameter,
+                )
+                with self.catch_errors():
+                    value = self.visit(param)
+            else:
+                value = self.visit(param)
             extracted = _type_param_value_from_value(value, self)
             if extracted is None:
                 assert False, f"unexpected type parameter value: {value!r}"
@@ -12892,9 +12956,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 return type_from_value(
                     KnownValue(ast.unparse(node)), self, node, suppress_errors=True
                 )
-            return type_from_value(
-                self.visit(node), self, node, suppress_errors=suppress_errors
-            )
+            with override(self, "_treat_type_param_names_as_types", True):
+                value = self.visit(node)
+            return type_from_value(value, self, node, suppress_errors=suppress_errors)
 
         def _paramspec_default_from_pep695_expr(self, node: ast.expr) -> Value:
             if isinstance(node, ast.Constant) and node.value is Ellipsis:
@@ -17072,6 +17136,8 @@ def is_typing_object(value: object, typing_name: str) -> bool:
 def _type_param_value_from_value(
     value: Value, visitor: NameCheckVisitor
 ) -> TypeParam | None:
+    if isinstance(value, SyntheticTypeFormValue):
+        return _type_param_value_from_value(value.inner_type, visitor)
     if isinstance(value, TypeVarValue):
         return value.typevar_param
     if isinstance(value, TypeVarTupleValue):

--- a/pycroscope/relations.py
+++ b/pycroscope/relations.py
@@ -610,10 +610,7 @@ def _has_relation_impl(
 
     # SyntheticTypeFormValue
     if isinstance(left, SyntheticTypeFormValue):
-        if left == right:
-            return {}
-        else:
-            return CanAssignError(f"{right} is not {relation.description} {left}")
+        return _has_relation(gradualize(left.get_fallback_value()), right, relation_ctx)
     if isinstance(right, SyntheticTypeFormValue):
         return _has_relation(
             left,

--- a/pycroscope/stacked_scopes.py
+++ b/pycroscope/stacked_scopes.py
@@ -763,7 +763,10 @@ class Scope:
     )
 
     def __post_init__(self) -> None:
-        if self.parent_scope is not None:
+        if (
+            self.parent_scope is not None
+            and self.scope_type is not ScopeType.annotation_scope
+        ):
             self.parent_scope = self.parent_scope.scope_used_as_parent()
 
     def add_constraint(

--- a/pycroscope/test_typevar.py
+++ b/pycroscope/test_typevar.py
@@ -1576,6 +1576,68 @@ class TestGenericClasses(TestNameCheckVisitorBase):
         """)
 
     @skip_before((3, 12))
+    def test_pep695_type_parameter_scoping_rules(self):
+        self.assert_passes(
+            """
+            class LaterBound[S: list[T], T]:  # E: invalid_type_parameter
+                ...
+
+            class Outer[T]:
+                class Inner[T]:  # E: invalid_type_parameter
+                    ...
+
+                def method[T](self) -> None:  # E: invalid_type_parameter
+                    ...
+
+                type Alias[T] = T  # E: invalid_type_parameter
+
+            def outer[T]() -> None:
+                def inner[T]() -> None:  # E: invalid_type_parameter
+                    ...
+        """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 12))
+    def test_pep695_annotation_scopes_overlay_containing_scopes(self):
+        self.assert_passes(
+            """
+            from typing import Literal, ParamSpec, TypeVar, TypeVarTuple, assert_type
+
+            class Outer:
+                class Private:
+                    ...
+
+                class Inner[T](Private):
+                    ...
+
+                def method[T](self, value: Inner[T]) -> Inner[T]:
+                    return value
+
+            def identity[T](value: T) -> T:
+                return value
+
+            assert_type(identity("x"), Literal["x"])
+
+            class VariadicOuter[**P, *Ts]:
+                def method(self) -> None:
+                    assert_type(P, ParamSpec)
+                    assert_type(Ts, TypeVarTuple)
+
+            def make_outer(a: int, b: str) -> None:
+                class GenericOuter[T]:
+                    T = a
+
+                    class Inner:
+                        T = b
+
+                        def method(self) -> None:
+                            assert_type(T, TypeVar)
+        """,
+            run_in_both_module_modes=True,
+        )
+
+    @skip_before((3, 12))
     def test_pep695_type_parameter_default_must_reference_earlier_params(self):
         self.assert_passes(
             """

--- a/pycroscope/type_params.py
+++ b/pycroscope/type_params.py
@@ -754,6 +754,7 @@ class ActiveTypeParams:
         self._variance_outside_annotations = 0
         self._subscript_arg_polarities: list[tuple[tuple[int, bool], ...]] = []
         self._scopes: list[TypeParamScope] = []
+        self._native_pep695_identity_scopes: list[set[TypeParamIdentity]] = []
 
     @contextmanager
     def push_scope(self, owner: TypeParamOwner | None = None) -> Generator[None]:
@@ -787,6 +788,12 @@ class ActiveTypeParams:
         for scope in self._scopes:
             type_params.update(scope.bindings)
         return type_params
+
+    def current_native_pep695_identities(self) -> set[TypeParamIdentity]:
+        identities: set[TypeParamIdentity] = set()
+        for scope in self._native_pep695_identity_scopes:
+            identities.update(scope)
+        return identities
 
     def get_type_param(self, identity: object) -> TypeParam | None:
         if not _is_type_param_identity(identity):
@@ -866,13 +873,27 @@ class ActiveTypeParams:
         *,
         aliases: Sequence[Iterable[object]] | None = None,
         owner: TypeParamOwner | None = None,
+        is_native: bool = True,
     ) -> Generator[None]:
         if not type_params:
             yield
             return
-        with self.push_scope(owner):
-            self.add_pep695_scope(type_params, aliases=aliases)
-            yield
+        if aliases is None:
+            aliases = [()] * len(type_params)
+        native_identities = {
+            identity
+            for type_param, param_aliases in zip(type_params, aliases)
+            for identity in (type_param.typevar, *_typed_identities(param_aliases))
+        }
+        if is_native:
+            self._native_pep695_identity_scopes.append(native_identities)
+        try:
+            with self.push_scope(owner):
+                self.add_pep695_scope(type_params, aliases=aliases)
+                yield
+        finally:
+            if is_native:
+                self._native_pep695_identity_scopes.pop()
 
     @contextlib.contextmanager
     def push_class_type_params(

--- a/pycroscope/value.py
+++ b/pycroscope/value.py
@@ -3682,8 +3682,7 @@ class TypeFormValue(Value):
 
 @dataclass(frozen=True)
 class SyntheticTypeFormValue(Value):
-    """Represents an object that can be used in annotations,
-    but for which we do not have a runtime object."""
+    """Represents an object whose type-form and runtime meanings differ."""
 
     inner_type: Value
     runtime_type: Value

--- a/tools/conformance_known_failures.txt
+++ b/tools/conformance_known_failures.txt
@@ -2,9 +2,6 @@
 # If a listed case starts passing, or an unlisted case starts failing,
 # the conformance CI workflow should fail and this file should be updated.
 
-# Doesn't detect when you use a TypeVar in the wrong place
-generics_syntax_scoping
-
 # Fails to reject "x" | int annotations that fail at runtime
 # Does not correctly pick up forward refs in unimportable module
 annotations_forward_refs


### PR DESCRIPTION
## Summary

- model PEP 695 annotation scopes as overlays on their containing scopes
- enforce nested type-parameter name reuse and declaration-order restrictions
- preserve the separate type-form and runtime meanings of native type-parameter objects
- remove `generics_syntax_scoping` from the conformance known-failure list

## Rationale

PEP 695 annotation scopes can see names from their containing scope, but their type parameters have additional visibility and shadowing rules. Pycroscope previously treated these scopes too much like ordinary parent scopes and did not distinguish native PEP 695 parameters from compatibility bindings. This caused incorrect name resolution in class and function headers, missed invalid nested declarations, and treated type-parameter objects as types in runtime expressions.

This change tracks native annotation-scope bindings explicitly and uses `SyntheticTypeFormValue` for the dual type-form/runtime representation.
